### PR TITLE
fix cli init help message show config help

### DIFF
--- a/packages/akashic-cli-config/src/cli.ts
+++ b/packages/akashic-cli-config/src/cli.ts
@@ -4,6 +4,11 @@ import * as commander from "commander";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons";
 import * as config from "./config";
 
+/**
+ * akashic cli configを実行する
+ * 
+ * この関数は複数回呼ばれるべきではない
+ */
 export function run(argv: string[]): void {
 
 	const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8"));

--- a/packages/akashic-cli-config/src/cli.ts
+++ b/packages/akashic-cli-config/src/cli.ts
@@ -6,7 +6,7 @@ import * as config from "./config";
 
 /**
  * akashic cli configを実行する
- * 
+ *
  * この関数は複数回呼ばれるべきではない
  */
 export function run(argv: string[]): void {

--- a/packages/akashic-cli-config/src/cli.ts
+++ b/packages/akashic-cli-config/src/cli.ts
@@ -4,46 +4,48 @@ import * as commander from "commander";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons";
 import * as config from "./config";
 
-const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8"));
-
-commander
-	.description("List and edit configurations")
-	.version(packageJson.version)
-	.usage("<command> [argument]");
-
-commander
-	.command("get [target]")
-	.description("get configuration from your .akashicrc")
-	.action((target: string, opts: any = {}) => {
-		const logger = new ConsoleLogger({ quiet: opts.quiet });
-		config.getConfigItem(null, target).then(value => logger.print(value));
-	});
-
-commander
-	.command("set [target] [value]")
-	.description("set configuration to your .akashicrc")
-	.action((target: string, value: string, opts: any = {}) => {
-		config.setConfigItem(null, target, value);
-	});
-
-commander
-	.command("delete [target]")
-	.description("delete configuration from your .akashicrc")
-	.action((target: string, opts: any = {}) => {
-		config.deleteConfigItem(null, target);
-	});
-
-commander
-	.command("list")
-	// akashicrcの仕様を定義する validator が出来るまで --all は実装できない
-	// .option("-a, --all", "List all items")
-	.description("list configuration from your .akashicrc")
-	.action((opts: any = {}) => {
-		const logger = new ConsoleLogger({ quiet: opts.quiet });
-		config.listConfigItems(logger);
-	});
-
 export function run(argv: string[]): void {
+
+	const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8"));
+
+	commander
+		.description("List and edit configurations")
+		.version(packageJson.version)
+		.usage("<command> [argument]");
+
+	commander
+		.command("get [target]")
+		.description("get configuration from your .akashicrc")
+		.action((target: string, opts: any = {}) => {
+			const logger = new ConsoleLogger({ quiet: opts.quiet });
+			config.getConfigItem(null, target).then(value => logger.print(value));
+		});
+
+	commander
+		.command("set [target] [value]")
+		.description("set configuration to your .akashicrc")
+		.action((target: string, value: string, opts: any = {}) => {
+			config.setConfigItem(null, target, value);
+		});
+
+	commander
+		.command("delete [target]")
+		.description("delete configuration from your .akashicrc")
+		.action((target: string, opts: any = {}) => {
+			config.deleteConfigItem(null, target);
+		});
+
+	commander
+		.command("list")
+		// akashicrcの仕様を定義する validator が出来るまで --all は実装できない
+		// .option("-a, --all", "List all items")
+		.description("list configuration from your .akashicrc")
+		.action((opts: any = {}) => {
+			const logger = new ConsoleLogger({ quiet: opts.quiet });
+			config.listConfigItems(logger);
+		});
+
+
 	commander.parse(argv);
 
 	if (!/^(get|set|delete|list)$/.test(argv[2])) {


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
akashic-cli-configを外部から呼ぶ際（ex: init -h）に、akashic-cli-configのhelp相当のメッセージが表示されてしまう現象を修正します。

### 概要

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

