### PR TITLE
majorバージョンアップをrenovateの対象外にする対応

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
     {
       "updateTypes": ["patch"],
       "groupName": "all dependencies"
+    },
+    {
+      "updateTypes": ["major"],
+      "enabled": false
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
### 概要
* renovateで行うバージョンアップはminorかpatchだけにしようかと思っています。
  * そもそもrenovateを行いたいモチベーションは`npm audit`で警告が出ないようにするためなのですが、現状の設定だと20個ほどのライブラリのメジャーバージョンアップデートのPRが出てしまいます。(ちなみに、そのほとんどが`npm audit`とは関係ないものかと思います)
  * また、メジャーバージョンのアップデートが必要な場合はコードの修正も必要になるので、それについては自動化する必要はないのではとも思っています