### PR TITLE
Support COE-plugin experimentally

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
@@ -4,6 +4,7 @@ declare module agv {
 		addContent(content: any): void;
 		removeContent(content: any): void;
 		setViewSize(width: number, height: number): void;
+		registerExternalPlugin(plugin: ExternalPlugin): void;
 	}
 	class GameContent {
 		constructor(...args: any[]);
@@ -13,15 +14,24 @@ declare module agv {
 		addContentLoadListener(contentLoadListener: any): void;
 		addErrorListener(errorListener: ErrorListener): void;
 		removeErrorListener(errorListener: ErrorListener): void;
+		getGameVars(propertyName: string, listener: (vars: any) => void): void;
+		getGame(): GameLike;
+		onExternalPluginRegister: TriggerLike; // NOTE: 拡張
 	}
 	interface PlaylogConfig {
 		playId: string;
 		executionMode: ExecutionMode;
 		replayTargetTimeFunc: () => number;
-		playlogServerUrl: string;
-		playToken: string;
+		playlogServerUrl?: string;
+		playToken?: string;
 	}
 	interface GameViewSharedObject {}
+	interface GameLoaderCustomizer {
+		platformCustomizer?: (platform: any, opts?: any) => void;
+		createCustomAudioPlugins?: () => any[];
+		createCustomAmflowClient?: () => any;
+		overwriteEngineConfig?: string;
+	}
 	interface GameConfig {
 		contentUrl: string;
 		player: {
@@ -29,15 +39,26 @@ declare module agv {
 			name?: string;
 		};
 		playConfig: PlaylogConfig;
-		gameLoaderCustomizer: {
-			platformCustomizer?: (platform: any, opts?: any) => void;
-			createCustomAudioPlugins?: () => any[];
-			createCustomAmflowClient?: () => any;
-			overwriteEngineConfig?: string;
-		};
+		gameLoaderCustomizer: GameLoaderCustomizer;
 	}
 	interface ErrorListener {
 		onError: (e: Error) => void;
+	}
+	interface ExternalPlugin {
+		name: string;
+		onload: (game: GameLike, dataBus: any, gameContent: GameContent) => void;
+	}
+	interface TriggerLike {
+		add: (...args: any[]) => void;
+		addOnce: (...args: any[]) => void;
+		remove: (...args: any[]) => void;
+		fire: (arg: any) => void;
+	}
+	interface GameExternalPluginsLike {
+		coe?: any;
+	}
+	interface GameLike {
+		external: GameExternalPluginsLike;
 	}
 	enum ExecutionMode {
 		Active, Passive, Replay

--- a/packages/akashic-cli-serve/src/client/common/interface/plugin.ts
+++ b/packages/akashic-cli-serve/src/client/common/interface/plugin.ts
@@ -1,0 +1,43 @@
+import { Event } from "@akashic/playlog";
+
+export interface CoePlugin {
+	startSession: (parameters: CoeStartSessionParameterObject) => void;
+	exitSession: (sessionId: string, parameters: CoeExitSessionParameterObject) => void;
+	sendLocalEvents: (sessionId: string, events: Event[]) => void;
+}
+
+export interface CoeApplicationIdentifier {
+	type: string;
+	version: string;
+	url?: string;
+}
+
+export interface CoeExternalMessage {
+	type: string;
+	sessionId: string;
+	result?: any;
+	target?: string;
+	id?: number;
+	data?: any;
+}
+
+export interface CoeStartSessionParameterObject {
+	sessionId: string;
+	local?: boolean;
+	localEvents?: Event[];
+	delayRange?: number;
+	application?: CoeApplicationIdentifier;
+	cascadeApplications?: CoeApplicationIdentifier[];
+	messageHandler?: (message: CoeExternalMessage) => void;
+	eventSendablePlayers?: string[];
+	additionalData?: any;
+	size?: {
+		width: number;
+		height: number;
+	};
+}
+
+export interface CoeExitSessionParameterObject {
+	needsResult?: boolean;
+	needsPlaylog?: boolean;
+}

--- a/packages/akashic-cli-serve/src/client/operator/ExternalPluginOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/ExternalPluginOperator.ts
@@ -1,0 +1,12 @@
+import { GameViewManager } from "../akashic/GameViewManager";
+
+export class ExternalPluginOperator {
+	constructor(gameViewManager: GameViewManager) {
+		gameViewManager.registerExternalPlugin({
+			name: "coe",
+			onload: (_game: agv.GameLike, _dataBus: any, gameContent: agv.GameContent) => {
+				gameContent.onExternalPluginRegister.fire("coe");
+			}
+		});
+	}
+}

--- a/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
@@ -1,0 +1,159 @@
+import { Event } from "@akashic/playlog";
+import {
+	CoeStartSessionParameterObject, CoeExitSessionParameterObject, CoeApplicationIdentifier, CoeExternalMessage
+} from "../common/interface/plugin";
+import { GameViewManager } from "../akashic/GameViewManager";
+import { LocalInstanceEntity } from "./LocalInstanceEntity";
+
+export interface GameState {
+	score?: number;
+	playThrethold?: number;
+	clearThrethold?: number;
+}
+
+export interface CreateCoeLocalInstanceParameterObject {
+	local: boolean;
+	playId: string;
+	contentUrl?: string;
+	argument?: any;
+	initialEvents?: Event[];
+	coeHandler?: {
+		onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+		onLocalInstanceDelete: (playId: string) => Promise<void>;
+	};
+}
+
+
+export interface CoePluginEntityParameterObject {
+	gameViewManager: GameViewManager;
+	onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+	onLocalInstanceDelete: (playId: string) => Promise<void>;
+}
+
+export class CoePluginEntity {
+	private _gameViewManager: GameViewManager;
+	private _localInstance: LocalInstanceEntity;
+	private _coePluginMessageHandler: (parameters: CoeExternalMessage) => void;
+	private _createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+	private _deleteLocalInstance: (playId: string) => Promise<void>;
+
+	constructor(param: CoePluginEntityParameterObject) {
+		this._gameViewManager = param.gameViewManager;
+		this._createLocalInstance = param.onLocalInstanceCreate;
+		this._deleteLocalInstance = param.onLocalInstanceDelete;
+	}
+
+	async bootstrap(game: agv.GameLike, _gameContent: agv.GameContent): Promise<void> {
+		game.external.coe = {
+			startSession: this.startSession,
+			exitSession: this.exitSession,
+			sendLocalEvents: this.sendLocalEvents
+		};
+	}
+
+	startSession = async (parameters: CoeStartSessionParameterObject): Promise<void> => {
+		try {
+			if (parameters && parameters.messageHandler) {
+				this._coePluginMessageHandler = parameters.messageHandler;
+			}
+
+			if (parameters.application == null) {
+				throw new Error("Cannot start session");
+			}
+
+			const contentUrl = this._resolveContentUrl(parameters.application, parameters.cascadeApplications);
+
+			if (parameters.local) {
+				this._startLocalSession(contentUrl, parameters);
+				return;
+			}
+
+			if (typeof parameters.delayRange === "number") {
+				window.setTimeout(() => {
+					this._startSession(contentUrl, parameters);
+				}, Math.floor(Math.random() * parameters.delayRange));
+				return;
+			}
+
+			await this._startSession(contentUrl, parameters);
+		} catch (e) {
+			// TODO: エラーハンドリング
+			console.error(e);
+		}
+	}
+
+	exitSession = async (sessionId: string, parameters: CoeExitSessionParameterObject): Promise<void> => {
+		try {
+			console.log("exitSession", sessionId, parameters);
+			if (parameters == null) {
+				return;
+			}
+			if (parameters.needsResult) {
+				const instance = this._localInstance;
+				if (instance == null) {
+					throw new Error("Invalid operation");
+				}
+				const gameState = await this._gameViewManager.getGameVars<GameState>(instance.gameContent, "gameState");
+				this._coePluginMessageHandler({
+					type: "end",
+					result: gameState ? gameState.score : null,
+					sessionId
+				});
+			}
+			await this._deleteLocalInstance(sessionId);
+		} catch (e) {
+			// TODO: エラーハンドリング
+			console.error(e);
+		}
+	}
+
+	sendLocalEvents = async (_sessionId: string, _events: Event[]): Promise<void> => {
+		// TODO
+	}
+
+	private async _startSession(_contentUrl: string, _parameters: any): Promise<void> {
+		// TODO
+	}
+
+	private async _startLocalSession(contentUrl: string, parameters: CoeStartSessionParameterObject): Promise<void> {
+		try {
+			this._localInstance = await this._createLocalInstance({
+				contentUrl,
+				playId: parameters.sessionId,
+				local: true,
+				argument: {
+					coe: {
+						permission: {
+							advance: true,
+							advanceRequest: true,
+							aggregation: true
+						},
+						roles: ["broadcaster"],
+						debugMode: false
+					}
+				},
+				initialEvents: parameters.localEvents
+			});
+		} catch (e) {
+			// TODO: エラーハンドリング
+			console.error(e);
+		}
+	}
+
+	private _resolveContentUrl(application: CoeApplicationIdentifier, cascadeApplications?: CoeApplicationIdentifier[]): string {
+		if (cascadeApplications && cascadeApplications[0] && cascadeApplications[0].url) {
+			const url = cascadeApplications[0].url;
+			if (url.indexOf("?") === 0) {
+				return `${this._resolveContentUrl(application)}${url}`;
+			}
+			return this._resolveContentUrl(application);
+		} else {
+			if (application.url == null) {
+				// TODO
+				throw new Error("Could not resolve content url");
+			}
+			return application.url;
+		}
+	}
+}
+

--- a/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
@@ -4,6 +4,7 @@ import {TimeKeeper} from "../../common/TimeKeeper";
 import {Player} from "../../common/types/Player";
 import {GameViewManager} from "../akashic/GameViewManager";
 import {PlayEntity} from "./PlayEntity";
+import {CoePluginEntity, CreateCoeLocalInstanceParameterObject} from "./CoePluginEntity";
 import {GameInstanceEntity} from "./GameInstanceEntity";
 import {ExecutionMode} from "./ExecutionMode";
 
@@ -22,10 +23,15 @@ const toAgvExecutionMode = (() => {
 export interface LocalInstanceEntityParameterObject {
 	gameViewManager: GameViewManager;
 	contentUrl: string;
-	playToken: string;
 	executionMode: ExecutionMode;
 	play: PlayEntity;
 	player: Player;
+	playToken?: string;
+	playlogServerUrl?: string;
+	coeHandler?: {
+		onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+		onLocalInstanceDelete: (playId: string) => Promise<void>;
+	};
 }
 
 export class LocalInstanceEntity implements GameInstanceEntity {
@@ -37,6 +43,7 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 	@observable isPaused: boolean;
 
 	readonly play: PlayEntity;
+	readonly coePlugin: CoePluginEntity;
 	readonly contentUrl: string;
 
 	private _timeKeeper: TimeKeeper;
@@ -52,28 +59,49 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 		this.contentUrl = params.contentUrl;
 		this._timeKeeper = new TimeKeeper();
 		this._gameViewManager = params.gameViewManager;
+		const playConfig: agv.PlaylogConfig = {
+			playId: this.play.playId,
+			executionMode: toAgvExecutionMode(this.executionMode),
+			replayTargetTimeFunc: this._getReplayTargetTime
+		};
+		let gameLoaderCustomizer: agv.GameLoaderCustomizer = {};
+		if (params.playlogServerUrl != null) {
+			playConfig.playlogServerUrl = params.playlogServerUrl;
+			gameLoaderCustomizer.createCustomAmflowClient = () => this.play.amflow;
+		}
+		if (params.playToken != null) {
+			playConfig.playToken = params.playToken;
+		}
 		this._agvGameContent = this._gameViewManager.createGameContent({
 			contentUrl: this.contentUrl,
 			player: {
 				id: this.player.id,
 				name: this.player.name
 			},
-			playConfig: {
-				playId: this.play.playId,
-				executionMode: toAgvExecutionMode(this.executionMode),
-				replayTargetTimeFunc: this._getReplayTargetTime,
-				playlogServerUrl: "dummy-playlog-server-url",
-				playToken: params.playToken
-			} as agv.PlaylogConfig,
-			gameLoaderCustomizer: {
-				createCustomAmflowClient: () => this.play.amflow
-			}
+			playConfig,
+			gameLoaderCustomizer
 		});
+		if (params.coeHandler != null) {
+			this.coePlugin = new CoePluginEntity({
+				gameViewManager: this._gameViewManager,
+				onLocalInstanceCreate: params.coeHandler.onLocalInstanceCreate,
+				onLocalInstanceDelete: params.coeHandler.onLocalInstanceDelete
+			});
+			this._agvGameContent.onExternalPluginRegister.addOnce((name: string) => {
+				if (name !== "coe") return;
+				const game = this._agvGameContent.getGame();
+				this.coePlugin.bootstrap(game, this._agvGameContent);
+			});
+		}
 	}
 
 	@computed
 	get isJoined(): boolean {
 		return this.play.joinedPlayerTable.has(this.player.id);
+	}
+
+	get gameContent(): agv.GameContent {
+		return this._agvGameContent;
 	}
 
 	async start(): Promise<void> {

--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -19,6 +19,13 @@ import { PlayEntity } from "./PlayEntity";
 export interface CreatePlayParameterObject {
 	contentUrl: string;
 	clientContentUrl?: string;
+	parent?: PlayEntity;
+}
+
+export interface CreateStandalonePlayParameterObject {
+	contentUrl: string;
+	playId: string;
+	parent?: PlayEntity;
 }
 
 export class PlayStore {
@@ -63,6 +70,26 @@ export class PlayStore {
 		// でなければ onPlayCreate 通知(が来て PlayEntity が生成される)を待つ
 		const play = await (new Promise<PlayEntity>(resolve => (this._creationWaiters[playId] = resolve)));
 		delete this._creationWaiters[playId];
+		return play;
+	}
+
+	/**
+	 * スタンドアロンのプレーを作成する。
+	 */
+	async createStandalonePlay(param: CreateStandalonePlayParameterObject): Promise<PlayEntity> {
+		const playId = param.playId;
+
+		if (this.plays[playId])
+			return this.plays[playId];
+
+		const play = new PlayEntity({
+			playId,
+			contentUrl: param.contentUrl,
+			clientContentUrl: "dummy",
+			parent: param.parent
+		});
+		this.plays[playId] = play;
+
 		return play;
 	}
 

--- a/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
+++ b/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
@@ -3,6 +3,7 @@ export interface EngineConfig {
 	engine_urls: string[];
 	content_url: string;
 	asset_base_url?: string;
+	external?: string[];
 }
 
 export const getEngineConfig = (baseUrl: string, isRaw: boolean): EngineConfig => {
@@ -13,6 +14,7 @@ export const getEngineConfig = (baseUrl: string, isRaw: boolean): EngineConfig =
 			`${baseUrl}/public/external/engineFilesV1_0_8_Canvas.js`,
 			`${baseUrl}/public/external/playlogClientV3_2_1.js`
 		],
+		external: ["coe"], // TODO: game.json から取得するように
 		content_url: `${baseUrl}/${gameContentDir}/game.json`,
 		asset_base_url: `${baseUrl}/${gameContentDir}`
 	};


### PR DESCRIPTION
# このPullRequestが解決する内容
`g.game.external.coe` の実装 ( `coe-plugin` ) を部分的に実装します。

## coe-plugin (Summary)

### startSession
`g.game.external.coe.startSession(param)` によって実行される処理。
対象のプレー (≒セッション) に与えられた場合、そのプレーの子供のプレーとして新規に作成される。

### exitSession
`g.game.external.coe.exitSession(sessionId, param)` によって実行される処理。
対象のプレーを停止および削除する。

## 設計
- Operator
  - ExternalPluginOperator
    - akashic plugin のイベント通知
  - LocalInstance
    - CoePluginEntity (1:1)
      - coe#startSession(), coe#exitSession() の実装

