### PR TITLE
Add a button that takes over start argument and creates new play

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -96,7 +96,7 @@ export class Operator {
 		} else if (reuseStartupOption) {
 			const argText = this.store.startupScreenUiStore.instanceArgumentEditContent;
 			await this.startContent({
-				joinsSelf: this.store.startupScreenUiStore.joinsAutomatically, // joinについては起動画面での選択と直近の状態どちらを優先すべきか
+				joinsSelf: this.store.startupScreenUiStore.joinsAutomatically, // joinについても起動時の設定を引き継ぐ
 				instanceArgument: (argText !== "") ? JSON.parse(argText) : undefined
 			});
 		}
@@ -138,7 +138,7 @@ export class Operator {
 		await this._restartWithNewPlay(false);
 	}
 
-	restartWithStartupOption = async (): Promise<void> => {
+	restartWithCurrentArgument = async (): Promise<void> => {
 		await this._restartWithNewPlay(true);
 	}
 

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -38,7 +38,7 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 			playbackRate: play.activePlaybackRate,
 			isActivePausing: play.isActivePausing,
 			onClickReset: operator.restart,
-			onClickResetWithStartupOption: operator.restartWithStartupOption,
+			onClickResetWithCurrentArgument: operator.restartWithCurrentArgument,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance
 		};

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -37,7 +37,8 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 		return {
 			playbackRate: play.activePlaybackRate,
 			isActivePausing: play.isActivePausing,
-			onClickReset: operator.restartWithNewPlay,
+			onClickReset: operator.restart,
+			onClickResetWithStartupOption: operator.restartWithStartupOption,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance
 		};

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -7,7 +7,7 @@ export interface PlayControlPropsData {
 	playbackRate: number;
 	isActivePausing: boolean;
 	onClickReset?: () => void;
-	onClickResetWithStartupOption?: () => void;
+	onClickResetWithCurrentArgument?: () => void;
 	onClickActivePause?: (toPause: boolean) => void;
 	onClickAddInstance?: () => void;
 }
@@ -28,7 +28,7 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				icon="power_settings_new"
 				title={"新規プレイ(起動引数引継ぎ)\r\r新しいプレイを作成し、現在の全インスタンスから接続します。その際、各インスタンスは前回使用していた起動引数を引き回します"}
-				onClick={props.onClickResetWithStartupOption} />
+				onClick={props.onClickResetWithCurrentArgument} />
 			<ToolIconButton
 				icon="pause_circle_filled"
 				title={`アクティブインスタンスをポーズ${props.isActivePausing ? "解除" : ""}\r\r`

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -7,6 +7,7 @@ export interface PlayControlPropsData {
 	playbackRate: number;
 	isActivePausing: boolean;
 	onClickReset?: () => void;
+	onClickResetWithStartupOption?: () => void;
 	onClickActivePause?: (toPause: boolean) => void;
 	onClickAddInstance?: () => void;
 }
@@ -24,6 +25,10 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 				icon="power_settings_new"
 				title={"新規プレイ\r\r新しいプレイを作成し、現在の全インスタンスから接続します。"}
 				onClick={props.onClickReset} />
+			<ToolIconButton
+				icon="power_settings_new"
+				title={"新規プレイ(起動引数引継ぎ)\r\r新しいプレイを作成し、現在の全インスタンスから接続します。その際、各インスタンスは前回使用していた起動引数を引き回します"}
+				onClick={props.onClickResetWithStartupOption} />
 			<ToolIconButton
 				icon="pause_circle_filled"
 				title={`アクティブインスタンスをポーズ${props.isActivePausing ? "解除" : ""}\r\r`


### PR DESCRIPTION
### 概要
* 起動引数指定モードで新規プレイ作成する時に、毎回ゲーム画面の前に起動画面に飛ばさせるので、起動画面の表示をスキップして前回と同じ起動引数を使用して新規プレイを作成するボタンを新たに作成しました。

### やったこと
* 前回起動画面で指定したもの(起動引数と自動joinのON/OFF)を新規プレイ作成時に使いまわす機能を実装しました。

### ここでやらないこと
* ボタンのデザイン・UIについては別PRで対応します。
  * ここでは機能のみ実装しています。