### PR TITLE
akashic-cli-serveに依存しているamflowとplaylogのバージョンを前のものに戻す対応

### DIFF
--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-serve",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,14 +54,14 @@
       }
     },
     "@akashic/headless-driver": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-0.4.10.tgz",
-      "integrity": "sha512-Dfi3VOW8cUAdpHHy1dOldcNUHyUJSmucYyBK3v7rLLVmgguRCkaC6JrJE9zi8OEAsReqVdsowYG37Rt/cTUKBw==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-0.4.11.tgz",
+      "integrity": "sha512-mXTLYEclu0wPfQlbdvzdQeE6ZOtuUWe1Rz3Jc2Qxs6d78zsrgRIRwQHN6GqIAusSToL/GbGpAQC/5od3125emA==",
       "requires": {
         "@akashic/amflow": "0.2.2",
-        "@akashic/headless-driver-runner": "0.4.10",
-        "@akashic/headless-driver-runner-v1": "0.4.10",
-        "@akashic/headless-driver-runner-v2": "0.4.10",
+        "@akashic/headless-driver-runner": "0.4.11",
+        "@akashic/headless-driver-runner-v1": "0.4.11",
+        "@akashic/headless-driver-runner-v2": "0.4.11",
         "@akashic/playlog": "1.3.1",
         "@akashic/trigger": "0.1.5",
         "js-sha256": "0.9.0",
@@ -69,9 +69,9 @@
       }
     },
     "@akashic/headless-driver-runner": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner/-/headless-driver-runner-0.4.10.tgz",
-      "integrity": "sha512-ft2Cin+fcUIHuKC54x9mzek1P5rSX4irEevTeMiPn8RYG/j2QEZiJNjLN+9dKC+jtC0NYxPojM9w0ejNj508ig==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner/-/headless-driver-runner-0.4.11.tgz",
+      "integrity": "sha512-+1kN4WoKdgrcO16/yDXgRg9BnYe82tHhyfhObMNlsfj8jwknqxt0CT9ke91RQEN6vJc8EHJYYV54DSy9gxNvEg==",
       "requires": {
         "@akashic/amflow": "0.2.2",
         "@akashic/trigger": "0.1.5",
@@ -79,21 +79,21 @@
       }
     },
     "@akashic/headless-driver-runner-v1": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v1/-/headless-driver-runner-v1-0.4.10.tgz",
-      "integrity": "sha512-5m8NugSSuyrlFE1wVROZFDuDTnLKyNJUCizCv/vX+u9cGcq2mRgd12xsHct7pLnG54VkGPC6kzbt6/0pV+6NFg==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v1/-/headless-driver-runner-v1-0.4.11.tgz",
+      "integrity": "sha512-ubuTMD8Y1wOFatbTrJvb1zJmv2SAfZSk8FiuTmZw3B1aiU+I5qacQH7aOGeHTtEmkoCorzABzSQnKAxU4jNhFA==",
       "requires": {
         "@akashic/engine-files": "1.1.9",
-        "@akashic/headless-driver-runner": "0.4.10"
+        "@akashic/headless-driver-runner": "0.4.11"
       }
     },
     "@akashic/headless-driver-runner-v2": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v2/-/headless-driver-runner-v2-0.4.10.tgz",
-      "integrity": "sha512-JVZKLn+509cK5QbylmP8mOIUKXHODhJEsiyFflDve2hURyQvbk3yAfRw2vtDWio8jOlQMr83RYmkpuPjt7pevg==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver-runner-v2/-/headless-driver-runner-v2-0.4.11.tgz",
+      "integrity": "sha512-m87SBT1QofuePRqLRDawoFOmyjWweifkIgp06cGt5UX+WLvI+LXadeiB1z1hvDHtYXuR8rZnYXnpgsS0YnEOOQ==",
       "requires": {
         "@akashic/engine-files": "2.1.19",
-        "@akashic/headless-driver-runner": "0.4.10"
+        "@akashic/headless-driver-runner": "0.4.11"
       },
       "dependencies": {
         "@akashic/akashic-engine": {

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -34,8 +34,8 @@
     "socket.io": "2.2.0"
   },
   "devDependencies": {
-    "@akashic/amflow": "0.3.1",
-    "@akashic/playlog": "1.3.2",
+    "@akashic/amflow": "0.2.2",
+    "@akashic/playlog": "1.3.1",
     "@storybook/addon-actions": "4.1.18",
     "@storybook/addon-knobs": "4.1.18",
     "@storybook/react": "4.1.18",


### PR DESCRIPTION
https://github.com/akashic-games/akashic-cli/pull/120 でamflowとplaylogのバージョンを上げましたがその影響でmasterブランチでテストが落ちてしまっているので、それらライブラリを元のバージョンに戻す対応を行いました。