### PR TITLE
scanで一部のメッセージがおかしい問題を修正

### DIFF
--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -90,8 +90,8 @@ export class Configuration extends cmn.Configuration {
 					_assertAssetFilenameValid(aid);
 					_assertAssetTypeNoConflict(aid, f, "image", decl.type);
 					if (decl.width !== size.width || decl.height !== size.height) {
-						this._logger.info("Detected change of the image size for " + aid + " " + unixPath +
-							" from " + decl.width + "x" + decl.height + " to " + size.width + "x" + size.height);
+						this._logger.info("Detected change of the image size for " + aid + " (" + unixPath +
+							") from " + decl.width + "x" + decl.height + " to " + size.width + "x" + size.height);
 						decl.width = size.width;
 						decl.height = size.height;
 					}
@@ -135,8 +135,8 @@ export class Configuration extends cmn.Configuration {
 					if (aidSet && aidSet.length > 0) {
 						aidSet.forEach((aid: string) => {
 							if (assets[aid].duration !== durationMap[current].duration) {
-								this._logger.info("Detected change of the audio duration for " + current + ": "
-									+ assets[aid].path + " from " + assets[aid].duration + " to " + durationMap[current]);
+								this._logger.info("Detected change of the audio duration for " + current + " ("
+									+ assets[aid].path + ") from " + assets[aid].duration + " to " + durationMap[current].duration);
 								assets[aid].duration = durationMap[current].duration;
 							}
 						});


### PR DESCRIPTION
掲題どおり。音声アセットの duration が変化した時の警告メッセージの実装がおかしく「 `[object Object]` 」が表示されていました。

```
INFO: Detected change of the audio duration for bgm1: audio/bgm1 from 66500 to [object Object]
```

ついでに「アセットID (アセットパス)」という形式で統一されるように `()` を加える微調整をしています。
