### PR TITLE
refactor: Refactor functions with names toggle

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
@@ -13,24 +13,24 @@ export class UiOperator {
 		// this.store.ui.toolBar.showActivePlaybackRateDialog();
 	}
 
-	toggleShowAppearance = (show: boolean): void => {
-		this.store.toolBarUiStore.toggleShowAppearance(show);
+	setShowAppearance = (show: boolean): void => {
+		this.store.toolBarUiStore.setShowAppearance(show);
 	}
 
-	toggleShowDevtools = (show: boolean): void => {
-		this.store.toolBarUiStore.toggleShowDevtools(show);
+	setShowDevtools = (show: boolean): void => {
+		this.store.toolBarUiStore.setShowDevtools(show);
 	}
 
-	toggleShowDisplayOptionPopover = (show: boolean): void => {
-		this.store.toolBarUiStore.toggleShowDisplayOptionPopover(show);
+	setShowDisplayOptionPopover = (show: boolean): void => {
+		this.store.toolBarUiStore.setShowDisplayOptionPopover(show);
 	}
 
-	toggleShowBackgroundImage = (show: boolean) => {
-		this.store.toolBarUiStore.toggleShowBackgroundImage(show);
+	setShowBackgroundImage = (show: boolean) => {
+		this.store.toolBarUiStore.setShowBackgroundImage(show);
 	}
 
-	toggleShowGrid = (show: boolean) => {
-		this.store.toolBarUiStore.toggleShowGrid(show);
+	setShowGrid = (show: boolean) => {
+		this.store.toolBarUiStore.setShowGrid(show);
 	}
 
 	setDevtoolHeight = (height: number) => {
@@ -45,8 +45,8 @@ export class UiOperator {
 		this.store.devtoolUiStore.setEventListWidth(width);
 	}
 
-	toggleShowEventList = (show: boolean): void => {
-		this.store.devtoolUiStore.toggleShowEventList(show);
+	setShowEventList = (show: boolean): void => {
+		this.store.devtoolUiStore.setShowEventList(show);
 	}
 
 	copyRegisteredEventToEditor = (eventName: string): void => {

--- a/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
@@ -37,7 +37,7 @@ export class DevtoolUiStore {
 	}
 
 	@action
-	toggleShowEventList(show: boolean): void {
+	setShowEventList(show: boolean): void {
 		this.showsEventList = show;
 		storage.put({ showsEventList: show });
 	}

--- a/packages/akashic-cli-serve/src/client/store/ToolBarUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/ToolBarUiStore.ts
@@ -32,29 +32,29 @@ export class ToolBarUiStore {
 	}
 
 	@action
-	toggleShowAppearance(show: boolean): void {
+	setShowAppearance(show: boolean): void {
 		this.showsAppearanceMenu = show;
 	}
 
 	@action
-	toggleShowDevtools(show: boolean): void {
+	setShowDevtools(show: boolean): void {
 		this.showsDevtools = show;
 		storage.put({ showsDevtools: show });
 	}
 
 	@action
-	toggleShowDisplayOptionPopover(show: boolean): void {
+	setShowDisplayOptionPopover(show: boolean): void {
 		this.showsDisplayOptionPopover = show;
 	}
 
 	@action
-	toggleShowBackgroundImage(show: boolean): void {
+	setShowBackgroundImage(show: boolean): void {
 		this.showsBackgroundImage = show;
 		storage.put({ showsBackgroundImage: show });
 	}
 
 	@action
-	toggleShowGrid(show: boolean): void {
+	setShowGrid(show: boolean): void {
 		this.showsGrid = show;
 		storage.put({ showsGrid: show });
 	}

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -28,7 +28,7 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				eventListWidth: devtoolUiStore.eventListWidth,
 				eventListMinWidth: 150,
 				onEventListResize: operator.ui.setEventListWidth,
-				onToggleList: operator.ui.toggleShowEventList,
+				onClickShowEventList: operator.ui.setShowEventList,
 				eventNames: sandboxConfig.events ? Object.keys(sandboxConfig.events) : [],
 				eventEditContent: devtoolUiStore.eventEditContent,
 				onClickSendEvent: operator.play.sendRegisteredEvent,

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -32,8 +32,8 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 			showsDevtools={toolBarUiStore.showsDevtools}
 			showsInstanceControl={(localInstance.executionMode === "replay") || toolBarUiStore.showsDevtools}
 			targetService={targetService}
-			onToggleAppearance={operator.ui.toggleShowAppearance}
-			onToggleDevTools={operator.ui.toggleShowDevtools}
+			onToggleAppearance={operator.ui.setShowAppearance}
+			onClickDevTools={operator.ui.setShowDevtools}
 		/>;
 	}
 
@@ -83,9 +83,9 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 			showsDisplayOptionPopover: toolBarUiStore.showsDisplayOptionPopover,
 			showsBackgroundImage: toolBarUiStore.showsBackgroundImage,
 			showsGrid: toolBarUiStore.showsGrid,
-			onToggleDisplayOptionPopover: operator.ui.toggleShowDisplayOptionPopover,
-			onToggleShowBackgroundImage: operator.ui.toggleShowBackgroundImage,
-			onToggleShowGrid: operator.ui.toggleShowGrid
+			onClickDisplayOptionPopover: operator.ui.setShowDisplayOptionPopover,
+			onChangeShowBackgroundImage: operator.ui.setShowBackgroundImage,
+			onChangeShowGrid: operator.ui.setShowGrid
 		};
 	}
 }

--- a/packages/akashic-cli-serve/src/client/view/molecule/DisplayOptionControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/DisplayOptionControl.tsx
@@ -7,9 +7,9 @@ export interface DisplayOptionControlPropsData {
 	showsDisplayOptionPopover: boolean;
 	showsBackgroundImage: boolean;
 	showsGrid: boolean;
-	onToggleDisplayOptionPopover: (show: boolean) => void;
-	onToggleShowBackgroundImage: (show: boolean) => void;
-	onToggleShowGrid: (show: boolean) => void;
+	onClickDisplayOptionPopover: (show: boolean) => void;
+	onChangeShowBackgroundImage: (show: boolean) => void;
+	onChangeShowGrid: (show: boolean) => void;
 }
 
 export interface DisplayOptionControlProps {
@@ -28,9 +28,9 @@ export class DisplayOptionControl extends React.Component<DisplayOptionControlPr
 			showsDisplayOptionPopover,
 			showsBackgroundImage,
 			showsGrid,
-			onToggleDisplayOptionPopover,
-			onToggleShowBackgroundImage,
-			onToggleShowGrid
+			onClickDisplayOptionPopover,
+			onChangeShowBackgroundImage,
+			onChangeShowGrid
 		} = this._lastProps!;
 
 		return <div ref={this._onRef} style={{position: "relative"}}>
@@ -38,7 +38,7 @@ export class DisplayOptionControl extends React.Component<DisplayOptionControlPr
 				icon="image"
 				title={"表示オプション"}
 				pushed={showsDisplayOptionPopover}
-				onClick={onToggleDisplayOptionPopover} />
+				onClick={onClickDisplayOptionPopover} />
 			{
 				showsDisplayOptionPopover ?
 					<div className={styles["popover"]}>
@@ -50,7 +50,7 @@ export class DisplayOptionControl extends React.Component<DisplayOptionControlPr
 										className={styles["checkbox"]}
 										type="checkbox"
 										checked={showsBackgroundImage}
-										onChange={() => onToggleShowBackgroundImage(!showsBackgroundImage)}
+										onChange={() => onChangeShowBackgroundImage(!showsBackgroundImage)}
 									/>
 									Show backgorund image
 								</label>
@@ -61,7 +61,7 @@ export class DisplayOptionControl extends React.Component<DisplayOptionControlPr
 										className={styles["checkbox"]}
 										type="checkbox"
 										checked={showsGrid}
-										onChange={() => onToggleShowGrid(!showsGrid)}
+										onChange={() => onChangeShowGrid(!showsGrid)}
 									/>
 									Show grid
 								</label>
@@ -110,7 +110,7 @@ export class DisplayOptionControl extends React.Component<DisplayOptionControlPr
 		if (!ref || !lastProps || !(target instanceof Element))
 			return;
 		if (lastProps.showsDisplayOptionPopover && !ref.contains(target as Element)) {
-			lastProps.onToggleDisplayOptionPopover(false);
+			lastProps.onClickDisplayOptionPopover(false);
 		}
 	}
 }

--- a/packages/akashic-cli-serve/src/client/view/molecule/EventsDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/EventsDevtool.tsx
@@ -11,7 +11,7 @@ export interface EventsDevtoolProps {
 	eventListWidth: number;
 	eventListMinWidth: number;
 	onEventListResize: (width: number) => void;
-	onToggleList: (nextVal: boolean) => void;
+	onClickShowEventList: (nextVal: boolean) => void;
 	eventNames: string[];
 	eventEditContent: string;
 	onClickSendEvent: (eventName: string) => void;
@@ -61,7 +61,7 @@ export class EventsDevtool extends React.Component<EventsDevtoolProps, {}> {
 						icon="list"
 						title={"イベントリストの表示・非表示を切り替え"}
 						pushed={props.showsEventList}
-						onClick={props.onToggleList} />
+						onClick={props.onClickShowEventList} />
 					<div className={styles["sep"]} />
 					<ToolLabelButton
 						title="Send to the play"

--- a/packages/akashic-cli-serve/src/client/view/organism/ToolBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/organism/ToolBar.tsx
@@ -19,7 +19,7 @@ export interface ToolBarProps {
 	showsInstanceControl: boolean;
 	targetService: ServiceType;
 	onToggleAppearance: (show: boolean) => void;
-	onToggleDevTools: (show: boolean) => void;
+	onClickDevTools: (show: boolean) => void;
 }
 
 @observer
@@ -54,7 +54,7 @@ export class ToolBar extends React.Component<ToolBarProps, {}> {
 					icon="menu"
 					title={"Devtools"}
 					pushed={props.showsDevtools}
-					onClick={props.onToggleDevTools} />
+					onClick={props.onClickDevTools} />
 			</div>
 		</div>;
 	}

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -25,7 +25,7 @@ const TestWithBehaviour = observer(() => (
 			eventListWidth: store.eventListWidth,
 			eventListMinWidth: 200,
 			onEventListResize: (w => (store.eventListWidth = w)),
-			onToggleList: (v => (store.showsEventList = v)),
+			onClickShowEventList: (v => (store.showsEventList = v)),
 			eventNames: [
 				"Foo",
 				"Start",
@@ -67,7 +67,7 @@ storiesOf("o-Devtool", module)
 				eventListWidth: 250,
 				eventListMinWidth: 200,
 				onEventListResize: action("events:list-resize"),
-				onToggleList: action("events:toggle-list"),
+				onClickShowEventList: action("events:list"),
 				eventNames: [
 					"Foo",
 					"Start",
@@ -131,7 +131,7 @@ storiesOf("o-Devtool", module)
 				eventListWidth: 250,
 				eventListMinWidth: 200,
 				onEventListResize: action("events:list-resize"),
-				onToggleList: action("events:toggle-list"),
+				onClickShowEventList: action("events:list"),
 				eventNames: [
 					"Foo",
 					"Start",

--- a/packages/akashic-cli-serve/src/client/view/stories/EventsDevtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/EventsDevtool.stories.tsx
@@ -25,7 +25,7 @@ const TestWithBehaviour = observer(() => (
 		onEventListResize={w => (store.width = w)}
 		eventNames={Object.keys(store.events)}
 		eventEditContent={store.editContent}
-		onToggleList={v => (store.shows = v)}
+		onClickShowEventList={v => (store.shows = v)}
 		onClickSendEvent={action("send")}
 		onClickCopyEvent={name => (store.editContent = JSON.stringify(store.events[name]))}
 		onClickSendEditingEvent={action("send-edit")}
@@ -45,7 +45,7 @@ storiesOf("m-EventsDevtool", module)
 				"foo (a very long long event name example to test, woo hoo!)"
 			]}
 			eventEditContent={`["test"]`}
-			onToggleList={action("toggle-list")}
+			onClickShowEventList={action("list")}
 			onEventListResize={action("event-list-resize")}
 			onClickSendEvent={action("send")}
 			onClickCopyEvent={action("copy")}
@@ -96,7 +96,7 @@ storiesOf("m-EventsDevtool", module)
 				"Test 32"
 			]}
 			eventEditContent={`["test"]`}
-			onToggleList={action("toggle-list")}
+			onClickShowEventList={action("list")}
 			onEventListResize={action("event-list-resize")}
 			onClickSendEvent={action("send")}
 			onClickCopyEvent={action("copy")}

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
@@ -58,16 +58,16 @@ const TestWithBehaviour = observer(() => (
 				showsDisplayOptionPopover: store.showsDisplayOptionPopover,
 				showsBackgroundImage: store.showsBackgroundImage,
 				showsGrid: store.showsGrid,
-				onToggleDisplayOptionPopover: (show => store.showsDisplayOptionPopover = show),
-				onToggleShowBackgroundImage: (show => store.showsBackgroundImage = show),
-				onToggleShowGrid: (show => store.showsGrid = show)
+				onClickDisplayOptionPopover: (show => store.showsDisplayOptionPopover = show),
+				onChangeShowBackgroundImage: (show => store.showsBackgroundImage = show),
+				onChangeShowGrid: (show => store.showsGrid = show)
 			})}
 			showsAppearance={store.showsAppearance}
 			showsDevtools={store.showsDevtools}
 			showsInstanceControl={store.showsDevtools}
 			targetService={ServiceType.None}
 			onToggleAppearance={v => (store.showsAppearance = v)}
-			onToggleDevTools={v => (store.showsDevtools = v)}
+			onClickDevTools={v => (store.showsDevtools = v)}
 		/>
 ));
 
@@ -101,16 +101,16 @@ storiesOf("o-ToolBar", module)
 				showsDisplayOptionPopover: true,
 				showsBackgroundImage: false,
 				showsGrid: true,
-				onToggleDisplayOptionPopover: action("toggle-display-option"),
-				onToggleShowBackgroundImage: action("toggle-bgimage"),
-				onToggleShowGrid: action("toggle-grid")
+				onClickDisplayOptionPopover: action("display-option"),
+				onChangeShowBackgroundImage: action("bgimage"),
+				onChangeShowGrid: action("grid")
 			})}
 			showsAppearance={false}
 			showsDevtools={true}
 			showsInstanceControl={true}
 			targetService={ServiceType.None}
 			onToggleAppearance={action("toggle-appearance")}
-			onToggleDevTools={action("toggle-dev-tools")}
+			onClickDevTools={action("dev-tools")}
 		/>
 	))
 	.add("with-behavior", () => <TestWithBehaviour />);


### PR DESCRIPTION
## 修正内容

akashic-cli-serveで関数名に `toggle` がつく関数のリファクタリング

-  `setter` の実装になっている関数があるので、その関数名を `toggleXXX()`  -> `setXXX()` へ修正。

- コンポーネントのイベントハンドラ名と関数名が異なる名前を修正
 例) checkBoxの `onChange`で 設定されている関数が `onToggleXXX()` となっているのを、 `onChangeXXX()` へ修正