### PR TITLE
akashic-cli-initのランキング対応新市場コンテンツテンプレートの修正

### DIFF
--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -24,7 +24,7 @@ export = (originalParam: g.GameMainParameterObject) => {
 		if (msg.data && msg.data.type === "start" && msg.data.parameters) {
 			param.sessionParameter = msg.data.parameters; // sessionParameterフィールドを追加
 			if (msg.data.parameters.randomSeed) {
-				param.sessionParameter.random = new g.XorshiftRandomGenerator(sessionParameters.randomSeed);
+				param.sessionParameter.random = new g.XorshiftRandomGenerator(msg.data.parameters.randomSeed);
 			} else {
 				param.sessionParameter.random = g.game.random;
 			}

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -23,6 +23,11 @@ export = (originalParam: g.GameMainParameterObject) => {
 	scene.message.add((msg) => {
 		if (msg.data && msg.data.type === "start" && msg.data.parameters) {
 			param.sessionParameter = msg.data.parameters; // sessionParameterフィールドを追加
+			if (msg.data.parameters.randomSeed) {
+				param.sessionParameter.random = new g.XorshiftRandomGenerator(sessionParameters.randomSeed);
+			} else {
+				param.sessionParameter.random = g.game.random;
+			}
 			g.game.popScene();
 			main(param);
 		}

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -13,6 +13,8 @@ export = (originalParam: g.GameMainParameterObject) => {
 	param.sessionParameter = {};
 	// コンテンツが動作している環境がRPGアツマール上かどうか
 	param.isAtsumaru = typeof window !== "undefined" && typeof window.RPGAtsumaru !== "undefined";
+	// 乱数生成器
+	param.random = g.game.random;
 
 	const limitTickToWait = 3; // セッションパラメーターが来るまでに待つtick数
 
@@ -24,9 +26,7 @@ export = (originalParam: g.GameMainParameterObject) => {
 		if (msg.data && msg.data.type === "start" && msg.data.parameters) {
 			param.sessionParameter = msg.data.parameters; // sessionParameterフィールドを追加
 			if (msg.data.parameters.randomSeed) {
-				param.sessionParameter.random = new g.XorshiftRandomGenerator(msg.data.parameters.randomSeed);
-			} else {
-				param.sessionParameter.random = g.game.random;
+				param.random = new g.XorshiftRandomGenerator(msg.data.parameters.randomSeed);
 			}
 			g.game.popScene();
 			main(param);

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -25,7 +25,7 @@ export = (originalParam: g.GameMainParameterObject) => {
 	scene.message.add((msg) => {
 		if (msg.data && msg.data.type === "start" && msg.data.parameters) {
 			param.sessionParameter = msg.data.parameters; // sessionParameterフィールドを追加
-			if (msg.data.parameters.randomSeed) {
+			if (msg.data.parameters.randomSeed != null) {
 				param.random = new g.XorshiftRandomGenerator(msg.data.parameters.randomSeed);
 			}
 			g.game.popScene();

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
@@ -3,9 +3,9 @@ export interface GameMainParameterObject extends g.GameMainParameterObject {
 		mode?: string;
 		totalTimeLimit?: number;
 		difficulty?: number;
-		random?: g.RandomGenerator;
 	};
 	isAtsumaru: boolean;
+	random: g.RandomGenerator;
 }
 
 export interface RPGAtsumaruWindow {

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
@@ -3,9 +3,7 @@ export interface GameMainParameterObject extends g.GameMainParameterObject {
 		mode?: string;
 		totalTimeLimit?: number;
 		difficulty?: number;
-		randomSeed?: number;
-		playThreshold?: number;
-		clearThreshold?: number;
+		random?: g.RandomGenerator;
 	};
 	isAtsumaru: boolean;
 }

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/parameterObject.ts
@@ -3,6 +3,7 @@ export interface GameMainParameterObject extends g.GameMainParameterObject {
 		mode?: string;
 		totalTimeLimit?: number;
 		difficulty?: number;
+		randomSeed?: number;
 	};
 	isAtsumaru: boolean;
 	random: g.RandomGenerator;


### PR DESCRIPTION
### 概要
akashic-cli-initのランキング対応新市場コンテンツテンプレートに対して以下の修正を行いました。
* sessionParameterとして共通乱数シード値を利用した乱数生成オブジェクト(random)を追加
  * 共通乱数シード値を受け取って乱数生成オブジェクトを生成する処理はほぼ一意に決まっているのでテンプレート内部で隠蔽した方が利便性があると判断しました
* sessionParameterから不要なプロパティ(playThreshold, clearThreshold)の削除