### PR TITLE
fix error when running remark lint

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,3 @@
+node_modules/
+packages/akashic-cli-serve/www/thirdparty/
+CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "lerna bootstrap --no-ci",
     "build": "lerna run build",
     "test": "npm run lint:md && lerna run test",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ./.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "publish:patch": "node build/updateChangelog.js patch && npm run commit-changelog && lerna publish patch --yes",
     "publish:minor": "node build/updateChangelog.js minor && npm run commit-changelog && lerna publish minor --yes",
     "publish:major": "node build/updateChangelog.js major && npm run commit-changelog && lerna publish major --yes",

--- a/packages/akashic-cli-commons/package.json
+++ b/packages/akashic-cli-commons/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint --type-check -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:jasmine && npm run lint",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"
   },

--- a/packages/akashic-cli-config/package.json
+++ b/packages/akashic-cli-config/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json src/**/*.ts spec/*.ts --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:jasmine && npm run lint",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"
   },

--- a/packages/akashic-cli-export-html/package.json
+++ b/packages/akashic-cli-export-html/package.json
@@ -20,7 +20,7 @@
     "build:template:ect": "shx cp templates/bundle-index.ect templates-build/ && shx cp templates/no-bundle-index.ect templates-build/",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:jasmine && npm run lint",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js",
     "update-template": "npm run update-template:v1 && npm run update-template:v2 && node ./build-template-support/updateEngineFiles.js",

--- a/packages/akashic-cli-export-zip/package.json
+++ b/packages/akashic-cli-export-zip/package.json
@@ -12,7 +12,7 @@
     "lint:ts": "npm run lint:ts:src && npm run lint:ts:spec",
     "lint:ts:src": "tslint --project tsconfig.json -c ../tslint.json",
     "lint:ts:spec": "tslint --project ./spec/tsconfig.json -c ../tslint.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:ts && npm run lint",
     "test:ts": "npm run test:ts:compile && npm run test:ts:jasmine",
     "test:ts:compile": "npm run build && tsc -p ./spec",

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p ./ && npm run zip",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "zip": "cd ./templates-src && npm run zip:js && npm run zip:ts && npm run zip:js-min",
     "zip:js": "cd ./templates-src/javascript/ && bestzip ../../templates/javascript.zip *",
     "zip:js-min": "cd ./templates-src/javascript-minimal/ && bestzip ../../templates/javascript-minimal.zip *",

--- a/packages/akashic-cli-install/package.json
+++ b/packages/akashic-cli-install/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:jasmine && npm run lint",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/index.js ./node_modules/jasmine/bin/jasmine.js"
   },

--- a/packages/akashic-cli-modify/package.json
+++ b/packages/akashic-cli-modify/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint --type-check -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:build && npm run test:jasmine && npm run lint",
     "test:build": "tsc -p spec/",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"

--- a/packages/akashic-cli-scan/package.json
+++ b/packages/akashic-cli-scan/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint --type-check -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:build && npm run test:jasmine && npm run lint",
     "test:build": "tsc -p spec/",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -16,7 +16,7 @@
     "lint": "npm run lint:client && npm run lint:server && npm run lint:md",
     "lint:client": "tslint -p ./src/client -c tslint.json 'src/client/**/*.ts*' 'src/common/**/*.ts'",
     "lint:server": "tslint -p ./src/server -c tslint.json 'src/server/**/*.ts'",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "storybook": "start-storybook -p 9001 -c .storybook -s ./www"
   },
   "author": "DWANGO Co., Ltd.",

--- a/packages/akashic-cli-stat/package.json
+++ b/packages/akashic-cli-stat/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint --type-check -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run test:jasmine && npm run lint",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/main.node.js ./node_modules/jasmine/bin/jasmine.js"
   },

--- a/packages/akashic-cli-uninstall/package.json
+++ b/packages/akashic-cli-uninstall/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run build && npm run test:compile  && npm run test:jasmine",
     "test:compile": "tsc -p ./spec",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/index.js ./node_modules/jasmine/bin/jasmine.js"

--- a/packages/akashic-cli-update/package.json
+++ b/packages/akashic-cli-update/package.json
@@ -10,7 +10,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run build && npm run test:compile  && npm run test:jasmine",
     "test:compile": "tsc -p ./spec",
     "test:jasmine": "istanbul cover --report text --report html --colors -i ./lib/index.js ./node_modules/jasmine/bin/jasmine.js"

--- a/packages/akashic-cli/package.json
+++ b/packages/akashic-cli/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p ./",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint -c ../tslint.json --project ./tsconfig.json",
-    "lint:md": "remark ./*.md --frail --no-stdout --quiet --rc-path ../../.remarkrc",
+    "lint:md": "remark . --frail --no-stdout --quiet --rc-path ../../.remarkrc",
     "test": "npm run lint",
     "test:jasmine": "jasmine ./spec/**/*[sS]pec.js"
   },


### PR DESCRIPTION
### 概要
自動生成されたCHANGELOG.mdがremark lintに引っかかってしまってテストが落ちてしまうという問題が見つかったので、CHANGELOG.mdをremarkの対象から外すという対応を行いました(remarkはそもそも手動で書いたものに対して行いたいので)。