### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@2.1.19、engineFiles@1.1.9)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -24,7 +24,7 @@
     "akashic-cli-serve": "./bin/run"
   },
   "dependencies": {
-    "@akashic/headless-driver": "0.4.6",
+    "@akashic/headless-driver": "0.4.8",
     "@akashic/trigger": "0.1.5",
     "chalk": "~2.4.2",
     "chokidar": "^2.1.2",


### PR DESCRIPTION
※本PRは自動生成されたものです

# akashic-cli-serve
* engineFilesV2: 2.1.19
* engineFilesV1: 1.1.9
* headless-driver: 0.4.8
* akashic-gameview-web: 0.10.23
* amflow: 0.2.2
* playlog: 1.3.1

