### PR TITLE
コンテンツツリー対応

### DIFF
--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-serve",
-  "version": "0.0.20",
+  "version": "0.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -28,19 +28,19 @@
       }
     },
     "@akashic/engine-files": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.1.6.tgz",
-      "integrity": "sha512-t5gSgBFWYW5D5nWX2UmHyvrFJUxJbXsK/nzr8WPTOE4jJkiLJJex38L3LPHQbWsxiUrcVoVhvK5Meb3M2YGkmA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.1.8.tgz",
+      "integrity": "sha512-T8N65++p0GAcxpAdqdxLV3NiLEZXMnowWzJjdDxOYFebmZzYROHH/TNlFf6Qtx14diBHp56YoYg7lDjXVDGqLw==",
       "requires": {
         "@akashic/akashic-engine": "1.12.17",
         "@akashic/akashic-pdi": "1.10.2",
-        "@akashic/game-driver": "0.11.19"
+        "@akashic/game-driver": "0.11.20"
       }
     },
     "@akashic/game-driver": {
-      "version": "0.11.19",
-      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-0.11.19.tgz",
-      "integrity": "sha512-iQr/zf4QajpfJc7Ks9WN4zoUSxpriNGByfIchKbbzxAW/IAFTsSpyG0wmKiZR9PqcgeSIJPJlyHq7fj9SmrEcQ==",
+      "version": "0.11.20",
+      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-0.11.20.tgz",
+      "integrity": "sha512-TKnWU4/qGcCoC7WqhspI+uV9XVxcwOmmS5StYiJzZ+BIP+ktnswA9E9T8OHfYTBxQXwfXgkxMxUFH6z2pStPMw==",
       "requires": {
         "@akashic/akashic-engine": "~1.12.9",
         "es6-promise": "^3.1.2"
@@ -54,24 +54,24 @@
       }
     },
     "@akashic/headless-driver": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-0.2.1.tgz",
-      "integrity": "sha512-LWanHmqHlb1aPYADeXTtCfwDjHA8Va7gTjTs+CQaGKOlI/OXMx/d43YSgrMOqrgJv6A4mzp1mfnAqXOagnpwow==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-0.3.7.tgz",
+      "integrity": "sha512-mOqs4gIMiuKOCz+P0J7nKNnESA2BFjW5M2xxYWYJSzlHzQRmeepDUY4/h+K4NtsOjynh6sF1rL5nzU+aWF9vYQ==",
       "requires": {
         "@akashic/amflow": "0.2.2",
-        "@akashic/headless-driver-runner": "0.2.1",
-        "@akashic/headless-driver-runner-v1": "0.2.1",
-        "@akashic/headless-driver-runner-v2": "0.2.1",
+        "@akashic/headless-driver-runner": "0.3.0",
+        "@akashic/headless-driver-runner-v1": "0.3.4",
+        "@akashic/headless-driver-runner-v2": "0.3.7",
         "@akashic/playlog": "1.3.1",
         "@akashic/trigger": "0.1.5",
-        "lodash.clone": "4.5.0",
+        "lodash.clonedeep": "4.5.0",
         "node-fetch": "2.3.0"
       }
     },
     "@akashic/headless-driver-runner": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner/-/headless-driver-runner-0.2.1.tgz",
-      "integrity": "sha512-UOw+xlX4p7teAonllEjGJUUzVQYyQylF4c42Ty0c5CRdissy30rmmq/LMrrFj6/Ft08sHa/pqo/O32IVrgrVwg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner/-/headless-driver-runner-0.3.0.tgz",
+      "integrity": "sha512-Uc97PGY0fkkDmT5jDtGnfaX/hxrN6nFtBCf8zy6AEsfK0xmWgdNxYL2KMTW9vK5UGJ0zCtKiHC47vUSHk+ZyYw==",
       "requires": {
         "@akashic/amflow": "0.2.2",
         "@akashic/trigger": "0.1.5",
@@ -79,29 +79,29 @@
       }
     },
     "@akashic/headless-driver-runner-v1": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v1/-/headless-driver-runner-v1-0.2.1.tgz",
-      "integrity": "sha512-fzd79vnrloQBIC3e5t/vkU4dS/lRLVG88v4yE8eYI0qCGxhdjIkJjDmDH4xxLoD+PxM9zkEqq5yCgLCn/yAKow==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v1/-/headless-driver-runner-v1-0.3.4.tgz",
+      "integrity": "sha512-GwYTG32MMlFvvC+Q2PurZeMAWcEaieIiXpN+mpPFBvwVxLNK9/mrkaFKJjE7oueybBSE7zIMp9sB8ekeNwi4uQ==",
       "requires": {
-        "@akashic/engine-files": "1.1.6",
-        "@akashic/headless-driver-runner": "0.2.1",
+        "@akashic/engine-files": "1.1.8",
+        "@akashic/headless-driver-runner": "0.3.0",
         "node-fetch": "2.3.0"
       }
     },
     "@akashic/headless-driver-runner-v2": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v2/-/headless-driver-runner-v2-0.2.1.tgz",
-      "integrity": "sha512-9ANW9J03WLnU8krvC1WHBPiu/Wq2i2wIdb7TeXlUbPa1KhW5RtmHVDj5VUXdUdxyrgumHbmCq2MwOyqS8V2+cw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v2/-/headless-driver-runner-v2-0.3.7.tgz",
+      "integrity": "sha512-es0jOVQfnUPeHeqk2IDghDtjzb01N0ZaiV6+7aWTKU2RUd4oQTweIBXDv9fE4PaBocIoLw4QN/rkBF0j9mHQVA==",
       "requires": {
-        "@akashic/engine-files": "2.1.9",
-        "@akashic/headless-driver-runner": "0.2.1",
+        "@akashic/engine-files": "2.1.14",
+        "@akashic/headless-driver-runner": "0.3.0",
         "node-fetch": "2.3.0"
       },
       "dependencies": {
         "@akashic/akashic-engine": {
-          "version": "2.4.10",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.4.10.tgz",
-          "integrity": "sha512-lfJisPMx+0BJBpbFrlZYS6wbGQIvXWCto1zxB2sI7MRnUmBGQyJrijdt5xdfiOMhaTCAQTclgb2EJVWDrQnL/Q=="
+          "version": "2.4.14",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-2.4.14.tgz",
+          "integrity": "sha512-8bv4c1yWFydclFaiz41+XP7GdiI+gJxT1hVb0QZ1ZodSJQG198Oxj0SpeFq+rvDT7ysiUPx9Xg9LhcgMUy5SQA=="
         },
         "@akashic/akashic-pdi": {
           "version": "2.4.1",
@@ -114,11 +114,11 @@
           }
         },
         "@akashic/engine-files": {
-          "version": "2.1.9",
-          "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.1.9.tgz",
-          "integrity": "sha512-xvSvf2fLBgL4S6reArvqEAZubTa4lpQXLLuaBx9mORpbv3Y1scwzqsisfOO5vjh+56i42rwlEuo1q3Q9k1Yzcg==",
+          "version": "2.1.14",
+          "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.1.14.tgz",
+          "integrity": "sha512-aKm6burKKD5lLIuDqvCdOEw/EeH/cq2Jp7efSqcu17/RPFy+gUxIvsmIllyDOV4o5DSkuUS4gSVSR+jPENUU7A==",
           "requires": {
-            "@akashic/akashic-engine": "2.4.10",
+            "@akashic/akashic-engine": "2.4.14",
             "@akashic/akashic-pdi": "2.4.1",
             "@akashic/game-driver": "1.4.11"
           }
@@ -1980,6 +1980,21 @@
         "@types/events": "*",
         "@types/node": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/lodash": {
+      "version": "4.14.123",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
+      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
       }
     },
     "@types/mime": {
@@ -7972,12 +7987,13 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
-    "lodash.clone": {
+    "lodash.clonedeep": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -31,7 +31,7 @@
     "chokidar": "^2.1.2",
     "commander": "2.19.0",
     "express": "4.16.3",
-    "lodash": "~4.17.11",
+    "lodash.clonedeep": "4.5.0",
     "socket.io": "~2.1.1"
   },
   "devDependencies": {
@@ -42,6 +42,7 @@
     "@storybook/react": "~4.1.4",
     "@types/express": "4.16.0",
     "@types/express-serve-static-core": "4.16.0",
+    "@types/lodash.clonedeep": "4.5.6",
     "@types/node": "10.5.2",
     "@types/query-string": "6.1.0",
     "@types/react": "16.4.9",

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -41,11 +41,12 @@ export const createPlayToken = async(
 	playerId: string,
 	isActive: boolean,
 	name?: string,
-	envInfo?: any
+	envInfo?: any,
+	passedArgument?: string
 ): Promise<PlayTokenPostApiResponse> => {
 	return await ApiRequest.post<PlayTokenPostApiResponse>(
 		`/api/plays/${playId}/token`,
-		{playerId, isActive: isActive.toString(), name, envInfo}
+		{playerId, isActive: isActive.toString(), name, envInfo, passedArgument}
 	);
 };
 

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -53,10 +53,10 @@ export const broadcast = async(playId: string, message: any): Promise<void> => {
 	return await ApiRequest.post<void>(`/api/plays/${playId}/broadcast`, message);
 };
 
-export const createRunner = async(playId: string, isActive: boolean, token: string): Promise<RunnerPostApiResponse> => {
+export const createRunner = async(playId: string, isActive: boolean, token: string, args?: any): Promise<RunnerPostApiResponse> => {
 	return await ApiRequest.post<RunnerPostApiResponse>(
 		"/api/runners",
-		{playId, isActive: isActive.toString(), token}
+		{playId, isActive: isActive.toString(), token, args}
 	);
 };
 

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -36,6 +36,7 @@ export const resumePlayDuration = async(playId: string): Promise<PlayPatchApiRes
 	return await ApiRequest.patch<PlayPatchApiResponse>(`/api/plays/${playId}`, {status: "running"});
 };
 
+// TODO リファクタリング: 直接tokenに必要ないものをdebug用情報としてまとめる
 export const createPlayToken = async(
 	playId: string,
 	playerId: string,

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -136,7 +136,7 @@ export class Operator {
 
 	createNewPlay = async (param: CreatePlayParameterObject): Promise<PlayEntity> => {
 		const play = await this.store.playStore.createPlay(param);
-		const argument = JSON.parse(this.store.argumentsTable[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME]);
+		const argument = this.store.sandboxConfig.arguments[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME];
 		const tokenResult = await ApiClient.createPlayToken(play.playId, "", true, null, JSON.stringify(argument));  // TODO 空文字列でなくnullを使う
 		play.createServerInstance({ playToken: tokenResult.data.playToken, argument });
 		await ApiClient.broadcast(this.store.currentPlay.playId, { type: "newPlay", newPlayId: play.playId });
@@ -144,8 +144,7 @@ export class Operator {
 	}
 
 	createChildPlayAndSendEvents = async (param: CreateNewPlayAndSendEventsParameterObject): Promise<void> => {
-		const {parentPlayId, contentUrl, clientContentUrl, sessionParameters} = param;
-		const {type, version, url} = param.application;
+		const {parentPlayId, contentUrl, clientContentUrl, sessionParameters, application} = param;
 		const parentPlay = ((parentPlayId != null) && this.store.playStore.plays[parentPlayId]) || this.getCurrentPlay();
 		if (parentPlay == null) {
 			throw new Error("play not found");
@@ -159,11 +158,7 @@ export class Operator {
 				type: "child_start",
 				sessionId: childPlay.playId,
 				userId: ":akashic",
-				application: {
-					type,
-					version,
-					url
-				},
+				application,
 				cascadeApplications: []
 			}
 		]);
@@ -262,7 +257,7 @@ export class Operator {
 			contentUrl: this.contentUrl,
 			clientContentUrl: this.clientContentUrl
 		});
-		const argument = JSON.parse(this.store.argumentsTable[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME]);
+		const argument = this.store.sandboxConfig.arguments[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME];
 		const tokenResult = await ApiClient.createPlayToken(play.playId, "", true, null, JSON.stringify(argument));  // TODO 空文字列でなくnullを使う
 		play.createServerInstance({ playToken: tokenResult.data.playToken, argument });
 		ApiClient.resumePlayDuration(play.playId);

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -100,7 +100,14 @@ export class Operator {
 		const store = this.store;
 		const play = store.currentPlay;
 		const argument = params != null ? params.instanceArgument : undefined;
-		const tokenResult = await ApiClient.createPlayToken(play.playId, store.player.id, false, store.player.name, null, JSON.stringify(argument));
+		const tokenResult = await ApiClient.createPlayToken(
+			play.playId,
+			store.player.id,
+			false,
+			store.player.name,
+			null,
+			JSON.stringify(argument)
+		);
 		const instance = await play.createLocalInstance({
 			gameViewManager: this.gameViewManager,
 			playId: play.playId,

--- a/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
@@ -51,7 +51,7 @@ export class UiOperator {
 	}
 
 	selectInstanceArguments = (name: string | null): void => {
-		const content = (name != null) ? this.store.argumentsTable[name] : "";
+		const content = (name != null) ? this.store.argumentsStringTable[name] : "";
 		const { startupScreenUiStore } = this.store;
 		startupScreenUiStore.setSelectedArgumentName(name);
 		startupScreenUiStore.setInstanceArgumentEditContent(content);

--- a/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
@@ -17,40 +17,35 @@ export interface CoeSessionData {
 	messageHandler: (parameters: CoeExternalMessage) => void;
 }
 
-export interface CreateCoeLocalInstanceParameterObject {
+export interface CreateSessionInstanceParameterObject {
 	local: boolean;
 	playId: string;
 	parent?: LocalInstanceEntity;
 	contentUrl?: string;
 	argument?: any;
 	initialEvents?: Event[];
-	coeHandler?: {
-		createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
-	};
 }
-
 
 export interface CoePluginEntityParameterObject {
 	gameViewManager: GameViewManager;
 	targetInstance: LocalInstanceEntity;
-	createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+	createSessionInstance: (params: CreateSessionInstanceParameterObject) => Promise<LocalInstanceEntity>;
 }
-
 
 export class CoePluginEntity {
 	private _gameViewManager: GameViewManager;
 	private _targetInstance: LocalInstanceEntity;
 	private _childrenTable: { [sessionId: string]: CoeSessionData };
-	private _createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
+	private _createSessionInstacne: (params: CreateSessionInstanceParameterObject) => Promise<LocalInstanceEntity>;
 
 	constructor(param: CoePluginEntityParameterObject) {
 		this._gameViewManager = param.gameViewManager;
 		this._targetInstance = param.targetInstance;
 		this._childrenTable = {};
-		this._createLocalInstance = param.createLocalInstance;
+		this._createSessionInstacne = param.createSessionInstance;
 	}
 
-	async bootstrap(game: agv.GameLike, _gameContent: agv.GameContent): Promise<void> {
+	async setup(game: agv.GameLike, _gameContent: agv.GameContent): Promise<void> {
 		game.external.coe = {
 			startSession: this.startSession,
 			exitSession: this.exitSession,
@@ -122,7 +117,7 @@ export class CoePluginEntity {
 	private async _startSession(contentUrl: string, parameters: any, argument: any): Promise<void> {
 		try {
 			const sessionId = parameters.sessionId;
-			const instance = await this._createLocalInstance({
+			const instance = await this._createSessionInstacne({
 				contentUrl,
 				playId: sessionId,
 				local: false,
@@ -140,7 +135,7 @@ export class CoePluginEntity {
 	private async _startLocalSession(contentUrl: string, parameters: CoeStartSessionParameterObject, argument: any): Promise<void> {
 		try {
 			const sessionId = parameters.sessionId;
-			const instance = await this._createLocalInstance({
+			const instance = await this._createSessionInstacne({
 				contentUrl,
 				playId: sessionId,
 				local: true,

--- a/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/CoePluginEntity.ts
@@ -45,7 +45,7 @@ export class CoePluginEntity {
 		this._createSessionInstacne = param.createSessionInstance;
 	}
 
-	async setup(game: agv.GameLike, _gameContent: agv.GameContent): Promise<void> {
+	setup(game: agv.GameLike, _gameContent: agv.GameContent): void {
 		game.external.coe = {
 			startSession: this.startSession,
 			exitSession: this.exitSession,
@@ -103,7 +103,7 @@ export class CoePluginEntity {
 				});
 			}
 
-			child.instance.stop();
+			await child.instance.stop();
 		} catch (e) {
 			// TODO: エラーハンドリング
 			console.error(e);

--- a/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
@@ -1,3 +1,4 @@
+import cloneDeep = require("lodash.clonedeep");
 import {action, observable, computed} from "mobx";
 import {Trigger} from "@akashic/trigger";
 import {TimeKeeper} from "../../common/TimeKeeper";
@@ -47,6 +48,7 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 	readonly play: PlayEntity;
 	readonly coePlugin: CoePluginEntity;
 	readonly contentUrl: string;
+	readonly argument: any;
 
 	private _timeKeeper: TimeKeeper;
 	private _gameViewManager: GameViewManager;
@@ -59,6 +61,7 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 		this.play = params.play;
 		this.isPaused = false;
 		this.contentUrl = params.contentUrl;
+		this.argument = params.argument;
 		this._timeKeeper = new TimeKeeper();
 		this._gameViewManager = params.gameViewManager;
 		const playConfig: agv.PlaylogConfig = {
@@ -82,12 +85,12 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 			},
 			playConfig,
 			gameLoaderCustomizer,
-			argument: params.argument
+			argument: cloneDeep(params.argument)
 		});
 		if (params.coeHandler != null) {
 			this.coePlugin = new CoePluginEntity({
 				gameViewManager: this._gameViewManager,
-				localInstance: this,
+				targetInstance: this,
 				onLocalInstanceCreate: params.coeHandler.onLocalInstanceCreate,
 				onLocalInstanceDelete: params.coeHandler.onLocalInstanceDelete
 			});

--- a/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
@@ -32,8 +32,7 @@ export interface LocalInstanceEntityParameterObject {
 	playlogServerUrl?: string;
 	parent?: LocalInstanceEntity;
 	coeHandler?: {
-		onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
-		onLocalInstanceDelete: (playId: string) => Promise<void>;
+		createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
 	};
 }
 
@@ -91,8 +90,7 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 			this.coePlugin = new CoePluginEntity({
 				gameViewManager: this._gameViewManager,
 				targetInstance: this,
-				onLocalInstanceCreate: params.coeHandler.onLocalInstanceCreate,
-				onLocalInstanceDelete: params.coeHandler.onLocalInstanceDelete
+				createLocalInstance: params.coeHandler.createLocalInstance
 			});
 			this._agvGameContent.onExternalPluginRegister.addOnce((name: string) => {
 				if (name !== "coe") return;

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -74,7 +74,9 @@ export class PlayEntity {
 		this.joinedPlayerTable = observable.map((param.joinedPlayers || []).map(p => [p.id, p]));
 		this.status = "preparing";
 		this.localInstances = [];
-		this.serverInstances = !param.runners ? [] : param.runners.map(desc => new ServerInstanceEntity({ runnerId: desc.runnerId, play: this }));
+		this.serverInstances = !param.runners ? [] : param.runners.map(desc => {
+			return new ServerInstanceEntity({ runnerId: desc.runnerId, play: this, passedArgument: desc.passedArgument });
+		});
 		this._timeKeeper = new TimeKeeper();
 		this._clientContentUrl = param.clientContentUrl!;
 		this._contentUrl = param.contentUrl;
@@ -194,11 +196,11 @@ export class PlayEntity {
 	}
 
 	@action
-	handleRunnerCreate(runnerId: string): void {
-		const instance = new ServerInstanceEntity({ runnerId, play: this });
+	handleRunnerCreate(e: RunnerDescription): void {
+		const instance = new ServerInstanceEntity({ runnerId: e.runnerId, play: this, passedArgument: e.passedArgument });
 		this.serverInstances.push(instance);
-		if (this._serverInstanceWaiters[runnerId]) {
-			this._serverInstanceWaiters[runnerId](instance);
+		if (this._serverInstanceWaiters[e.runnerId]) {
+			this._serverInstanceWaiters[e.runnerId](instance);
 		}
 	}
 

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -30,6 +30,7 @@ export interface CreateLocalInstanceParameterObject {
 
 export interface CreateServerInstanceParameterObject {
 	playToken: string;
+	argument?: any;
 }
 
 export interface PlayEntityParameterObject {
@@ -119,7 +120,7 @@ export class PlayEntity {
 	}
 
 	async createServerInstance(param: CreateServerInstanceParameterObject): Promise<ServerInstanceEntity> {
-		const runnerResult = await ApiClient.createRunner(this.playId, true, param.playToken);
+		const runnerResult = await ApiClient.createRunner(this.playId, true, param.playToken, param.argument);
 		const runnerId = runnerResult.data.runnerId;
 
 		// ApiClient.createRunner() に対する onRunnerCreate 通知が先行していれば、この時点で ServerInstanceEntity が生成済みになっている

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -11,9 +11,8 @@ import { GameViewManager } from "../akashic/GameViewManager";
 import { SocketIOAMFlowClient } from "../akashic/SocketIOAMFlowClient";
 import { Player } from "../../common/types/Player";
 import { ExecutionMode } from "./ExecutionMode";
-import { LocalInstanceEntity } from "./LocalInstanceEntity";
+import { LocalInstanceEntity, HandleRegisterPluginParameterObject } from "./LocalInstanceEntity";
 import { ServerInstanceEntity } from "./ServerInstanceEntity";
-import { CreateCoeLocalInstanceParameterObject } from "./CoePluginEntity";
 
 export interface CreateLocalInstanceParameterObject {
 	gameViewManager: GameViewManager;
@@ -26,9 +25,7 @@ export interface CreateLocalInstanceParameterObject {
 	contentUrl?: string;
 	argument?: any;
 	initialEvents?: playlog.Event[];
-	coeHandler?: {
-		createLocalInstance: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
-	};
+	handleRegisterPlugin?: (params: HandleRegisterPluginParameterObject) => void;
 }
 
 export interface CreateServerInstanceParameterObject {
@@ -105,8 +102,6 @@ export class PlayEntity {
 			play: this,
 			contentUrl: param.contentUrl != null ? param.contentUrl : this._contentUrl, // TODO: 本来は this._clientContentUrl をみるべき
 			// contentUrl: this._clientContentUrl,  // クライアントスクリプトデバッグのためにはこちらに戻す必要あり
-			coeHandler: param.coeHandler,
-			parent: param.parent,
 			...param
 		});
 		i.onStop.add(this._handleLocalInstanceStopped);

--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -128,7 +128,7 @@ export class PlayStore {
 	}
 
 	private handleRunnerCreate = (e: RunnerCreateTestbedEvent): void => {
-		this.plays[e.playId].handleRunnerCreate(e.runnerId);
+		this.plays[e.playId].handleRunnerCreate(e);
 	}
 
 	private handleRunnerRemove = (e: RunnerRemoveTestbedEvent): void => {

--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -102,7 +102,7 @@ export class PlayStore {
 
 		// TODO LocalInstance はここで解放すべき？
 		if (e.playStatus === "suspending") {
-			play.teardown();
+			play.handleSuspend();
 			delete this.plays[e.playId];
 		}
 	}

--- a/packages/akashic-cli-serve/src/client/store/ServerInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/ServerInstanceEntity.ts
@@ -6,15 +6,18 @@ import {GameInstanceEntity} from "./GameInstanceEntity";
 export interface ServerInstanceEntityParameterObject {
 	runnerId: string;
 	play: PlayEntity;
+	passedArgument: string;
 }
 
 export class ServerInstanceEntity implements GameInstanceEntity {
-	@observable runnerId: string;
-	@observable play: PlayEntity;
+	@observable readonly runnerId: string;
+	@observable readonly play: PlayEntity;
+	@observable readonly passedArgument: string;
 
 	constructor(param: ServerInstanceEntityParameterObject) {
 		this.runnerId = param.runnerId;
 		this.play = param.play;
+		this.passedArgument = param.passedArgument;
 	}
 
 	async stop(): Promise<void> {

--- a/packages/akashic-cli-serve/src/client/store/SessionEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/SessionEntity.ts
@@ -1,0 +1,136 @@
+import { observable, action } from "mobx";
+import { PlayEntity } from "./PlayEntity";
+import { LocalInstanceEntity } from "./LocalInstanceEntity";
+
+/*
+import * as playlog from "@akashic/playlog";
+import { Trigger } from "@akashic/trigger";
+import { TimeKeeper } from "../../common/TimeKeeper";
+import { PlayStatus } from "../../common/types/PlayStatus";
+import { PlayDurationState } from "../../common/types/PlayDurationState";
+import { RunnerDescription, ClientInstanceDescription } from "../../common/types/TestbedEvent";
+import * as ApiClient from "../api/ApiClient";
+import { socketInstance } from "../api/socketInstance";
+import { GameViewManager } from "../akashic/GameViewManager";
+import { SocketIOAMFlowClient } from "../akashic/SocketIOAMFlowClient";
+import { Player } from "../../common/types/Player";
+import { ExecutionMode } from "./ExecutionMode";
+import { ServerInstanceEntity } from "./ServerInstanceEntity";
+*/
+
+export interface ContentInfo {
+	url: string;
+	clientUrl?: string;
+}
+
+export interface SessionEntityParameterObject {
+	contentInfo: contentInfo;
+	playId: string;
+	local: boolean;
+	serverInstanceArgument?: any;
+	instanceArgument: any;
+}
+
+export class SessionEntity {
+	static 
+
+	@observable play: PlayEntity | null;
+	@observable instance: LocalInstanceEntity;
+	@observable parent: SessionEntity | null;
+
+	private _param: SessionEntityParameterObject;
+
+	constructor(param: SessionEntityParameterObject) {
+		this._param = param;
+	}
+
+	async initialize(): Promise<void> {
+
+		// プレイを作る
+		const param = this._param;
+		const { contentInfo, playId, local } = param;
+		const play = await (local ? playStore.createStandalonePlay({ contentInfo, playId }) : playStore.createPlay({ contentInfo });
+
+		// サーバインスタンスを作る
+		if (!local) {
+			const argument = store.sandboxConfig.arguments[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME];
+			const playToken = (await ApiClient.createPlayToken(play.playId, "", true, null, JSON.stringify(argument))).playToken;  // TODO 空文字列でなくnullを使う
+			play.createServerInstance({ playToken, argument });
+			ApiClient.resumePlayDuration(play.playId);
+			return play;
+		}
+
+		// 親の死を監視する
+		const options = await ApiClient.getOptions();
+		if (optionsResult.autoStart) {
+			await this.startContent();
+		}
+	}
+
+	private async _initializeAsNonLocal(): Promise<void> {
+		const param = this._param;
+		const { contentInfo, playId, serverInstanceArgument } = param;
+		const play = await playStore.createPlay({ contentInfo });
+
+		// サーバインスタンスを作る
+		const playToken = (await ApiClient.createPlayToken(play.playId, "", true, null, JSON.stringify(serverInstanceArgument))).playToken;  // TODO 空文字列でなくnullを使う
+		play.createServerInstance({ playToken, argument: serverInstanceArgument });
+
+		ApiClient.resumePlayDuration(play.playId);
+
+	}
+
+	private async _createServerLoop(): Promise<PlayEntity> {
+		// 一部フローで二度手間になるが、createServerInstance() 時に参照するのでこの箇所で更新しておく
+		this.store.setSandboxConfig((await ApiClient.getSandboxConfig(this.store.contentId)) || {});
+
+		const play = await this.store.playStore.createPlay({
+			contentUrl: this.contentUrl,
+			clientContentUrl: this.clientContentUrl
+		});
+		const argument = this.store.sandboxConfig.arguments[Operator.ACTIVE_SERVER_INSTANCE_ARGUMENT_NAME];
+		const playToken = (await ApiClient.createPlayToken(play.playId, "", true, null, JSON.stringify(argument))).playToken;  // TODO 空文字列でなくnullを使う
+		play.createServerInstance({ playToken, argument });
+		ApiClient.resumePlayDuration(play.playId);
+		return play;
+	}
+
+}
+
+
+	async bootstrap(): Promise<void> {
+		const store = this.store;
+		await store.playStore.assertInitialized();
+		await store.devtoolUiStore.assertInitialized();
+		const playIds = Object.keys(store.playStore.plays);
+		const play = (playIds.length === 0) ? await this._createServerLoop() : store.playStore.plays[playIds[playIds.length - 1]];
+		await this.setCurrentPlay(play);
+	}
+
+	startContent = async (params?: StartContentParameterObject): Promise<void> => {
+		const store = this.store;
+		const play = store.currentPlay;
+		const playToken = (await ApiClient.createPlayToken(
+			play.playId,
+			store.player.id,
+			false,
+			store.player.name,
+			null,
+			JSON.stringify(argument)
+		)).playToken;
+		const instance = await play.createLocalInstance({
+			gameViewManager: this.gameViewManager,
+			playId: play.playId,
+			playToken,
+			playlogServerUrl: "dummy-playlog-server-url",
+			executionMode: "passive",
+			player: store.player,
+			argument,
+			handleRegisterPlugin: this._handleRegisterPlugin
+		});
+		store.setCurrentLocalInstance(instance);
+		if (params != null && params.joinsSelf) {
+			store.currentPlay.join(store.player.id, store.player.name);
+		}
+	}
+t 

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -24,7 +24,7 @@ export class Store {
 	@observable currentLocalInstance: LocalInstanceEntity | null;
 
 	@observable sandboxConfig: SandboxConfig;
-	@observable argumentsTable: { [name: string]: string };
+	@observable argumentsStringTable: { [name: string]: string };
 
 	constructor() {
 		this.contentId = 0;
@@ -41,7 +41,7 @@ export class Store {
 		this.currentPlay = null;
 		this.currentLocalInstance = null;
 		this.sandboxConfig = null;
-		this.argumentsTable = {};
+		this.argumentsStringTable = {};
 	}
 
 	@action
@@ -58,16 +58,15 @@ export class Store {
 	setSandboxConfig(cfg: SandboxConfig): void {
 		this.sandboxConfig = {
 			events: {},
+			arguments: {},
 			...cfg
 		};
 
 		// mobx の reaction として書くべき？
-		if (cfg.arguments) {
-			const args = cfg.arguments;
-			this.argumentsTable = Object.keys(args).reduce((acc, key) => {
-				acc[key] = JSON.stringify(args[key], null, 2);
-				return acc;
-			}, {} as { [name: string]: string });
-		}
+		const args = cfg.arguments;
+		this.argumentsStringTable = Object.keys(args).reduce((acc, key) => {
+			acc[key] = JSON.stringify(args[key], null, 2);
+			return acc;
+		}, {} as { [name: string]: string });
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -56,13 +56,16 @@ export class Store {
 
 	@action
 	setSandboxConfig(cfg: SandboxConfig): void {
-		this.sandboxConfig = cfg;
+		this.sandboxConfig = {
+			events: {},
+			...cfg
+		};
 
 		// mobx の reaction として書くべき？
 		if (cfg.arguments) {
 			const args = cfg.arguments;
 			this.argumentsTable = Object.keys(args).reduce((acc, key) => {
-				acc[key.replace(/^\</, "\\<")] = JSON.stringify(args[key], null, 2);
+				acc[key] = JSON.stringify(args[key], null, 2);
 				return acc;
 			}, {} as { [name: string]: string });
 		}

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -63,7 +63,7 @@ export class Store {
 		};
 
 		// mobx の reaction として書くべき？
-		const args = cfg.arguments;
+		const args = this.sandboxConfig.arguments;
 		this.argumentsStringTable = Object.keys(args).reduce((acc, key) => {
 			acc[key] = JSON.stringify(args[key], null, 2);
 			return acc;

--- a/packages/akashic-cli-serve/src/client/view/App.tsx
+++ b/packages/akashic-cli-serve/src/client/view/App.tsx
@@ -24,7 +24,7 @@ export class App extends React.Component<AppProps, {}> {
 				<StartupScreenContainer
 					operator={operator}
 					startupScreenUiStore={store.startupScreenUiStore}
-					argumentsTable={store.argumentsTable}
+					argumentsStringTable={store.argumentsStringTable}
 				/>
 			</div>;
 		}

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -31,7 +31,7 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				eventListMinWidth: 150,
 				onEventListResize: operator.ui.setEventListWidth,
 				onToggleList: operator.ui.toggleShowEventList,
-				eventNames: sandboxConfig.events ? Object.keys(sandboxConfig.events) : [],
+				eventNames: Object.keys(sandboxConfig.events),
 				eventEditContent: devtoolUiStore.eventEditContent,
 				onClickSendEvent: operator.play.sendRegisteredEvent,
 				onClickCopyEvent: operator.ui.copyRegisteredEventToEditor,

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -39,18 +39,20 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				onEventEditContentChanged: operator.ui.setEventEditContent
 			}}
 			instancesDevtoolProps={{
-				instances: play.serverInstances.map(desc => ({
+				instances: play.serverInstances.map(si => ({
 					type: "active" as ("active" | "passive"),
-					env: `server (runnerId: ${desc.runnerId})`,
+					env: `server (runnerId: ${si.runnerId})`,
 					playerId: null,
 					name: null,
-					isJoined: false
-				})).concat(play.clientInstances.map(desc => ({
-					type: (desc.isActive ? "active" : "passive") as ("active" | "passive"),
-					env: desc.envInfo ? JSON.stringify(desc.envInfo) : null,
-					playerId: desc.playerId,
-					name: desc.name,
-					isJoined: play.joinedPlayerTable.has(desc.playerId)
+					isJoined: false,
+					passedArgument: si.passedArgument
+				})).concat(play.clientInstances.map(ci => ({
+					type: (ci.isActive ? "active" : "passive") as ("active" | "passive"),
+					env: ci.envInfo ? JSON.stringify(ci.envInfo) : null,
+					playerId: ci.playerId,
+					name: ci.name,
+					isJoined: play.joinedPlayerTable.has(ci.playerId),
+					passedArgument: ci.passedArgument
 				}))),
 				onClickAddInstance: operator.play.openNewClientInstance
 			}}

--- a/packages/akashic-cli-serve/src/client/view/container/StartupScreenContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/StartupScreenContainer.tsx
@@ -7,18 +7,18 @@ import { StartupScreenUiStore } from "../../store/StartupScreenUiStore";
 export interface StartupScreenContainerProps {
 	operator: Operator;
 	startupScreenUiStore: StartupScreenUiStore;
-	argumentsTable: { [name: string]: string };
+	argumentsStringTable: { [name: string]: string };
 }
 
 @observer
 export class StartupScreenContainer extends React.Component<StartupScreenContainerProps, {}> {
 	render(): React.ReactNode {
-		const { operator, startupScreenUiStore, argumentsTable } = this.props;
+		const { operator, startupScreenUiStore, argumentsStringTable } = this.props;
 		return <StartupScreen
 			listWidth={startupScreenUiStore.instanceArgumentListWidth}
 			listMinWidth={150}
 			onListResize={operator.ui.setInstanceArgumentListWidth}
-			argumentsTable={argumentsTable}
+			argumentsStringTable={argumentsStringTable}
 			selectedArgumentName={startupScreenUiStore.selectedArgumentName}
 			argumentEditContent={startupScreenUiStore.instanceArgumentEditContent}
 			joinsAutomatically={startupScreenUiStore.joinsAutomatically}

--- a/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
@@ -18,14 +18,6 @@ export interface InstancesDevtoolProps {
 	onClickAddInstance: () => void;
 }
 
-function prettify(val: any) {
-	try {
-		return JSON.stringify(JSON.parse(val), null, 2)
-	} catch (_e) {
-		return "";
-	}
-}
-
 @observer
 export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}> {
 	render(): React.ReactNode {
@@ -59,7 +51,7 @@ export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}>
 									<td>{ (i.name != null) ? i.name : "(null)" }</td>
 									<td>{ i.isJoined ? "true" : "false" }</td>
 									<td>{ i.env || "(N/A)" }</td>
-									<td title={prettify(i.passedArgument)}>{ i.passedArgument || "(N/A)" }</td>
+									<td title={i.passedArgument}>{ i.passedArgument || "(N/A)" }</td>
 								</tr>
 							))
 						}

--- a/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
@@ -7,6 +7,7 @@ import * as styles from "./InstancesDevtool.css";
 export interface InstanceViewData {
 	type: "active" | "passive";  // TODO isActive: boolean にする
 	env?: string;
+	passedArgument?: string;
 	playerId: string | null;
 	name: string | null;
 	isJoined: boolean;
@@ -15,6 +16,14 @@ export interface InstanceViewData {
 export interface InstancesDevtoolProps {
 	instances: InstanceViewData[];
 	onClickAddInstance: () => void;
+}
+
+function prettify(val: any) {
+	try {
+		return JSON.stringify(JSON.parse(val), null, 2)
+	} catch (_e) {
+		return "";
+	}
 }
 
 @observer
@@ -37,6 +46,7 @@ export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}>
 							<th>Name</th>
 							<th>Joined</th>
 							<th>Env</th>
+							<th>Passed Argument</th>
 						</tr>
 					</thead>
 					<tbody>
@@ -49,6 +59,7 @@ export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}>
 									<td>{ (i.name != null) ? i.name : "(null)" }</td>
 									<td>{ i.isJoined ? "true" : "false" }</td>
 									<td>{ i.env || "(N/A)" }</td>
+									<td title={prettify(i.passedArgument)}>{ i.passedArgument || "(N/A)" }</td>
 								</tr>
 							))
 						}
@@ -57,6 +68,7 @@ export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}>
 						<tr>
 							<td></td>
 							<td><a href="#" onClick={this._onClickAddInstanceLink}>Add an instance</a></td>
+							<td></td>
 							<td></td>
 							<td></td>
 							<td></td>

--- a/packages/akashic-cli-serve/src/client/view/organism/StartupScreen.tsx
+++ b/packages/akashic-cli-serve/src/client/view/organism/StartupScreen.tsx
@@ -8,7 +8,7 @@ export interface StartupScreenProps {
 	listWidth: number;
 	listMinWidth: number;
 	onListResize: (width: number) => void;
-	argumentsTable: { [name: string]: string };
+	argumentsStringTable: { [name: string]: string };
 	argumentEditContent: string;
 	selectedArgumentName: string | null;
 	joinsAutomatically: boolean;
@@ -27,14 +27,14 @@ export class StartupScreen extends React.Component<StartupScreenProps, {}> {
 			onListResize,
 			selectedArgumentName,
 			argumentEditContent,
-			argumentsTable,
+			argumentsStringTable,
 			joinsAutomatically,
 			onSelectArgument,
 			onChangeJoinsAutomatically,
 			onClickStart
 		} = this.props;
 		const isValidArg = this._isValidArgument(argumentEditContent);
-		const selectedArg = ((selectedArgumentName == null) ? "" : argumentsTable[selectedArgumentName]);
+		const selectedArg = ((selectedArgumentName == null) ? "" : argumentsStringTable[selectedArgumentName]);
 		const isShowingSelected = (selectedArg === argumentEditContent);
 		const showsEditor = selectedArgumentName || !isShowingSelected;
 
@@ -49,7 +49,7 @@ export class StartupScreen extends React.Component<StartupScreenProps, {}> {
 						(No Arguments)
 					</li>
 					{
-						Object.keys(argumentsTable).map(name => (
+						Object.keys(argumentsStringTable).map(name => (
 							<li
 								key={"template:" + name}
 								className={(name === selectedArgumentName && isShowingSelected) ? styles["selected"] : ""}

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -40,9 +40,9 @@ const TestWithBehaviour = observer(() => (
 		}}
 		instancesDevtoolProps={{
 			instances: [
-				{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false },
-				{ type: "passive", env: "Chrome", playerId: "1234567890", name: "player-1", isJoined: true },
-				{ type: "passive", env: "Chrome", playerId: "aa0941jlta", name: "player-2", isJoined: false },
+				{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false, passedArgument: '{ "foo": "dummy" }' },
+				{ type: "passive", env: "Chrome", playerId: "1234567890", name: "player-1", isJoined: true, passedArgument: "argdummy2" },
+				{ type: "passive", env: "Chrome", playerId: "aa0941jlta", name: "player-2", isJoined: false, passedArgument: "argdummy3" },
 				{ type: "passive", env: "Firefox", playerId: "asfaiout", name: "player-3", isJoined: true }
 			],
 			onClickAddInstance: action("add-instance")
@@ -239,10 +239,10 @@ storiesOf("o-Devtool", module)
 			}}
 			instancesDevtoolProps={{
 				instances: [
-					{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false },
-					{ type: "passive", env: "Chrome", playerId: "1234567890", name: "player-1", isJoined: true },
+					{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false, passedArgument: "dummy1" },
+					{ type: "passive", env: "Chrome", playerId: "1234567890", name: "player-1", isJoined: true, passedArgument: "dummy2" },
 					{ type: "passive", env: "Chrome", playerId: "aa0941jlta", name: "player-2", isJoined: false },
-					{ type: "passive", env: "Firefox", playerId: "asfaiout", name: "player-3", isJoined: true }
+					{ type: "passive", env: "Firefox", playerId: "asfaiout", name: "player-3", isJoined: true, passedArgument: "dummy3" }
 				],
 				onClickAddInstance: action("add-instance")
 			}}

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -40,7 +40,7 @@ const TestWithBehaviour = observer(() => (
 		}}
 		instancesDevtoolProps={{
 			instances: [
-				{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false, passedArgument: '{ "foo": "dummy" }' },
+				{ type: "active", env: "(server)", playerId: null, name: null, isJoined: false, passedArgument: "{ \"foo\": \"dummy\" }" },
 				{ type: "passive", env: "Chrome", playerId: "1234567890", name: "player-1", isJoined: true, passedArgument: "argdummy2" },
 				{ type: "passive", env: "Chrome", playerId: "aa0941jlta", name: "player-2", isJoined: false, passedArgument: "argdummy3" },
 				{ type: "passive", env: "Firefox", playerId: "asfaiout", name: "player-3", isJoined: true }

--- a/packages/akashic-cli-serve/src/client/view/stories/StartupScreen.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/StartupScreen.stories.tsx
@@ -9,7 +9,7 @@ const store = observable({
 	joinsAutomatically: false,
 	width: 280,
 	editContent: `{ "foo": 100 }`,
-	argumentsTable: {
+	argumentsStringTable: {
 		"Start (difficulty: 3)": JSON.stringify([[32, 0, "test1"]], null, 2),
 		"Start (difficulty: 10)": JSON.stringify([[32, 0, "test2"]], null, 2),
 		"Stop": JSON.stringify([[32, 0, "stop"]], null, 2),
@@ -35,11 +35,11 @@ const TestWithBehaviour = observer(() => (
 			listWidth={store.width}
 			listMinWidth={200}
 			onListResize={w => (store.width = w)}
-			argumentsTable={store.argumentsTable}
+			argumentsStringTable={store.argumentsStringTable}
 			selectedArgumentName={store.selectedArgumentName}
 			argumentEditContent={store.editContent}
 			joinsAutomatically={store.joinsAutomatically}
-			onSelectArgument={name => ((store.selectedArgumentName = name), (store.editContent = (store.argumentsTable[name] || "")))}
+			onSelectArgument={name => ((store.selectedArgumentName = name), (store.editContent = (store.argumentsStringTable[name] || "")))}
 			onArgumentsEditContentChanged={v => (store.editContent = v)}
 			onChangeJoinsAutomatically={v => (store.joinsAutomatically = v)}
 			onClickStart={action("start-content")} />
@@ -52,7 +52,7 @@ storiesOf("m-StartupScreen", module)
 			<StartupScreen
 				listWidth={250}
 				listMinWidth={100}
-				argumentsTable={{
+				argumentsStringTable={{
 					"Start (difficulty: 3)": "1",
 					"Start (difficulty: 10)": "1",
 					"Stop": "1",
@@ -68,12 +68,12 @@ storiesOf("m-StartupScreen", module)
 				onClickStart={action("start-content")} />
 		</Box>
 	))
-	.add("many argumentsTable", () => (
+	.add("many argumentsStringTable", () => (
 		<Box>
 			<StartupScreen
 				listWidth={250}
 				listMinWidth={100}
-				argumentsTable={{
+				argumentsStringTable={{
 					"Start (difficulty: 3)": "1",
 					"Start (difficulty: 10)": "1",
 					"Stop": "1",

--- a/packages/akashic-cli-serve/src/common/types/TestbedEvent.ts
+++ b/packages/akashic-cli-serve/src/common/types/TestbedEvent.ts
@@ -33,6 +33,7 @@ export interface RunnerDescription {
 	playId: string;
 	runnerId: string;
 	isActive: boolean;
+	passedArgument: string;
 }
 
 export interface RunnerCreateTestbedEvent extends RunnerDescription {
@@ -60,6 +61,7 @@ export interface ClientInstanceDescription {
 	name: string;
 	isActive: boolean;
 	envInfo: any;  // TODO 中身を固めてanyをやめる
+	passedArgument: string;
 }
 
 export interface ClientInstanceAppearTestbedEvent extends ClientInstanceDescription {

--- a/packages/akashic-cli-serve/src/server/controller/PlayTokenController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/PlayTokenController.ts
@@ -16,7 +16,8 @@ export const createHandlerToCreatePlayToken = (amflowManager: SocketIOAMFlowMana
 			const name = req.body.name;
 			const isActive = (req.body.isActive === "true");
 			const envInfo = req.body.envInfo;
-			const playToken = amflowManager.createPlayToken(playId, playerId, name, isActive, envInfo);
+			const passedArgument = req.body.passedArgument;
+			const playToken = amflowManager.createPlayToken(playId, playerId, name, isActive, envInfo, passedArgument);
 			if (!playToken) {
 				throw new InternalServerError({ errorMessage: "Cannot generate playToken" });
 			}

--- a/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
@@ -30,8 +30,9 @@ export const createHandlerToCreateRunner = (playStore: PlayStore, runnerStore: R
 			const playId = req.body.playId;
 			const isActive = Boolean(req.body.isActive);
 			const token = req.body.token;
+			const args = req.body.args;
 			const amflow = playStore.createAMFlow(playId);
-			const runner = await runnerStore.createAndStartRunner(playId, isActive, token, amflow);
+			const runner = await runnerStore.createAndStartRunner(playId, isActive, token, args, amflow);
 			responseSuccess<RunnerPostApiResponseData>(res, 200, { playId: runner.playId, runnerId: runner.runnerId });
 		} catch (e) {
 			next(e);

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -79,7 +79,9 @@ export class PlayStore {
 	}
 
 	async stopPlay(playId: string): Promise<void> {
-		await this.playManager.stopPlay(playId);
+		// TODO headless-driver は stopPlay() すると全記録消えてしまうのをなんとかする
+		// TODO headless-driver に反映しないなら、 playStatus を自前で管理しておかないと、playStatus取得APIを作った時におかしくなる
+		// await this.playManager.stopPlay(playId);
 		this.onPlayStatusChange.fire({playId, playStatus: "suspending"});
 	}
 

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -26,7 +26,13 @@ export class RunnerStore {
 		this.runnerManager = params.runnerManager;
 	}
 
-	async createAndStartRunner(playId: string, isActive: boolean, token: string, args: any, amflow: AMFlowClient): Promise<RunnerV1 | RunnerV2> {
+	async createAndStartRunner(
+		playId: string,
+		isActive: boolean,
+		token: string,
+		args: any,
+		amflow: AMFlowClient
+	): Promise<RunnerV1 | RunnerV2> {
 		const runnerId = await this.runnerManager.createRunner({
 			playId,
 			amflow,

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -36,7 +36,7 @@ export class RunnerStore {
 		});
 		const runner = this.runnerManager.getRunner(runnerId);
 		await this.runnerManager.startRunner(runner.runnerId);
-		this.onRunnerCreate.fire({ playId, runnerId, isActive });
+		this.onRunnerCreate.fire({ playId, runnerId, isActive, passedArgument: JSON.stringify(args) });
 		return runner;
 	}
 

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -26,12 +26,13 @@ export class RunnerStore {
 		this.runnerManager = params.runnerManager;
 	}
 
-	async createAndStartRunner(playId: string, isActive: boolean, token: string, amflow: AMFlowClient): Promise<RunnerV1 | RunnerV2> {
+	async createAndStartRunner(playId: string, isActive: boolean, token: string, args: any, amflow: AMFlowClient): Promise<RunnerV1 | RunnerV2> {
 		const runnerId = await this.runnerManager.createRunner({
 			playId,
 			amflow,
 			executionMode: isActive ? "active" : "passive",
-			playToken: token
+			playToken: token,
+			gameArgs: args
 		});
 		const runner = this.runnerManager.getRunner(runnerId);
 		await this.runnerManager.startRunner(runner.runnerId);

--- a/packages/akashic-cli-serve/src/server/domain/SocketIOAMFlowManager.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SocketIOAMFlowManager.ts
@@ -34,9 +34,9 @@ export class SocketIOAMFlowManager {
 		this.connectionIdCounter = 0;
 	}
 
-	createPlayToken(playId: string, playerId: string, name: string, isActive: boolean, envInfo: any): string {
+	createPlayToken(playId: string, playerId: string, name: string, isActive: boolean, envInfo: any, passedArgument: string): string {
 		const token = this.playStore.createPlayToken(playId, isActive);
-		const desc = { id: ++this.idCounter, playId, playerId, name, isActive, envInfo };
+		const desc = { id: ++this.idCounter, playId, playerId, name, isActive, envInfo, passedArgument };
 		this.descMap[token] = desc;
 		return token;
 	}

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -22,8 +22,10 @@ function convertToStrings(params: any[]): string[] {
 	return params.map(param => {
 		if (typeof param === "object") {
 			return util.inspect(param, {depth: null});
-		} else {
+		} else if (param != null) {
 			return param.toString();
+		} else {
+			return JSON.stringify(param);
 		}
 	});
 }


### PR DESCRIPTION
master 未マージの #46, #54 を統合し、不足している対応を加えます。(この PR は不足部分の対応のみの PR です)　次の変更を加えています。

#### 機能補完

- `COEPluginEntity` に複数の子セッションを扱う実装がなかったので追加
- 親セッションの起動引数を子セッションの起動引数に使い回すように
- 親セッションでの join 状態を子セッションに反映するように
- サーバインスタンスの起動引数を指定できるように
  - `sandbox.config.js` の `arguments["<serverActiveInstanceArgument>"]` の値を暗黙に引き渡すようにしています (今暫定的に独断で決めた仕様)

#### 不具合修正・リファクタ

- セッション終了時にサーバインスタンスが多重に破棄されていた問題を修正
- `COEPluginEntity` と `LocalInstanceEntity` が密結合・循環参照になっていたので分離
  - プラグイン相当のものが増えるたびに `LocalInstanceEntity` が膨れていくのに抵抗があったため
  - `LocalInstanceEntity` にはプラグイン登録コールバック `handleRegisterPlugin` だけが渡せるように

#### 拡張

- 各インスタンスの起動引数を Instances devtool で確認できるように

#### 未対応

以下はこの PR に含めていません (のでコンテンツツリー対応としてはまだ不完全です):

- 子セッションの自発終了時、 play と instance の破棄
- Operator の整理

複数トピックを一気に対応してしまったので、レビュー上は個別のコミットをご覧いただく方がいいかもしれません。
