### PR TITLE
downpile script to es5 when executing export html at atsumaru-option

### DIFF
--- a/packages/akashic-cli-export-html/src/app/exportAtsumaru.ts
+++ b/packages/akashic-cli-export-html/src/app/exportAtsumaru.ts
@@ -27,7 +27,9 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 				dest: completedParam.output,
 				hashLength: completedParam.hashLength,
 				strip: true,
-				force: true
+				force: true,
+				babel: true,
+				omitEmptyJs: true
 			});
 		}).then(() => {
 			// game.jsonへの追記


### PR DESCRIPTION
### 概要
* atsumaruオプション付きでexport-htmlを実行した時にexportされるfiles以下のスクリプトがes5にダウンパイルされていなかったので、ダウンパイルされるように修正しました。
  * htmlファイル中のスクリプトのダウンパイルは行っていません(そもそもexport-htmlにはダウンパイルオプションが無いため)