### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@2.1.30、engineFiles@1.1.12)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -24,7 +24,7 @@
     "akashic-cli-serve": "./bin/run"
   },
   "dependencies": {
-    "@akashic/headless-driver": "0.5.10",
+    "@akashic/headless-driver": "0.5.12",
     "@akashic/trigger": "0.1.5",
     "chalk": "2.4.2",
     "chokidar": "2.1.8",


### PR DESCRIPTION
※本PRは自動生成されたものです

# akashic-cli-serve
* engineFilesV2: 2.1.30
* engineFilesV1: 1.1.12
* headless-driver: 0.5.12
* akashic-gameview-web: 1.0.0
* amflow: ~0.3.1
* playlog: ~1.3.2

