### PR TITLE
Add --debug-proxy-audio option

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
@@ -23,6 +23,41 @@ export interface CreateGameContentParameterObject {
 	playConfig: agv.PlaylogConfig;
 	gameLoaderCustomizer: agv.GameLoaderCustomizer;
 	argument?: any;
+	proxyAudio?: boolean;
+}
+
+// --debug-proxy-audio用の暫定実装。デバッグ用なのでログに出すのみ。
+// 将来的にはこれを使って、音を鳴らしつつ再生状況を devtools に表示するようにもしてもいいかもしれない。
+export class LogAudioPdiHandler {
+	audioPlayerIdCounter: number = 0;
+
+	loadAudioAsset(param: { id: string, assetPath: string }, handler: (err?: any) => void): void {
+		console.info("AUDIOLOG: loadAudioAsset", param);
+		setTimeout(() => handler(), 0);
+	}
+	unloadAudioAsset(assetId: string): void {
+		console.info("AUDIOLOG: unloadAudioAsset", assetId);
+	}
+	createAudioPlayer(assetId: string): string {
+		const ret = "lap" + this.audioPlayerIdCounter++;
+		console.info("AUDIOLOG: createAudioPlayer", assetId, ret);
+		return ret;
+	}
+	destroyAudioPlayer(audioPlayerId: string): void {
+		console.info("AUDIOLOG: destroyAudioPlayer", audioPlayerId);
+	}
+	playAudioPlayer(audioPlayerId: string): void {
+		console.info("AUDIOLOG: playAudioPlayer", audioPlayerId);
+	}
+	stopAudioPlayer(audioPlayerId: string): void {
+		console.info("AUDIOLOG: stopAudioPlayer", audioPlayerId);
+	}
+	changeAudioVolume(audioPlayerId: string, volume: number): void {
+		console.info("AUDIOLOG: changeAudioVolume", audioPlayerId, volume);
+	}
+	changeAudioPlaybackRate(audioPlayerId: string, rate: number): void {
+		console.info("AUDIOLOG: changeAudioPlaybackRate", audioPlayerId, rate);
+	}
 }
 
 export class GameViewManager {
@@ -51,7 +86,8 @@ export class GameViewManager {
 			player: param.player,
 			playConfig: param.playConfig,
 			gameLoaderCustomizer: param.gameLoaderCustomizer,
-			argument: param.argument
+			argument: param.argument,
+			audioPdiHandlers: param.proxyAudio ? new LogAudioPdiHandler() : null
 		};
 		// TODO: 複数コンテンツのホスティングに対応されれば削除
 		if (param.gameLoaderCustomizer.createCustomAmflowClient) {

--- a/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
@@ -29,8 +29,6 @@ export interface CreateGameContentParameterObject {
 // --debug-proxy-audio用の暫定実装。デバッグ用なのでログに出すのみ。
 // 将来的にはこれを使って、音を鳴らしつつ再生状況を devtools に表示するようにもしてもいいかもしれない。
 export class LogAudioPdiHandler {
-	audioPlayerIdCounter: number = 0;
-
 	loadAudioAsset(param: { id: string, assetPath: string }, handler: (err?: any) => void): void {
 		console.info("AUDIOLOG: loadAudioAsset", param);
 		setTimeout(() => handler(), 0);
@@ -38,10 +36,8 @@ export class LogAudioPdiHandler {
 	unloadAudioAsset(assetId: string): void {
 		console.info("AUDIOLOG: unloadAudioAsset", assetId);
 	}
-	createAudioPlayer(assetId: string): string {
-		const ret = "lap" + this.audioPlayerIdCounter++;
-		console.info("AUDIOLOG: createAudioPlayer", assetId, ret);
-		return ret;
+	createAudioPlayer(param: unknown): void {
+		console.info("AUDIOLOG: createAudioPlayer", param);
 	}
 	destroyAudioPlayer(audioPlayerId: string): void {
 		console.info("AUDIOLOG: destroyAudioPlayer", audioPlayerId);

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -92,6 +92,7 @@ export class Operator {
 			executionMode: "passive",
 			player: store.player,
 			argument: params != null ? params.instanceArgument : undefined,
+			proxyAudio: store.appOptions.proxyAudio,
 			coeHandler: {
 				onLocalInstanceCreate: async params => {
 					// TODO: local === true のみ対応
@@ -116,7 +117,8 @@ export class Operator {
 								debugMode: false
 							}
 						},
-						initialEvents: params.initialEvents
+						initialEvents: params.initialEvents,
+						proxyAudio: store.appOptions.proxyAudio
 					});
 				},
 				onLocalInstanceDelete: async playId => {

--- a/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
@@ -32,6 +32,7 @@ export interface LocalInstanceEntityParameterObject {
 	argument?: any;
 	playToken?: string;
 	playlogServerUrl?: string;
+	proxyAudio?: boolean;
 	coeHandler?: {
 		onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
 		onLocalInstanceDelete: (playId: string) => Promise<void>;
@@ -87,7 +88,8 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 			},
 			playConfig,
 			gameLoaderCustomizer,
-			argument: params.argument
+			argument: params.argument,
+			proxyAudio: params.proxyAudio
 		});
 		if (params.coeHandler != null) {
 			this.coePlugin = new CoePluginEntity({

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -25,6 +25,7 @@ export interface CreateLocalInstanceParameterObject {
 	playlogServerUrl?: string;
 	argument?: any;
 	initialEvents?: playlog.Event[];
+	proxyAudio?: boolean;
 	coeHandler?: {
 		onLocalInstanceCreate: (params: CreateCoeLocalInstanceParameterObject) => Promise<LocalInstanceEntity>;
 		onLocalInstanceDelete: (playId: string) => Promise<void>;

--- a/packages/akashic-cli-serve/src/common/types/AppOptions.ts
+++ b/packages/akashic-cli-serve/src/common/types/AppOptions.ts
@@ -1,4 +1,5 @@
 export interface AppOptions {
 	autoStart: boolean;
 	verbose: boolean;
+	proxyAudio: boolean;
 }

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -6,6 +6,7 @@ export interface ServerGlobalConfig {
 	autoStart: boolean;
 	verbose: boolean;
 	untrusted: boolean; // 簡易対応。究極的にはコンテンツごとに指定されるべき値
+	proxyAudio: boolean;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -18,5 +19,6 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	useGivenPort: false,
 	autoStart: true,
 	verbose: false,
-	untrusted: false
+	untrusted: false,
+	proxyAudio: false
 };

--- a/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
@@ -7,7 +7,8 @@ export const handleToGetStartupOptions = (req: express.Request, res: express.Res
 	try {
 		responseSuccess<OptionsApiResponseData>(res, 200, {
 			autoStart: serverGlobalConfig.autoStart,
-			verbose: serverGlobalConfig.verbose
+			verbose: serverGlobalConfig.verbose,
+			proxyAudio: serverGlobalConfig.proxyAudio,
 		});
 	} catch (e) {
 		next(e);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -39,6 +39,7 @@ export function run(argv: any): void {
 		.option("-v, --verbose", `Display detailed information on console.`)
 		.option("-A, --no-auto-start", `Wait automatic startup of contents.`)
 		.option("--debug-untrusted", `An internal debug option`)
+		.option("--debug-proxy-audio", `An internal debug option`)
 		.parse(argv);
 
 	if (commander.port && isNaN(commander.port)) {
@@ -47,6 +48,7 @@ export function run(argv: any): void {
 	}
 
 	serverGlobalConfig.untrusted = !!commander.debugUntrusted;
+	serverGlobalConfig.proxyAudio = !!commander.debugProxyAudio;
 
 	if (commander.hostname) {
 		serverGlobalConfig.hostname = commander.hostname;


### PR DESCRIPTION
掲題どおり。

内部デバッグ用オプション `--debug-proxy-audio` を追加します。
通常、ゲーム開発時に指定する必要はありません。指定すると音声が再生されません。
動作には `www/` 以下の一部ファイルに条件があります。(詳細割愛)

レビューのためブランチに向けて PR を作っていますが、通過後は master にマージします。