### PR TITLE
enable sandbox.config.js, send autoSendEvents for export-html

### DIFF
--- a/packages/akashic-cli-export-html/src/app/cli.ts
+++ b/packages/akashic-cli-export-html/src/app/cli.ts
@@ -115,7 +115,7 @@ export function run(argv: string[]): void {
 }
 
 function dropDeprecatedArgs(argv: string[]): string[] {
-	const filteredArgv = argv.filter(v => !/^(-s|--strip)$/.test(v));
+	const filteredArgv = argv.filter(v => !/^(--strip)$/.test(v));
 	if (argv.length !== filteredArgv.length) {
 		console.log("WARN: --strip option is deprecated. strip is applied by default.");
 		console.log("WARN: If you do not need to apply it, use --no-strip option.");

--- a/packages/akashic-cli-export-html/src/app/cli.ts
+++ b/packages/akashic-cli-export-html/src/app/cli.ts
@@ -19,6 +19,7 @@ interface CommandParameterObject {
 	magnify?: boolean;
 	injects?: string[];
 	atsumaru?: boolean;
+	autoSendEvents?: string | boolean;
 }
 
 const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
@@ -42,6 +43,7 @@ function cli(param: CommandParameterObject): void {
 		injects: param.injects,
 		unbundleText: !param.bundle || param.atsumaru,
 		lint: !param.atsumaru,
+		autoSendEvents: param.autoSendEvents,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version: ver, // export実行時のバージョン
@@ -92,6 +94,7 @@ commander
 	.option("-b, --bundle", "bundle assets and scripts in index.html (to reduce the number of files)")
 	.option("-m, --magnify", "fit game area to outer element size")
 	.option("-i, --inject [fileName]", "specify injected file content into index.html", inject, [])
+	.option("-A, --autoSendEvents [eventName]", "event name that send automatically when game start")
 	.option("-a, --atsumaru", "generate files that can be posted to RPG-atsumaru");
 
 export function run(argv: string[]): void {
@@ -110,7 +113,8 @@ export function run(argv: string[]): void {
 		magnify: commander["magnify"],
 		hashFilename: commander["hashFilename"],
 		injects: commander["inject"],
-		atsumaru: commander["atsumaru"]
+		atsumaru: commander["atsumaru"],
+		autoSendEvents: commander["autoSendEvents"]
 	});
 }
 

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -37,6 +37,17 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		code: encodeText(JSON.stringify(conf._content, null, "\t"))
 	});
 
+	try {
+		const sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
+		innerHTMLAssetArray.push({
+			name: "sandbox.config.js",
+			type: "script",
+			code: wrap(sandboxConfig, false)
+		});
+	} catch (error) {
+		// do nothing
+	}
+
 	var errorMessages: string[] = [];
 	var innerHTMLAssetNames = extractAssetDefinitions(conf, "script");
 	if (!options.unbundleText) {

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -42,7 +42,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		try {
 			options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 		} catch (error) {
-			options.autoSendEvents = "";
+			options.autoSendEvents = false;
 			console.log("failed read sandbox.config.js, autoSendEvents disabled.");
 		}
 	}

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -132,7 +132,9 @@ function writeEct(
 		magnify: !!options.magnify,
 		injectedContents: getInjectedContents(options.cwd, injects),
 		exportVersion: options.exportInfo !== undefined ? options.exportInfo.version : "",
-		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : ""
+		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : "",
+		autoSendEvents: "",
+		sandboxConfigJsCode: ""
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
 }

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -121,7 +121,6 @@ function writeEct(
 	const injects = options.injects ? options.injects : [];
 	var scripts = getDefaultBundleScripts(templatePath, conf._content.environment["sandbox-runtime"], options.minify, !options.unbundleText);
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
-
 	var html = ectRender.render("bundle-index", {
 		assets: innerHTMLAssetArray,
 		preloadScripts: scripts.preloadScripts,
@@ -132,7 +131,7 @@ function writeEct(
 		exportVersion: options.exportInfo !== undefined ? options.exportInfo.version : "",
 		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : "",
 		autoSendEvents: options.autoSendEvents,
-		sandboxConfigJsCode: options.sandboxConfigJsCode
+		sandboxConfigJsCode: options.sandboxConfigJsCode !== undefined ? options.sandboxConfigJsCode : ""
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
 }

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -13,7 +13,8 @@ import {
 	getDefaultBundleStyle,
 	extractAssetDefinitions,
 	getInjectedContents,
-	validateEs5Code
+	validateEs5Code,
+	readSandboxConfigJs
 } from "./convertUtil";
 
 interface InnerHTMLAssetData {
@@ -38,30 +39,12 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	});
 
 	try {
-		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
-		fs.accessSync(sandboxConfigJsPath);
-		var sandboxConfigJsString = fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
-		options.sandboxConfigJsCode = sandboxConfigJsString;
-		// sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
-		// fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
-		// assetPaths.push("sandbox.config.js");
+		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 	} catch (error) {
-		// do nothing
+		// sandbox.config.jsを取得できなかった場合、autoSendEventsを無効化する
 		options.autoSendEvents = false;
-		console.log("failed write sandboxConfig");
+		console.log("failed read sandbox.config.js, disable autoSendEvents.");
 	}
-	/*
-	try {
-		const sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
-		innerHTMLAssetArray.push({
-			name: "sandbox.config.js",
-			type: "script",
-			code: wrap(sandboxConfig, false)
-		});
-	} catch (error) {
-		// do nothing
-	}
-	*/
 
 	var errorMessages: string[] = [];
 	var innerHTMLAssetNames = extractAssetDefinitions(conf, "script");

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -41,9 +41,8 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	try {
 		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 	} catch (error) {
-		// sandbox.config.jsを取得できなかった場合、autoSendEventsを無効化する
 		options.autoSendEvents = false;
-		console.log("failed read sandbox.config.js, disable autoSendEvents.");
+		console.log("failed read sandbox.config.js, autoSendEvents disabled.");
 	}
 
 	var errorMessages: string[] = [];

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -38,6 +38,20 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	});
 
 	try {
+		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
+		fs.accessSync(sandboxConfigJsPath);
+		var sandboxConfigJsString = fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
+		options.sandboxConfigJsCode = sandboxConfigJsString;
+		// sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
+		// fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
+		// assetPaths.push("sandbox.config.js");
+	} catch (error) {
+		// do nothing
+		options.autoSendEvents = false;
+		console.log("failed write sandboxConfig");
+	}
+	/*
+	try {
 		const sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
 		innerHTMLAssetArray.push({
 			name: "sandbox.config.js",
@@ -47,6 +61,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	} catch (error) {
 		// do nothing
 	}
+	*/
 
 	var errorMessages: string[] = [];
 	var innerHTMLAssetNames = extractAssetDefinitions(conf, "script");
@@ -124,6 +139,7 @@ function writeEct(
 	const injects = options.injects ? options.injects : [];
 	var scripts = getDefaultBundleScripts(templatePath, conf._content.environment["sandbox-runtime"], options.minify, !options.unbundleText);
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
+
 	var html = ectRender.render("bundle-index", {
 		assets: innerHTMLAssetArray,
 		preloadScripts: scripts.preloadScripts,
@@ -133,8 +149,8 @@ function writeEct(
 		injectedContents: getInjectedContents(options.cwd, injects),
 		exportVersion: options.exportInfo !== undefined ? options.exportInfo.version : "",
 		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : "",
-		autoSendEvents: "",
-		sandboxConfigJsCode: ""
+		autoSendEvents: options.autoSendEvents,
+		sandboxConfigJsCode: options.sandboxConfigJsCode
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
 }

--- a/packages/akashic-cli-export-html/src/app/convertBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertBundle.ts
@@ -38,11 +38,13 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		code: encodeText(JSON.stringify(conf._content, null, "\t"))
 	});
 
-	try {
-		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
-	} catch (error) {
-		options.autoSendEvents = false;
-		console.log("failed read sandbox.config.js, autoSendEvents disabled.");
+	if (options.autoSendEvents) {
+		try {
+			options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
+		} catch (error) {
+			options.autoSendEvents = "";
+			console.log("failed read sandbox.config.js, autoSendEvents disabled.");
+		}
 	}
 
 	var errorMessages: string[] = [];

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -14,7 +14,6 @@ import {
 	validateEs5Code,
 	readSandboxConfigJs
 } from "./convertUtil";
-import { minify } from "uglify-js";
 
 export async function promiseConvertNoBundle(options: ConvertTemplateParameterObject): Promise<void> {
 	var content = await cmn.ConfigurationFile.read(path.join(options.source, "game.json"), options.logger);
@@ -34,9 +33,8 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	try {
 		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 	} catch (error) {
-		// sandbox.config.jsを取得できなかった場合、autoSendEventsを無効化する
 		options.autoSendEvents = false;
-		console.log("failed read sandbox.config.js, disable autoSendEvents.");
+		console.log("failed read sandbox.config.js, autoSendEvents disabled.");
 	}
 
 	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
@@ -101,12 +99,7 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
 	var version = conf._content.environment["sandbox-runtime"];
 	var versionsJson = require("./engineFilesVersion.json");
-	var sandboxConfig = "";
-	try {
-		sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
-	} catch (error) {
-		// do nothing
-	}
+	var sandboxConfig = options.sandboxConfigJsCode;
 	var html = ectRender.render("no-bundle-index", {
 		assets: assetPaths,
 		magnify: !!options.magnify,
@@ -116,8 +109,7 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 		exportVersion: options.exportInfo !== undefined ? options.exportInfo.version : "",
 		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : "",
 		autoSendEvents: options.autoSendEvents,
-		sandboxConfigJsCode: sandboxConfig
-
+		sandboxConfigJsCode: options.sandboxConfigJsCode !== undefined ? options.sandboxConfigJsCode : ""
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
 }

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -34,11 +34,14 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
 		fs.accessSync(sandboxConfigJsPath);
 		var sandboxConfigJsString = fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
-		sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
-		fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
-		assetPaths.push("sandbox.config.js");
+		options.sandboxConfigJsCode = sandboxConfigJsString;
+		// sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
+		// fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
+		// assetPaths.push("sandbox.config.js");
 	} catch (error) {
 		// do nothing
+		options.autoSendEvents = false;
+		console.log("failed write sandboxConfig");
 	}
 
 	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
@@ -103,6 +106,8 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
 	var version = conf._content.environment["sandbox-runtime"];
 	var versionsJson = require("./engineFilesVersion.json");
+	var sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
+
 	var html = ectRender.render("no-bundle-index", {
 		assets: assetPaths,
 		magnify: !!options.magnify,
@@ -110,7 +115,10 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 		version: version,
 		engineFilesVariable: versionsJson[`v${version}`].variable,
 		exportVersion: options.exportInfo !== undefined ? options.exportInfo.version : "",
-		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : ""
+		exportOption: options.exportInfo !== undefined ? options.exportInfo.option : "",
+		autoSendEvents: options.autoSendEvents,
+		sandboxConfigJsCode: sandboxConfig
+
 	});
 	fs.writeFileSync(path.resolve(outputPath, "./index.html"), html);
 }

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -11,7 +11,8 @@ import {
 	wrap,
 	extractAssetDefinitions,
 	getInjectedContents,
-	validateEs5Code
+	validateEs5Code,
+	readSandboxConfigJs
 } from "./convertUtil";
 import { minify } from "uglify-js";
 
@@ -31,17 +32,11 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	assetPaths.push("./js/game.json.js");
 
 	try {
-		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
-		fs.accessSync(sandboxConfigJsPath);
-		var sandboxConfigJsString = fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
-		options.sandboxConfigJsCode = sandboxConfigJsString;
-		// sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
-		// fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
-		// assetPaths.push("sandbox.config.js");
+		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 	} catch (error) {
-		// do nothing
+		// sandbox.config.jsを取得できなかった場合、autoSendEventsを無効化する
 		options.autoSendEvents = false;
-		console.log("failed write sandboxConfig");
+		console.log("failed read sandbox.config.js, disable autoSendEvents.");
 	}
 
 	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -34,7 +34,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
 		fs.accessSync(sandboxConfigJsPath);
 		var sandboxConfigJsString = fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
-		sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify)
+		sandboxConfigJsString = wrapScript(sandboxConfigJsString, "sandbox.config.js", options.minify);
 		fsx.outputFileSync(path.resolve(options.output, "sandbox.config.js"), sandboxConfigJsString);
 		assetPaths.push("sandbox.config.js");
 	} catch (error) {

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -30,7 +30,6 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	fsx.outputFileSync(gamejsonPath, wrapText(JSON.stringify(conf._content, null, "\t"), "game.json"));
 	assetPaths.push("./js/game.json.js");
 
-	// assetsに無いので手動でsandbox.config.jsをコピーする
 	try {
 		var sandboxConfigJsPath = path.join(options.source, "sandbox.config.js");
 		fs.accessSync(sandboxConfigJsPath);

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -34,7 +34,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		try {
 			options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 		} catch (error) {
-			options.autoSendEvents = "";
+			options.autoSendEvents = false;
 			console.log("failed read sandbox.config.js, autoSendEvents disabled.");
 		}
 	}

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -101,8 +101,12 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
 	var version = conf._content.environment["sandbox-runtime"];
 	var versionsJson = require("./engineFilesVersion.json");
-	var sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
-
+	var sandboxConfig = "";
+	try {
+		sandboxConfig = fs.readFileSync(path.join(options.source, "sandbox.config.js"), { encoding: "utf8" });
+	} catch (error) {
+		// do nothing
+	}
 	var html = ectRender.render("no-bundle-index", {
 		assets: assetPaths,
 		magnify: !!options.magnify,

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -34,7 +34,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		try {
 			options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
 		} catch (error) {
-			options.autoSendEvents = false;
+			options.autoSendEvents = "";
 			console.log("failed read sandbox.config.js, autoSendEvents disabled.");
 		}
 	}

--- a/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
+++ b/packages/akashic-cli-export-html/src/app/convertNoBundle.ts
@@ -30,11 +30,13 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	fsx.outputFileSync(gamejsonPath, wrapText(JSON.stringify(conf._content, null, "\t"), "game.json"));
 	assetPaths.push("./js/game.json.js");
 
-	try {
-		options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
-	} catch (error) {
-		options.autoSendEvents = false;
-		console.log("failed read sandbox.config.js, autoSendEvents disabled.");
+	if (options.autoSendEvents) {
+		try {
+			options.sandboxConfigJsCode = readSandboxConfigJs(options.source);
+		} catch (error) {
+			options.autoSendEvents = false;
+			console.log("failed read sandbox.config.js, autoSendEvents disabled.");
+		}
 	}
 
 	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
@@ -99,7 +101,6 @@ function writeEct(assetPaths: string[], outputPath: string, conf: cmn.Configurat
 	var ectRender = ect({root: __dirname + "/../templates-build", ext: ".ect"});
 	var version = conf._content.environment["sandbox-runtime"];
 	var versionsJson = require("./engineFilesVersion.json");
-	var sandboxConfig = options.sandboxConfigJsCode;
 	var html = ectRender.render("no-bundle-index", {
 		assets: assetPaths,
 		magnify: !!options.magnify,

--- a/packages/akashic-cli-export-html/src/app/convertUtil.ts
+++ b/packages/akashic-cli-export-html/src/app/convertUtil.ts
@@ -162,6 +162,12 @@ export function validateEs5Code(fileName: string, code: string): string[] {
 		.map(info => `${fileName}(${info.line}:${info.column}): ${info.message}`);
 }
 
+export function readSandboxConfigJs(sourceDir: string) {
+	const sandboxConfigJsPath = path.join(sourceDir, "sandbox.config.js");
+	fs.accessSync(sandboxConfigJsPath);
+	return fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
+}
+
 function getFileContentsFromDirectory(inputDirPath: string): string[] {
 	return fs.readdirSync(inputDirPath)
 		.map(fileName => fs.readFileSync(path.join(inputDirPath, fileName), "utf8").replace(/\r\n|\r/g, "\n"));

--- a/packages/akashic-cli-export-html/src/app/convertUtil.ts
+++ b/packages/akashic-cli-export-html/src/app/convertUtil.ts
@@ -164,7 +164,6 @@ export function validateEs5Code(fileName: string, code: string): string[] {
 
 export function readSandboxConfigJs(sourceDir: string) {
 	const sandboxConfigJsPath = path.join(sourceDir, "sandbox.config.js");
-	fs.accessSync(sandboxConfigJsPath);
 	return fs.readFileSync(sandboxConfigJsPath, "utf8").replace(/\r\n|\r/g, "\n");
 }
 

--- a/packages/akashic-cli-export-html/src/app/convertUtil.ts
+++ b/packages/akashic-cli-export-html/src/app/convertUtil.ts
@@ -21,6 +21,7 @@ export interface ConvertTemplateParameterObject {
 		version: string;
 		option: string;
 	};
+	autoSendeEvents?: string;
 }
 
 export function extractAssetDefinitions (conf: cmn.Configuration, type: string): string[] {

--- a/packages/akashic-cli-export-html/src/app/convertUtil.ts
+++ b/packages/akashic-cli-export-html/src/app/convertUtil.ts
@@ -21,7 +21,8 @@ export interface ConvertTemplateParameterObject {
 		version: string;
 		option: string;
 	};
-	autoSendeEvents?: string;
+	autoSendEvents?: string | boolean;
+	sandboxConfigJsCode?: string;
 }
 
 export function extractAssetDefinitions (conf: cmn.Configuration, type: string): string[] {

--- a/packages/akashic-cli-export-html/src/app/exportHTML.ts
+++ b/packages/akashic-cli-export-html/src/app/exportHTML.ts
@@ -77,7 +77,8 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 			injects: param.injects,
 			unbundleText: param.unbundleText,
 			lint: param.lint,
-			exportInfo: param.exportInfo
+			exportInfo: param.exportInfo,
+			autoSendEvents: param.autoSendEvents
 		};
 		if (param.bundle) {
 			return promiseConvertBundle(convertParam);

--- a/packages/akashic-cli-export-html/src/app/exportHTML.ts
+++ b/packages/akashic-cli-export-html/src/app/exportHTML.ts
@@ -22,6 +22,7 @@ export function _completeExportHTMLParameterObject(p: ExportHTMLParameterObject)
 	param.logger = param.logger || new cmn.ConsoleLogger();
 	return param;
 }
+
 export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string> {
 	const param = _completeExportHTMLParameterObject(p);
 	let gamepath: string;

--- a/packages/akashic-cli-export-html/templates/bundle-index.ect
+++ b/packages/akashic-cli-export-html/templates/bundle-index.ect
@@ -36,6 +36,18 @@ if (! ("gLocalAssetContainer" in window)) {
 <% end %>
 </script>
 
+<% if @autoSendEvents : %>
+	window.__akashic__.autoSendEvents = <%- @autoSendEvents %>;
+	window.__akashic__.sandboxConfigFunc = function () {
+		var module = { exports: {} };
+		var exports = module.exports;
+		(function () {
+			<%- @sandboxConfigJsCode %>
+		})();
+		return module.exports;
+	}
+<% end %>
+
 <script>
 <% for postloadScript in @postloadScripts : %>
 	<%- postloadScript %>

--- a/packages/akashic-cli-export-html/templates/bundle-index.ect
+++ b/packages/akashic-cli-export-html/templates/bundle-index.ect
@@ -40,7 +40,7 @@ if (! ("__akashic__" in window)) {
 <% end %>
 
 <% if @autoSendEvents : %>
-	window.__akashic__.autoSendEvents = "<%- @autoSendEvents %>";
+	window.__akashic__.autoSendEvents = <%- JSON.stringify(@autoSendEvents) %>;
 	window.__akashic__.sandboxConfigFunc = function () {
 		var module = { exports: {} };
 		var exports = module.exports;

--- a/packages/akashic-cli-export-html/templates/bundle-index.ect
+++ b/packages/akashic-cli-export-html/templates/bundle-index.ect
@@ -25,6 +25,10 @@ if (! ("gLocalAssetContainer" in window)) {
 	window.gLocalAssetContainer = {};
 }
 
+if (! ("__akashic__" in window)) {
+	window.__akashic__ = {};
+}
+
 <% for asset in @assets : %>
 	<% if asset.type is "script" : %>
 		window.gLocalAssetContainer["<%- asset.name %>"] = function(g) {
@@ -34,10 +38,9 @@ if (! ("gLocalAssetContainer" in window)) {
 		window.gLocalAssetContainer["<%- asset.name %>"] = "<%- asset.code %>";
 	<% end %>
 <% end %>
-</script>
 
 <% if @autoSendEvents : %>
-	window.__akashic__.autoSendEvents = <%- @autoSendEvents %>;
+	window.__akashic__.autoSendEvents = "<%- @autoSendEvents %>";
 	window.__akashic__.sandboxConfigFunc = function () {
 		var module = { exports: {} };
 		var exports = module.exports;
@@ -47,6 +50,7 @@ if (! ("gLocalAssetContainer" in window)) {
 		return module.exports;
 	}
 <% end %>
+</script>
 
 <script>
 <% for postloadScript in @postloadScripts : %>

--- a/packages/akashic-cli-export-html/templates/no-bundle-index.ect
+++ b/packages/akashic-cli-export-html/templates/no-bundle-index.ect
@@ -36,6 +36,22 @@ window.g = engineFiles.akashicEngine;
 <% for asset in @assets : %>
 <script src="<%- asset %>"></script>
 <% end %>
+
+<% if @autoSendEvents : %>
+<script>
+	window.__akashic__.autoSendEvents = "<%- @autoSendEvents %>";
+	window.__akashic__.sandboxConfigFunc = function () {
+		var module = { exports: {} };
+		var exports = module.exports;
+		(function () {
+			<%- @sandboxConfigJsCode %>
+		})();
+		return module.exports;
+	}
+</script>
+<% end %>
+
+
 <script src="./js/sandbox.js"></script>
 
 <% for injectedContent in @injectedContents : %>

--- a/packages/akashic-cli-export-html/templates/no-bundle-index.ect
+++ b/packages/akashic-cli-export-html/templates/no-bundle-index.ect
@@ -39,7 +39,7 @@ window.g = engineFiles.akashicEngine;
 
 <% if @autoSendEvents : %>
 <script>
-	window.__akashic__.autoSendEvents = "<%- @autoSendEvents %>";
+	window.__akashic__.autoSendEvents = <%- JSON.stringify(@autoSendEvents) %>;
 	window.__akashic__.sandboxConfigFunc = function () {
 		var module = { exports: {} };
 		var exports = module.exports;

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/initGlobals.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/initGlobals.js
@@ -3,3 +3,7 @@ window.g = require("@akashic/akashic-engine");
 if (! ("gLocalAssetContainer" in window)) {
 	window.gLocalAssetContainer = {};
 }
+
+if (! ("__akashic__" in window)) {
+	window.__akashic__ = {};
+}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
@@ -28,9 +28,10 @@ window.addEventListener("load", function() {
 				return readKeys.map(function (k, i) { return { readKey: k, values: svs[i] }; });
 			}
 		});
+
 		if (window.__akashic__.autoSendEvents) {
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
-			var autoSendEvents = (typeof window.__akashic__.autoSendEvents === "string") ? window.__akashic__.autoSendEvents : sandboxConfig.autoSendEvents;
+			var autoSendEvents = (window.__akashic__.autoSendEvents === "true") ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
 				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
@@ -29,9 +29,10 @@ window.addEventListener("load", function() {
 			}
 		});
 
-		if (window.__akashic__.autoSendEvents) {
+		if (window.__akashic__.autoSendEvents === true || typeof window.__akashic__.autoSendEvents === "string") {
+			if (window.__akashic__.autoSendEvents) {
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
-			var autoSendEvents = (window.__akashic__.autoSendEvents === "true") ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
+			var autoSendEvents = (window.__akashic__.autoSendEvents === true) ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
 				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
@@ -29,6 +29,16 @@ window.addEventListener("load", function() {
 			}
 		});
 
+		var sandboxConfigScript = window.gLocalAssetContainer["sandbox.config.js"];
+		if (sandboxConfigScript) {
+			var exporter = {module: {}, exports: {}};
+			sandboxConfigScript(exporter);
+			var sandboxConfig = exporter.module.exports;
+			if (!!sandboxConfig && sandboxConfig.autoSendEvents && sandboxConfig.events && sandboxConfig.events[sandboxConfig.autoSendEvents]) {
+				sandboxConfig.events[sandboxConfig.autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
+			}
+		}
+
 		var audioPlugins;
 		if (location.protocol !== "file:") {
 			// 特にSafariの制約(user activationなしでは音が鳴らない)回避のため、可能ならWebAudioを使う

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
@@ -28,14 +28,11 @@ window.addEventListener("load", function() {
 				return readKeys.map(function (k, i) { return { readKey: k, values: svs[i] }; });
 			}
 		});
-
-		var sandboxConfigScript = window.gLocalAssetContainer["sandbox.config.js"];
-		if (sandboxConfigScript) {
-			var exporter = {module: {}, exports: {}};
-			sandboxConfigScript(exporter);
-			var sandboxConfig = exporter.module.exports;
-			if (!!sandboxConfig && sandboxConfig.autoSendEvents && sandboxConfig.events && sandboxConfig.events[sandboxConfig.autoSendEvents]) {
-				sandboxConfig.events[sandboxConfig.autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
+		if (window.__akashic__.autoSendEvents) {
+			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
+			var autoSendEvents = (typeof window.__akashic__.autoSendEvents === "string") ? window.__akashic__.autoSendEvents : sandboxConfig.autoSendEvents;
+			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
+				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}
 		}
 

--- a/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v1/js/sandbox.js
@@ -30,7 +30,6 @@ window.addEventListener("load", function() {
 		});
 
 		if (window.__akashic__.autoSendEvents === true || typeof window.__akashic__.autoSendEvents === "string") {
-			if (window.__akashic__.autoSendEvents) {
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
 			var autoSendEvents = (window.__akashic__.autoSendEvents === true) ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/initGlobals.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/initGlobals.js
@@ -3,3 +3,7 @@ window.g = require("@akashic/akashic-engine");
 if (! ("gLocalAssetContainer" in window)) {
 	window.gLocalAssetContainer = {};
 }
+
+if (! ("__akashic__" in window)) {
+	window.__akashic__ = {};
+}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
@@ -29,13 +29,11 @@ window.addEventListener("load", function() {
 			}
 		});
 
-		var sandboxConfigScript = window.gLocalAssetContainer["sandbox.config.js"];
-		if (sandboxConfigScript) {
-			var exporter = {module: {}, exports: {}};
-			sandboxConfigScript(exporter);
-			var sandboxConfig = exporter.module.exports;
-			if (!!sandboxConfig && sandboxConfig.autoSendEvents && sandboxConfig.events && sandboxConfig.events[sandboxConfig.autoSendEvents]) {
-				sandboxConfig.events[sandboxConfig.autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
+		if (window.__akashic__.autoSendEvents) {
+			var autoSendEvents = window.__akashic__.autoSendEvents;
+			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
+			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
+				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}
 		}
 

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
@@ -31,7 +31,7 @@ window.addEventListener("load", function() {
 
 		if (window.__akashic__.autoSendEvents) {
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
-			var autoSendEvents = (typeof window.__akashic__.autoSendEvents === "string") ? window.__akashic__.autoSendEvents : sandboxConfig.autoSendEvents;
+			var autoSendEvents = (window.__akashic__.autoSendEvents === "true") ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
 				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
@@ -29,6 +29,16 @@ window.addEventListener("load", function() {
 			}
 		});
 
+		var sandboxConfigScript = window.gLocalAssetContainer["sandbox.config.js"];
+		if (sandboxConfigScript) {
+			var exporter = {module: {}, exports: {}};
+			sandboxConfigScript(exporter);
+			var sandboxConfig = exporter.module.exports;
+			if (!!sandboxConfig && sandboxConfig.autoSendEvents && sandboxConfig.events && sandboxConfig.events[sandboxConfig.autoSendEvents]) {
+				sandboxConfig.events[sandboxConfig.autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
+			}
+		}
+
 		var audioPlugins;
 		if (location.protocol !== "file:") {
 			// 特にSafariの制約(user activationなしでは音が鳴らない)回避のため、可能ならWebAudioを使う

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
@@ -30,8 +30,8 @@ window.addEventListener("load", function() {
 		});
 
 		if (window.__akashic__.autoSendEvents) {
-			var autoSendEvents = window.__akashic__.autoSendEvents;
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
+			var autoSendEvents = (typeof window.__akashic__.autoSendEvents === "string") ? window.__akashic__.autoSendEvents : sandboxConfig.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
 				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}

--- a/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v2/js/sandbox.js
@@ -29,9 +29,9 @@ window.addEventListener("load", function() {
 			}
 		});
 
-		if (window.__akashic__.autoSendEvents) {
+		if (window.__akashic__.autoSendEvents === true || typeof window.__akashic__.autoSendEvents === "string") {
 			var sandboxConfig = window.__akashic__.sandboxConfigFunc();
-			var autoSendEvents = (window.__akashic__.autoSendEvents === "true") ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
+			var autoSendEvents = (window.__akashic__.autoSendEvents === true) ? sandboxConfig.autoSendEvents : window.__akashic__.autoSendEvents;
 			if (!!sandboxConfig && autoSendEvents && sandboxConfig.events && sandboxConfig.events[autoSendEvents]) {
 				sandboxConfig.events[autoSendEvents].forEach((ev) => amflowClient.sendEvent(ev));
 			}


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

akashic export htmlコマンドで出力されるコンテンツに、sandbox.config.jsのAutoSendEventsイベントの送信機能を追加します。
この修正により、akashic-sandboxと同じように、playの起動時にイベントを送ることが出来るようになります。

`$akashic export html --autoSendEvents myEventName` とすることで、起動時に `myEventName` のイベントを送るようになります。
イベント名省略時は、sandbox.config.jsに `autoSendEvents` 要素があれば、これを送ります。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

