### PR TITLE
「新規プレイ」ボタンが動作していない問題を修正

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -47,10 +47,8 @@ export class Operator {
 	async bootstrap(contentLocator?: ClientContentLocator): Promise<void> {
 		const store = this.store;
 		let play: PlayEntity = null;
-		let isPlayCreated = false;
 		if (contentLocator) {
 			play = await this._createServerLoop(contentLocator);
-			isPlayCreated = true;
 		} else {
 			const plays = store.playStore.playsList();
 			if (plays.length > 0) {
@@ -58,11 +56,9 @@ export class Operator {
 			} else {
 				const loc = store.contentStore.defaultContent().locator;
 				play = await this._createServerLoop(loc);
-				isPlayCreated = true;
 			}
 		}
 		await this.setCurrentPlay(play);
-		if (isPlayCreated) this.play.sendRegisteredEvent(play.content.sandboxConfig.autoSendEvents);
 	}
 
 	setCurrentPlay = async (play: PlayEntity): Promise<void> => {
@@ -142,8 +138,8 @@ export class Operator {
 
 	restartWithNewPlay = async (): Promise<void> => {
 		const play = await this._createServerLoop(this.store.currentPlay.content.locator);
-		await ApiClient.broadcast(this.store.currentPlay.playId, { type: "switchPlay", nextPlayId: play.playId });
 		await this.store.currentPlay.deleteAllServerInstances();
+		await ApiClient.broadcast(this.store.currentPlay.playId, { type: "switchPlay", nextPlayId: play.playId });
 	}
 
 	private async _createServerLoop(contentLocator: ClientContentLocator): Promise<PlayEntity> {
@@ -151,6 +147,14 @@ export class Operator {
 		const tokenResult = await ApiClient.createPlayToken(play.playId, "", true);  // TODO 空文字列でなくnullを使う
 		await play.createServerInstance({ playToken: tokenResult.data.playToken });
 		await ApiClient.resumePlayDuration(play.playId);
+
+		// autoSendEvents
+		const sandboxConfig = this.store.contentStore.findOrRegister(contentLocator).sandboxConfig || {};
+		const { events, autoSendEvents } = sandboxConfig;
+		if (events && autoSendEvents && events[autoSendEvents] instanceof Array) {
+			events[autoSendEvents].forEach((pev: any) => play.amflow.enqueueEvent(pev));
+		}
+
 		return play;
 	}
 

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -38,12 +38,12 @@ export class PlayOperator {
 		const sandboxConfig = this.store.currentLocalInstance.content.sandboxConfig || {};
 		const pevs = sandboxConfig.events[eventName];
 		const amflow = this.store.currentPlay.amflow;
-		pevs.forEach((pev: any) => amflow.sendEvent(pev));
+		pevs.forEach((pev: any) => amflow.enqueueEvent(pev));
 	}
 
 	sendEditorEvent = (): void => {
 		const pevs = JSON.parse(this.store.devtoolUiStore.eventEditContent);
 		const amflow = this.store.currentPlay.amflow;
-		pevs.forEach((pev: any) => amflow.sendEvent(pev));
+		pevs.forEach((pev: any) => amflow.enqueueEvent(pev));
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -149,12 +149,12 @@ export class PlayEntity {
 
 	join(playerId: string, name?: string): void {
 		const highestPriority = 3;
-		this.amflow.sendEvent([playlog.EventCode.Join, highestPriority, playerId, name]);
+		this.amflow.enqueueEvent([playlog.EventCode.Join, highestPriority, playerId, name]);
 	}
 
 	leave(playerId: string): void {
 		const highestPriority = 3;
-		this.amflow.sendEvent([playlog.EventCode.Leave, highestPriority, playerId]);
+		this.amflow.enqueueEvent([playlog.EventCode.Leave, highestPriority, playerId]);
 	}
 
 	pauseActive(): void {

--- a/packages/akashic-cli-serve/src/client/store/storage.ts
+++ b/packages/akashic-cli-serve/src/client/store/storage.ts
@@ -84,7 +84,11 @@ export class Storage {
 
 	put(data: Partial<StorageData>): void {
 		this.data = { ...this.data, ...data };
-		window.sessionStorage.setItem(Storage.SESSION_STORAGE_KEY, JSON.stringify(this.data));
+		try {
+			window.sessionStorage.setItem(Storage.SESSION_STORAGE_KEY, JSON.stringify(this.data));
+		} catch (e) {
+			console.error("Failed to sessionStorage.setItem()", e);
+		}
 	}
 }
 


### PR DESCRIPTION
掲題どおり。ついでに入り込んでいるいくつかの不具合を修正します。

- (a) 「新規プレイ」ボタンを押すと、次のプレイが開始直後 (数フレーム描画後) に停止する
- (b) 「新規プレイ」ボタンを押した時、 `autoSendEvents` のイベントが送られない
- (c) sandbox.config.js に `autoSendEvents` がない場合にもイベントを送ろうとする (おそらく `null.forEach()` で例外が飛ぶ)
- (d) `sessionStorage` に書き込みできなかった場合ゲームが全く実行できない
   - 特に iOS Safari (quota が非常に小さい) で動かない。
