### PR TITLE
akashic-cli-initのjavascriptテンプレートの.eslintrc.jsonの修正

### DIFF
--- a/packages/akashic-cli-init/package-lock.json
+++ b/packages/akashic-cli-init/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-init",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2685,8 +2685,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2707,14 +2706,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2729,20 +2726,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2859,8 +2853,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2872,7 +2865,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2887,7 +2879,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2895,14 +2886,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2921,7 +2910,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3002,8 +2990,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3015,7 +3002,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3101,8 +3087,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3138,7 +3123,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3158,7 +3142,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3202,14 +3185,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/akashic-cli-init/templates-src/javascript-base/.eslintrc.json
+++ b/packages/akashic-cli-init/templates-src/javascript-base/.eslintrc.json
@@ -1,12 +1,29 @@
 {
+  "env": {
+    "commonjs": true,
+    "amd": true
+  },
   "parserOptions": {
     "ecmaVersion": 5
   },
+  "globals": {
+    "window": false,
+    "global": false,
+    "self": false,
+    "RPGAtsumaru": false,
+    "g": false
+  },
   "rules": {
-    "no-dupe-args": 2,
-    "no-dupe-keys": 2,
-    "no-duplicate-case": 2,
-    "no-inner-declarations": [2, "functions"],
-    "no-irregular-whitespace": 2
+    "no-dupe-args": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-inner-declarations": "error",
+    "no-irregular-whitespace": ["error", {
+      "skipStrings": true,
+      "skipComments": true,
+      "skipRegExps": true,
+      "skipTemplates": true
+    }],
+    "no-undef": "error"
   }
 }

--- a/packages/akashic-cli-init/templates-src/javascript-base/.eslintrc.json
+++ b/packages/akashic-cli-init/templates-src/javascript-base/.eslintrc.json
@@ -1,15 +1,12 @@
 {
   "env": {
-    "commonjs": true,
-    "amd": true
+    "commonjs": true
   },
   "parserOptions": {
     "ecmaVersion": 5
   },
   "globals": {
     "window": false,
-    "global": false,
-    "self": false,
     "RPGAtsumaru": false,
     "g": false
   },


### PR DESCRIPTION
### やったこと
* akashic-cli-initのjavascriptテンプレートの.eslintrc.jsonに以下のような改修を行いました
  * 全角スペースは以下の場合は使用することを許可
    * コメントアウト内
    * 文字列内
    * 正規表現内
    * テンプレートリテラル内
  * 未定義の変数の使用を禁止
    * ただし、`globals`に定義されているものやcommonjs, amdで定義されているものについては許可