### PR TITLE
arguments のないコンテンツを `-A` オプションで起動するとエラーになる問題を修正

### DIFF
--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -31,7 +31,7 @@ export class Store {
 		this.currentPlay = null;
 		this.currentLocalInstance = null;
 		this.sandboxConfig = null;
-		this.argumentsTable = null;
+		this.argumentsTable = {};
 	}
 
 	@action


### PR DESCRIPTION
掲題どおり。

sandbox.config.js に `arguments` がないコンテンツの場合、 `StartupScreen` の `argumentsTable` に `null` が渡ってエラーになっていました。