### PR TITLE
Add local (yet-published) E2E test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "postinstall": "lerna bootstrap --no-ci",
     "build": "lerna run build",
-    "test": "npm run lint:md && lerna run test",
+    "test": "npm run lint:md && lerna run test && node test/e2e.js --local",
+    "test:published": "node test/e2e.js",
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "publish:patch": "node build/updateChangelog.js patch && npm run commit-changelog && lerna publish patch --yes",
     "publish:minor": "node build/updateChangelog.js minor && npm run commit-changelog && lerna publish minor --yes",


### PR DESCRIPTION
`npm test` に E2E テストを加えます。(E2E といっていいのかわかりませんが、akashic-cli 全部をまとめて統合的に動作確認する)

テスト内容そのものは、 `npm publish` されたものが壊れていないかを確認するために使っていた `test/testAfterPublish.js` を流用します。
