### PR TITLE
Use alternative hostname for --debug-untrusted

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
@@ -68,7 +68,7 @@ export class GameViewManager {
 			width: params.width || 0,
 			height: params.height || 0,
 			sharedObject: params.sharedObject,
-			untrustedFrameUrl: params.untrustedFrameUrl || "/internal/untrusted_loader/loader_local.html",
+			untrustedFrameUrl: params.untrustedFrameUrl || this.getDefaultUntrustedFrameUrl(),
 			trustedChildOrigin: params.trustedChildOrigin || /.*/
 		});
 	}
@@ -149,5 +149,19 @@ export class GameViewManager {
 				() => options.g.ExceptionFactory.createAssetLoadError("can not load script: " + assetPath)
 			);
 		};
+	}
+
+	private getDefaultUntrustedFrameUrl(): string {
+		// untrustedFrameUrl の制約上、別ホストでアクセスさせる必要があるのでそれを求める
+		const { hostname, protocol, port } = window.location;
+		const altHost = (hostname === "localhost") ? "127.0.0.1" : "localhost";
+		const altOrigin = `${protocol}//${altHost}:${port}`;
+
+		if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+			// 上述の制約上、今の --debug-untrusted はローカルマシンでしか動作しないのてその旨警告しておく
+			console.warn("Hosted on neither localhost nor 127.0.0.1. --debug-untrusted will not work.");
+		}
+
+		return `${altOrigin}/internal/untrusted_loader/loader_local.html`;
 	}
 }

--- a/packages/akashic-cli-serve/src/server/route/ContentsRoute.ts
+++ b/packages/akashic-cli-serve/src/server/route/ContentsRoute.ts
@@ -11,6 +11,16 @@ export const createContentsRouter = (params: ContentsRouterParameterObject): exp
 	const targetDirs = params.targetDirs;
 	const contentsRouter = express.Router();
 
+	// --debug-untrusted の動作用に、localhost と 127.0.0.1 のリクエストはクロスドメインでも許す
+	// (ref. GameViewManger#getDefaultUntrustedFrameUrl())
+	contentsRouter.use((req, res, next) => {
+		if (req.hostname === "localhost" || req.hostname === "127.0.0.1") {
+			res.header("Access-Control-Allow-Origin", req.get("origin"));
+			res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+		}
+		next();
+	});
+
 	for (let i = 0; i < targetDirs.length; i++) {
 		contentsRouter.get(`/${i}/content/:scriptName(*.js$)`, createScriptAssetController(targetDirs[i]));
 		contentsRouter.use(`/${i}/content`, express.static(targetDirs[i]));


### PR DESCRIPTION
掲題どおり。

`--debug-untrusted` 時に使う URL を元ホストと違うものにします。(詳細割愛)
