### PR TITLE
specify scan dirs, asset extension

### DIFF
--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -197,7 +197,7 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["d"].type).toBe("image");
 		conf.scanAssetsScript(["script"]);
 		expect(conf.getContent().assets["_1"].type).toBe("script");
-		conf.scanAssetsText(["text"]);
+		conf.scanAssetsText(["text"], []);
 		expect(conf.getContent().assets["$"].type).toBe("text");
 		conf.scanAssetsAudio(["audio"]).then(() => {
 			expect(conf.getContent().assets["_"].type).toBe("audio");
@@ -567,7 +567,7 @@ describe("Configuration", function () {
 
 		expect(conf.getContent().assets["dummyText"].type).toBe("text");
 		expect(conf.getContent().assets["newDummy"]).toBe(undefined);
-		conf.scanAssetsText(["text"]);
+		conf.scanAssetsText(["text"], []);
 		expect(conf.getContent().assets["dummyText"].type).toBe("text");
 		expect(conf.getContent().assets["newDummy"].type).toBe("text");
 
@@ -588,7 +588,7 @@ describe("Configuration", function () {
 			},
 		});
 		conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"], [])}).toThrow();
 	});
 
 	it("scan text assets invalid file name", function() {
@@ -609,7 +609,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"], [])}).toThrow();
 		var conf = new cnf.Configuration({ content: <any>{}, logger: nullLogger, basepath: process.cwd() });
 		gamejson = {
 			assets: {
@@ -627,7 +627,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"], [])}).toThrow();
 	});
 
 	it("handles a path appeared multiple time", function () {
@@ -657,7 +657,7 @@ describe("Configuration", function () {
 			},
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"], [])}).toThrow();
 	});
 
 	it("vacuums obsolete declarations", function () {
@@ -788,7 +788,7 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["dummyImg"].type).toBe("image");
 		conf.scanAssetsScript(["code"]);
 		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
-		conf.scanAssetsText(["txt"]);
+		conf.scanAssetsText(["txt"], []);
 		expect(conf.getContent().assets["dummyTxt"].type).toBe("text");
 		conf.scanAssetsAudio(["sound"]).then(() => {
 			expect(conf.getContent().assets["dummySound"].type).toBe("audio");
@@ -834,7 +834,7 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["dummyImg"].type).toBe("image");
 		conf.scanAssetsScript(["code"]);
 		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
-		conf.scanAssetsText(["txt"]);
+		conf.scanAssetsText(["txt"], []);
 		expect(conf.getContent().assets["dummyTxt"].type).toBe("text");
 		conf.scanAssetsAudio(["sound"]).then(() => {
 			expect(conf.getContent().assets["dummySound"].type).toBe("audio");
@@ -1694,7 +1694,7 @@ describe("Configuration", function () {
 			text: ["text"]
 		};
 
-		conf.scanAssets(assetScanDir, {}).then(() => {
+		conf.scanAssets(assetScanDir, {text: []}).then(() => {
 			conf.vacuum(assetScanDir);
 			expect(conf.getContent()).toEqual({
 				width: 320,

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -734,12 +734,17 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["deletedSe"]).not.toBe(undefined);
 		expect(conf.getContent().assets["deletedTxt"]).not.toBe(undefined);
 		expect(conf.getContent().assets["deletedScript"]).not.toBe(undefined);
-		conf.vacuum({
+
+		var assetScanDir = {
 			audio: ["audio"],
 			image: ["image"],
 			script: ["script"],
 			text: ["text"]
-		});
+		};
+		var assretExtension = {
+			text: <string[]>[]
+		}
+		conf.vacuum(assetScanDir, assretExtension);
 		expect(conf.getContent().assets["chara"]).not.toBe(undefined);
 		expect(conf.getContent().assets["se"]).not.toBe(undefined);
 		expect(conf.getContent().assets["txt"]).not.toBe(undefined);
@@ -1693,9 +1698,12 @@ describe("Configuration", function () {
 			script: ["script"],
 			text: ["text"]
 		};
+		var assretExtension = {
+			text: <string[]>[]
+		}
 
 		conf.scanAssets(assetScanDir, {text: []}).then(() => {
-			conf.vacuum(assetScanDir);
+			conf.vacuum(assetScanDir, assretExtension);
 			expect(conf.getContent()).toEqual({
 				width: 320,
 				height: 320,

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1711,7 +1711,7 @@ describe("Configuration", function () {
 			text: <string[]>[]
 		}
 
-		conf.scanAssets(assetScanDir, {text: []}).then(() => {
+		conf.scanAssets({ scanDirectoryTable: assetScanDir, extension: {text: []} }).then(() => {
 			conf.vacuum(assetScanDir, assretExtension);
 			expect(conf.getContent()).toEqual({
 				width: 320,

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -755,22 +755,27 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["deletedScript"]).toBe(undefined);
 	});
 
-	it("scan target any asset dirs", function (done) {
+	it("specify scan target dir", function (done) {
 		var gamejson: any = {
 			assets: {
-				"": {
-					"type": "text",
-					"path": "text/foo/dummy.txt",
+				"dummyAudio": {
+					"type": "audio",
+					"path": "audio/foo/dummyAudio",
 					"global": true,
+					"duration": 100
 				},
-				"a2": {
-					"type": "txt",
-					"path": "text/foo/dummy.txt",
+				"dummyImage": {
+					"type": "image",
+					"path": "image/foo/dummyImage.png",
 				},
-				"a3": {
+				"dummyScript": {
+					"type": "script",
+					"path": "script/foo/dummyScript.js",
+				},
+				"dummyText": {
 					"type": "text",
-					"path": "text/foo/dummy.txt",
-				},
+					"path": "script/foo/dummyText.js",
+				}
 			}
 		};
 		mockfs({
@@ -791,12 +796,16 @@ describe("Configuration", function () {
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
 		conf.scanAssetsImage(["img"]);
 		expect(conf.getContent().assets["dummyImg"].type).toBe("image");
+		expect(conf.getContent().assets["dummyImage"].type).toBe("image");
 		conf.scanAssetsScript(["code"]);
 		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
+		expect(conf.getContent().assets["dummyScript"].type).toBe("script");
 		conf.scanAssetsText(["txt"], []);
 		expect(conf.getContent().assets["dummyTxt"].type).toBe("text");
+		expect(conf.getContent().assets["dummyText"].type).toBe("text");
 		conf.scanAssetsAudio(["sound"]).then(() => {
 			expect(conf.getContent().assets["dummySound"].type).toBe("audio");
+			expect(conf.getContent().assets["dummyAudio"].type).toBe("audio");
 			done();
 		}, done.fail);
 	});

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -193,13 +193,13 @@ describe("Configuration", function () {
 			logger: nullLogger,
 			basepath: "./"
 		});
-		conf.scanAssetsImage();
+		conf.scanAssetsImage(["image"]);
 		expect(conf.getContent().assets["d"].type).toBe("image");
-		conf.scanAssetsScript();
+		conf.scanAssetsScript(["script"]);
 		expect(conf.getContent().assets["_1"].type).toBe("script");
-		conf.scanAssetsText();
+		conf.scanAssetsText(["text"]);
 		expect(conf.getContent().assets["$"].type).toBe("text");
-		conf.scanAssetsAudio().then(() => {
+		conf.scanAssetsAudio(["audio"]).then(() => {
 			expect(conf.getContent().assets["_"].type).toBe("audio");
 			done();
 		}, done.fail);
@@ -237,7 +237,7 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["dummyImage"].height).toBe(90);
 		expect(conf.getContent().assets["dummyImage"].global).toBe(true);
 		expect(conf.getContent().assets["bar"]).toBeUndefined();
-		conf.scanAssetsImage();
+		conf.scanAssetsImage(["image"]);
 		expect(conf.getContent().assets["dummyImage"].type).toBe("image");
 		expect(conf.getContent().assets["dummyImage"].width).toBe(1);
 		expect(conf.getContent().assets["dummyImage"].height).toBe(1);
@@ -268,7 +268,7 @@ describe("Configuration", function () {
 			logger: nullLogger,
 			basepath: process.cwd()
 		});
-		expect(function(){conf.scanAssetsImage()}).toThrow();
+		expect(function(){conf.scanAssetsImage(["image"])}).toThrow();
 	});
 
 	it("scan image assets invalid file name", function() {
@@ -289,7 +289,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsImage()}).toThrow();
+		expect(function(){conf.scanAssetsImage(["image"])}).toThrow();
 
 		conf = new cnf.Configuration({ content: <any>{}, logger: nullLogger, basepath: process.cwd() });
 		gamejson = {
@@ -308,7 +308,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsImage()}).toThrow();
+		expect(function(){conf.scanAssetsImage(["image"])}).toThrow();
 	});
 
 	it("scan audio assets info - ogg", function (done) {
@@ -342,7 +342,7 @@ describe("Configuration", function () {
 
 		expect(conf.getContent().assets["dummyAudio"].type).toBe("audio");
 		expect(conf.getContent().assets["newDummy"]).toBe(undefined);
-		conf.scanAssetsAudio().then(() => {
+		conf.scanAssetsAudio(["audio"]).then(() => {
 			expect(conf.getContent().assets["dummyAudio"].type).toBe("audio");
 			expect(conf.getContent().assets["newDummy"].type).toBe("audio");
 			expect(conf.getContent().assets["newDummy"].systemId).toBe("sound");
@@ -382,7 +382,7 @@ describe("Configuration", function () {
 
 		expect(conf.getContent().assets["dummyAudio"].type).toBe("audio");
 		expect(conf.getContent().assets["newDummy"]).toBe(undefined);
-		conf.scanAssetsAudio().then(() => {
+		conf.scanAssetsAudio(["audio"]).then(() => {
 			expect(conf.getContent().assets["dummyAudio"].type).toBe("audio");
 			expect(conf.getContent().assets["newDummy"].type).toBe("audio");
 			expect(conf.getContent().assets["newDummy"].systemId).toBe("sound");
@@ -412,7 +412,7 @@ describe("Configuration", function () {
 			}
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: "." });
-		conf.scanAssetsAudio().then((done.fail as () => void)).catch((err: any) => {
+		conf.scanAssetsAudio(["audio"]).then((done.fail as () => void)).catch((err: any) => {
 			expect(err.message.indexOf("Conflicted Asset Type") >= 0).toBe(true);
 			done();
 		});
@@ -429,7 +429,7 @@ describe("Configuration", function () {
 		var loggedCount = 0;
 		var logger = new cmn.ConsoleLogger({ quiet: false, debugLogMethod: () => ++loggedCount });
 		var conf = new cnf.Configuration({ content: <any>{}, logger: logger, basepath: process.cwd() });
-		conf.scanAssetsAudio().then(() => {
+		conf.scanAssetsAudio(["audio"]).then(() => {
 			// アセット追加のログが1つ + duration差のwarnが1つ + AAC利用のwarnが1つ
 			expect(loggedCount).toBe(3);
 			done();
@@ -455,7 +455,7 @@ describe("Configuration", function () {
 			},
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		conf.scanAssetsAudio().then((done.fail as () => void), (err: any) => {
+		conf.scanAssetsAudio(["audio"]).then((done.fail as () => void), (err: any) => {
 			expect(err).toEqual(new Error("not aac"));
 			done();
 		});
@@ -480,10 +480,9 @@ describe("Configuration", function () {
 			},
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-
 		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
 		expect(conf.getContent().assets["newDummy"]).toBe(undefined);
-		conf.scanAssetsScript();
+		conf.scanAssetsScript(["script"]);
 		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
 		expect(conf.getContent().assets["newDummy"].type).toBe("script");
 
@@ -504,7 +503,7 @@ describe("Configuration", function () {
 			},
 		});
 		conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		expect(function(){conf.scanAssetsScript()}).toThrow();
+		expect(function(){conf.scanAssetsScript(["script"])}).toThrow();
 	});
 
 	it("scan script assets invalid file name", function() {
@@ -525,7 +524,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsScript()}).toThrow();
+		expect(function(){conf.scanAssetsScript(["script"])}).toThrow();
 		var conf = new cnf.Configuration({ content: <any>{}, logger: nullLogger, basepath: process.cwd() });
 		gamejson = {
 			assets: {
@@ -543,7 +542,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsScript()}).toThrow();
+		expect(function(){conf.scanAssetsScript(["script"])}).toThrow();
 	});
 
 	it("scan text assets info", function () {
@@ -568,7 +567,7 @@ describe("Configuration", function () {
 
 		expect(conf.getContent().assets["dummyText"].type).toBe("text");
 		expect(conf.getContent().assets["newDummy"]).toBe(undefined);
-		conf.scanAssetsText();
+		conf.scanAssetsText(["text"]);
 		expect(conf.getContent().assets["dummyText"].type).toBe("text");
 		expect(conf.getContent().assets["newDummy"].type).toBe("text");
 
@@ -589,7 +588,7 @@ describe("Configuration", function () {
 			},
 		});
 		conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		expect(function(){conf.scanAssetsText()}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
 	});
 
 	it("scan text assets invalid file name", function() {
@@ -610,7 +609,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsText()}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
 		var conf = new cnf.Configuration({ content: <any>{}, logger: nullLogger, basepath: process.cwd() });
 		gamejson = {
 			assets: {
@@ -628,7 +627,7 @@ describe("Configuration", function () {
 				},
 			},
 		});
-		expect(function(){conf.scanAssetsText()}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
 	});
 
 	it("handles a path appeared multiple time", function () {
@@ -658,7 +657,7 @@ describe("Configuration", function () {
 			},
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
-		expect(function(){conf.scanAssetsText()}).toThrow();
+		expect(function(){conf.scanAssetsText(["text"])}).toThrow();
 	});
 
 	it("vacuums obsolete declarations", function () {
@@ -735,7 +734,12 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["deletedSe"]).not.toBe(undefined);
 		expect(conf.getContent().assets["deletedTxt"]).not.toBe(undefined);
 		expect(conf.getContent().assets["deletedScript"]).not.toBe(undefined);
-		conf.vacuum();
+		conf.vacuum({
+			audio: ["audio"],
+			image: ["image"],
+			script: ["script"],
+			text: ["text"]
+		});
 		expect(conf.getContent().assets["chara"]).not.toBe(undefined);
 		expect(conf.getContent().assets["se"]).not.toBe(undefined);
 		expect(conf.getContent().assets["txt"]).not.toBe(undefined);
@@ -744,6 +748,98 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["deletedSe"]).toBe(undefined);
 		expect(conf.getContent().assets["deletedTxt"]).toBe(undefined);
 		expect(conf.getContent().assets["deletedScript"]).toBe(undefined);
+	});
+
+	it("scan target any asset dirs", function (done) {
+		var gamejson: any = {
+			assets: {
+				"": {
+					"type": "text",
+					"path": "text/foo/dummy.txt",
+					"global": true,
+				},
+				"a2": {
+					"type": "txt",
+					"path": "text/foo/dummy.txt",
+				},
+				"a3": {
+					"type": "text",
+					"path": "text/foo/dummy.txt",
+				},
+			}
+		};
+		mockfs({
+			"game.json": JSON.stringify(gamejson),
+			"sound": {
+				"dummySound.ogg": DUMMY_OGG_DATA
+			},
+			"img": {
+				"dummyImg.png": DUMMY_1x1_PNG_DATA
+			},
+			"txt": {
+				"dummyTxt.txt": "Lorem ipsum dolor sit amet, consectetur...",
+			},
+			"code": {
+				"dummyCode.js": "var x = 1;",
+			}
+		});
+		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
+		conf.scanAssetsImage(["img"]);
+		expect(conf.getContent().assets["dummyImg"].type).toBe("image");
+		conf.scanAssetsScript(["code"]);
+		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
+		conf.scanAssetsText(["txt"]);
+		expect(conf.getContent().assets["dummyTxt"].type).toBe("text");
+		conf.scanAssetsAudio(["sound"]).then(() => {
+			expect(conf.getContent().assets["dummySound"].type).toBe("audio");
+			done();
+		}, done.fail);
+	});
+
+	it("scan vacuum without no target dirs", function (done) {
+		var gamejson: any = {
+			assets: {
+				"": {
+					"type": "text",
+					"path": "text/foo/dummy.txt",
+					"global": true,
+				},
+				"a2": {
+					"type": "image",
+					"path": "text/foo/dummy.txt",
+				},
+				"a3": {
+					"type": "text",
+					"path": "text/foo/dummy.txt",
+				},
+			}
+		};
+		mockfs({
+			"game.json": JSON.stringify(gamejson),
+			"sound": {
+				"dummySound.ogg": DUMMY_OGG_DATA
+			},
+			"img": {
+				"dummyImg.png": DUMMY_1x1_PNG_DATA
+			},
+			"txt": {
+				"dummyTxt.txt": "Lorem ipsum dolor sit amet, consectetur...",
+			},
+			"code": {
+				"dummyCode.js": "var x = 1;",
+			}
+		});
+		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
+		conf.scanAssetsImage(["img"]);
+		expect(conf.getContent().assets["dummyImg"].type).toBe("image");
+		conf.scanAssetsScript(["code"]);
+		expect(conf.getContent().assets["dummyCode"].type).toBe("script");
+		conf.scanAssetsText(["txt"]);
+		expect(conf.getContent().assets["dummyTxt"].type).toBe("text");
+		conf.scanAssetsAudio(["sound"]).then(() => {
+			expect(conf.getContent().assets["dummySound"].type).toBe("audio");
+			done();
+		}, done.fail);
 	});
 
 	it("scan globalScripts field based on node_modules/", function (done) {
@@ -1591,8 +1687,15 @@ describe("Configuration", function () {
 		});
 		var conf = new cnf.Configuration({ content: gamejson, logger: nullLogger, basepath: process.cwd() });
 
-		conf.scanAssets().then(() => {
-			conf.vacuum();
+		var assetScanDir = {
+			audio: ["audio"],
+			image: ["image"],
+			script: ["script"],
+			text: ["text"]
+		};
+
+		conf.scanAssets(assetScanDir, {}).then(() => {
+			conf.vacuum(assetScanDir);
 			expect(conf.getContent()).toEqual({
 				width: 320,
 				height: 320,

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -72,7 +72,7 @@ export class Configuration extends cmn.Configuration {
 			.then(() => {
 				this.scanAssetsImage(assetScanDir.image);
 				this.scanAssetsScript(assetScanDir.script);
-				this.scanAssetsText(assetScanDir.text);
+				this.scanAssetsText(assetScanDir.text, assetExtension.text);
 			})
 			.then(() => this.scanAssetsAudio(assetScanDir.audio));
 	}
@@ -96,9 +96,15 @@ export class Configuration extends cmn.Configuration {
 	}
 
 
-	scanAssetsText(textAssetScanDirs: string[]) {
+	scanAssetsText(textAssetScanDirs: string[], textAssetExtension: string[]) {
+		const textAssetExtensionRegExp = new RegExp(textAssetExtension.join("|"), "i");
+		const textAssetExtensionFilter = textAssetExtension.length === 0 ?
+			(p: string) => { return true; } :
+			(p: string) => {
+				return textAssetExtensionRegExp.test(p);
+			};
 		textAssetScanDirs.forEach((dirname) => {
-			this._scanAssetsText(dirname);
+			this._scanAssetsText(dirname, textAssetExtensionFilter);
 		});
 	}
 
@@ -253,7 +259,7 @@ export class Configuration extends cmn.Configuration {
 		this.scanAssetsXXX(path.join(this._basepath, scriptAssetDir + "/"), _isScriptAssetPath, "script");
 	}
 
-	_scanAssetsText(textAssetDir: string): void {
+	_scanAssetsText(textAssetDir: string, _isTextAssetPath: (p: string) => boolean): void {
 		this.scanAssetsXXX(path.join(this._basepath, textAssetDir + "/"), _isTextAssetPath, "text");
 	}
 

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -97,12 +97,7 @@ export class Configuration extends cmn.Configuration {
 
 
 	scanAssetsText(textAssetScanDirs: string[], textAssetExtension: string[]) {
-		const textAssetExtensionRegExp = new RegExp(textAssetExtension.join("|"), "i");
-		const textAssetExtensionFilter = textAssetExtension.length === 0 ?
-			(p: string) => { return true; } :
-			(p: string) => {
-				return textAssetExtensionRegExp.test(p);
-			};
+		const textAssetExtensionFilter = createTextAssetExtensionFilter(textAssetExtension);
 		textAssetScanDirs.forEach((dirname) => {
 			this._scanAssetsText(dirname, textAssetExtensionFilter);
 		});
@@ -341,14 +336,16 @@ export class Configuration extends cmn.Configuration {
 	}
 
 	// アセットのうちでファイルが消えていた物を処理するためのメソッド
-	vacuum(assetScanDir: AssetScanDir): void {
+	vacuum(assetScanDir: AssetScanDir, assetExtension: AssetExtension): void {
 		function audioPathMaker(f: string): string {
 			return path.join(path.dirname(f), path.basename(f, path.extname(f)));  // remove the extension
 		}
 		assetScanDir.audio.forEach((assetDir) => {this.vacuumXXX(assetDir + "/", "audio", _isAudioFilePath, audioPathMaker); });
 		assetScanDir.image.forEach((assetDir) => {this.vacuumXXX(assetDir + "/", "image", _isImageFilePath); });
 		assetScanDir.script.forEach((assetDir) => {this.vacuumXXX(assetDir + "/", "script", _isScriptAssetPath); });
-		assetScanDir.text.forEach((assetDir) => {this.vacuumXXX(assetDir + "/", "text", _isTextAssetPath); });
+
+		const textAssetExtensionFilter = createTextAssetExtensionFilter(assetExtension.text);
+		assetScanDir.text.forEach((assetDir) => {this.vacuumXXX(assetDir + "/", "text", textAssetExtensionFilter); });
 	}
 
 	/**
@@ -428,4 +425,14 @@ export class Configuration extends cmn.Configuration {
 				return Object.keys(lsResult.dependencies);
 			});
 	}
+}
+
+function createTextAssetExtensionFilter(assetExtension: string[]) {
+	const assetExtensionRegExp = new RegExp(assetExtension.join("|"), "i");
+	const assetExtensionFilter = assetExtension.length === 0 ?
+		(p: string) => { return true; } :
+		(p: string) => {
+			return assetExtensionRegExp.test(p);
+		};
+	return assetExtensionFilter;
 }

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -5,7 +5,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import { getAudioDuration } from "./getAudioDuration";
 import { imageSize } from "image-size";
 import { ISize } from "image-size/dist/types/interface";
-import { ScanAssetParameterObject, AssetScanDir, AssetExtension } from "./scan";
+import { ScanAssetParameterObject, AssetScanDirectoryTable, AssetExtension } from "./scan";
 
 export function _isImageFilePath(p: string): boolean { return /.*\.(png|gif|jpg|jpeg)$/i.test(p); }
 export function _isAudioFilePath(p: string): boolean { return /.*\.(ogg|aac|mp4)$/i.test(p); }
@@ -53,6 +53,11 @@ export interface ConfigurationParameterObject extends cmn.ConfigurationParameter
 	resolveAssetIdsFromPath?: boolean;
 }
 
+export interface ScanAssetsInformation {
+	scanDirectoryTable: AssetScanDirectoryTable;
+	extension: AssetExtension;
+}
+
 export class Configuration extends cmn.Configuration {
 	_basepath: string;
 	_noOmitPackagejson: boolean;
@@ -67,15 +72,15 @@ export class Configuration extends cmn.Configuration {
 		this._npm = param.debugNpm ? param.debugNpm : new cmn.PromisedNpm({ logger: param.logger });
 	}
 
-	scanAssets(assetScanDir: AssetScanDir, assetExtension: AssetExtension): Promise<void> {
+	scanAssets(info: ScanAssetsInformation): Promise<void> {
 		return Promise.resolve()
 
-			.then(() => this.scanAssetsAudio(assetScanDir.audio))
+			.then(() => this.scanAssetsAudio(info.scanDirectoryTable.audio))
 			.then(() => {
-				this.scanAssetsImage(assetScanDir.image);
-				this.scanAssetsScript(assetScanDir.script);
-				this.scanAssetsText(assetScanDir.text, assetExtension.text);
-			})
+				this.scanAssetsImage(info.scanDirectoryTable.image);
+				this.scanAssetsScript(info.scanDirectoryTable.script);
+				this.scanAssetsText(info.scanDirectoryTable.text, info.extension.text);
+			});
 		}
 
 	scanAssetsImage(imageAssetScanDirs: string[]) {
@@ -337,7 +342,7 @@ export class Configuration extends cmn.Configuration {
 	}
 
 	// アセットのうちでファイルが消えていた物を処理するためのメソッド
-	vacuum(assetScanDir: AssetScanDir, assetExtension: AssetExtension): void {
+	vacuum(assetScanDir: AssetScanDirectoryTable, assetExtension: AssetExtension): void {
 		function audioPathMaker(f: string): string {
 			return path.join(path.dirname(f), path.basename(f, path.extname(f)));  // remove the extension
 		}

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -69,13 +69,14 @@ export class Configuration extends cmn.Configuration {
 
 	scanAssets(assetScanDir: AssetScanDir, assetExtension: AssetExtension): Promise<void> {
 		return Promise.resolve()
+
+			.then(() => this.scanAssetsAudio(assetScanDir.audio))
 			.then(() => {
 				this.scanAssetsImage(assetScanDir.image);
 				this.scanAssetsScript(assetScanDir.script);
 				this.scanAssetsText(assetScanDir.text, assetExtension.text);
 			})
-			.then(() => this.scanAssetsAudio(assetScanDir.audio));
-	}
+		}
 
 	scanAssetsImage(imageAssetScanDirs: string[]) {
 		imageAssetScanDirs.forEach((dirname) => {
@@ -84,8 +85,8 @@ export class Configuration extends cmn.Configuration {
 	}
 
 	scanAssetsAudio(audioAssetScanDirs: string[]): Promise<void> {
-		return new Promise((resolve, reject) => {
-			Promise.all(audioAssetScanDirs.map((dirname) => this._scanAssetsAudio(dirname))).then(() => resolve()).catch(reject);
+		return new Promise<void>((resolve, reject) => {
+			Promise.all(audioAssetScanDirs.map((dirname) => this._scanAssetsAudio(dirname))).then(() => resolve(), reject);
 		});
 	}
 

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,13 +16,11 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
-	.option("--imageAssetDir <dir>", "specify ImageAsset directory", (val: any, ret: any) => {
-		ret = ret || [];
-		ret.push(val);
-		return ret; })
-	.option("--audioAssetDir <dir>, specify AudioAsset directory")
-	.option("--scriptAssetDir <dir>, specify ScriptAsset directory")
-	.option("--textAssetDir <dir>, specify TextAsset directory")
+	.option("--imageAssetDir <dir>", "specify ImageAsset directory", commanderArgsCoordinater)
+	.option("--audioAssetDir <dir>", "specify AudioAsset directory", commanderArgsCoordinater)
+	.option("--scriptAssetDir <dir>", "specify ScriptAsset directory", commanderArgsCoordinater)
+	.option("--textAssetDir <dir>", "specify TextAsset directory", commanderArgsCoordinater)
+	.option("--textAssetExtension <extension>", "specify TextAsset extension", commanderArgsCoordinater)
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
 		var assetScanDir = {
@@ -31,9 +29,16 @@ commander
 			script: opts.scriptAssetDir,
 			text: opts.textAssetDir
 		};
+		var assetExtension = {
+			text: opts.textAssetExtension
+		};
 		promiseScanAsset({
-			target: target, cwd: opts.cwd, logger: logger,
-			resolveAssetIdsFromPath: opts.usePathAssetId, assetScanDir: assetScanDir
+			target: target,
+			cwd: opts.cwd,
+			logger: logger,
+			resolveAssetIdsFromPath: opts.usePathAssetId,
+			assetScanDir: assetScanDir,
+			assetExtension: assetExtension
 		})
 			.catch((err: any) => {
 				logger.error(err);
@@ -69,10 +74,14 @@ commander
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
-
 	if (argv.length < 3
 		|| !argv[2].match(/^(asset|globalScripts)$/)) {
 		commander.help();
 	}
+}
 
+function commanderArgsCoordinater (val: any, ret: any) {
+	ret = ret || [];
+	ret.push(val);
+	return ret;
 }

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -19,7 +19,7 @@ commander
 	.option("--imageAssetDir <dir>", "specify ImageAsset directory", (val: any, ret: any) => {
 		ret = ret || [];
 		ret.push(val);
-		return ret;})
+		return ret; })
 	.option("--audioAssetDir <dir>, specify AudioAsset directory")
 	.option("--scriptAssetDir <dir>, specify ScriptAsset directory")
 	.option("--textAssetDir <dir>, specify TextAsset directory")
@@ -29,9 +29,12 @@ commander
 			audio: opts.audioAssetDir,
 			image: opts.imageAssetDir,
 			script: opts.scriptAssetDir,
-			text: opts.textAssetDir,
-		}
-		promiseScanAsset({ target: target, cwd: opts.cwd, logger: logger, resolveAssetIdsFromPath: opts.usePathAssetId, assetScanDir: assetScanDir })
+			text: opts.textAssetDir
+		};
+		promiseScanAsset({
+			target: target, cwd: opts.cwd, logger: logger,
+			resolveAssetIdsFromPath: opts.usePathAssetId, assetScanDir: assetScanDir
+		})
 			.catch((err: any) => {
 				logger.error(err);
 				process.exit(1);

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -23,7 +23,7 @@ commander
 	.option("--textAssetExtension <extension>", "specify TextAsset extension", commanderArgsCoordinater)
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
-		var assetScanDir = {
+		var assetScanDirectoryTable = {
 			audio: opts.audioAssetDir,
 			image: opts.imageAssetDir,
 			script: opts.scriptAssetDir,
@@ -37,7 +37,7 @@ commander
 			cwd: opts.cwd,
 			logger: logger,
 			resolveAssetIdsFromPath: opts.usePathAssetId,
-			assetScanDir: assetScanDir,
+			assetScanDirectoryTable: assetScanDirectoryTable,
 			assetExtension: assetExtension
 		})
 			.catch((err: any) => {

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,9 +16,22 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
+	.option("--imageAssetDir <dir>", "specify ImageAsset directory", (val: any, ret: any) => {
+		ret = ret || [];
+		ret.push(val);
+		return ret;})
+	.option("--audioAssetDir <dir>, specify AudioAsset directory")
+	.option("--scriptAssetDir <dir>, specify ScriptAsset directory")
+	.option("--textAssetDir <dir>, specify TextAsset directory")
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
-		promiseScanAsset({ target: target, cwd: opts.cwd, logger: logger, resolveAssetIdsFromPath: opts.usePathAssetId })
+		var assetScanDir = {
+			audio: opts.audioAssetDir,
+			image: opts.imageAssetDir,
+			script: opts.scriptAssetDir,
+			text: opts.textAssetDir,
+		}
+		promiseScanAsset({ target: target, cwd: opts.cwd, logger: logger, resolveAssetIdsFromPath: opts.usePathAssetId, assetScanDir: assetScanDir })
 			.catch((err: any) => {
 				logger.error(err);
 				process.exit(1);

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -74,6 +74,7 @@ export interface ScanAssetParameterObject {
 
 	/**
 	 * 各アセットとして扱う拡張子。
+	 * 省略された場合、 `[]` 。
 	 */
 	assetExtension?: AssetExtension;
 }
@@ -120,7 +121,7 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 					conf.scanAssetsScript(param.assetScanDir.script);
 					break;
 				case "text":
-					conf.scanAssetsText(param.assetScanDir.text);
+					conf.scanAssetsText(param.assetScanDir.text, param.assetExtension.text);
 					break;
 				case "all":
 					return conf.scanAssets(param.assetScanDir, param.assetExtension).then(resolve, reject);

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -1,30 +1,30 @@
 import * as cmn from "@akashic/akashic-cli-commons";
 import { Configuration } from "./Configuration";
 
-export interface assetScanDir  {
+export interface AssetScanDir  {
 	/**
 	 * AudioAssetを取得するパス。
 	 * 省略された場合、 `["audio"]` 。
 	 */
-	audio?: string[],
+	audio?: string[];
 
 	/**
 	 * ImageAssetを取得するパス。
 	 * 省略された場合、 `["image"]` 。
 	 */
-	image?: string[],
+	image?: string[];
 
 	/**
 	 * ScriptAssetを取得するパス。
 	 * 省略された場合、 `["script"]` 。
 	 */
-	script?: string[],
+	script?: string[];
 
 	/**
 	 * TextAssetを取得するパス。
 	 * 省略された場合、 `["text"]` 。
 	 */
-	text?: string[]
+	text?: string[];
 }
 
 export interface AssetExtension {
@@ -32,7 +32,7 @@ export interface AssetExtension {
 	 * TextAssetの拡張子。
 	 * 省略された場合、全て利用できることを表す `[]` 。
 	 */
-	text?: string[]
+	text?: string[];
 }
 
 export interface ScanAssetParameterObject {
@@ -70,7 +70,7 @@ export interface ScanAssetParameterObject {
 	/**
 	 * 各アセットを取得するパス。
 	 */
-	assetScanDir?: assetScanDir;
+	assetScanDir?: AssetScanDir;
 
 	/**
 	 * 各アセットとして扱う拡張子。
@@ -97,7 +97,6 @@ export function _completeScanAssetParameterObject(param: ScanAssetParameterObjec
 export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void> {
 	_completeScanAssetParameterObject(param);
 
-	console.log("param", param.assetScanDir);
 	var restoreDirectory = cmn.Util.chdir(param.cwd);
 	return Promise.resolve()
 		.then(() => cmn.ConfigurationFile.read("./game.json", param.logger))
@@ -109,7 +108,7 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 				noOmitPackagejson: param.noOmitPackagejson,
 				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath
 			});
-			conf.vacuum();
+			conf.vacuum(param.assetScanDir);
 			return new Promise<void>((resolve, reject) => {
 				switch (param.target) {
 				case "image":

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -1,7 +1,7 @@
 import * as cmn from "@akashic/akashic-cli-commons";
 import { Configuration } from "./Configuration";
 
-export interface AssetScanDir  {
+export interface AssetScanDirectoryTable  {
 	/**
 	 * AudioAssetを取得するパス。
 	 * 省略された場合、 `["audio"]` 。
@@ -70,7 +70,7 @@ export interface ScanAssetParameterObject {
 	/**
 	 * 各アセットを取得するパス。
 	 */
-	assetScanDir?: AssetScanDir;
+	assetScanDirectoryTable?: AssetScanDirectoryTable;
 
 	/**
 	 * 各アセットとして扱う拡張子。
@@ -85,11 +85,11 @@ export function _completeScanAssetParameterObject(param: ScanAssetParameterObjec
 	param.logger = param.logger || new cmn.ConsoleLogger();
 
 	param.resolveAssetIdsFromPath = !!param.resolveAssetIdsFromPath;
-	param.assetScanDir = param.assetScanDir || {};
-	param.assetScanDir.audio = param.assetScanDir.audio || ["audio"];
-	param.assetScanDir.image = param.assetScanDir.image || ["image"];
-	param.assetScanDir.script = param.assetScanDir.script || ["script"];
-	param.assetScanDir.text = param.assetScanDir.text || ["text"];
+	param.assetScanDirectoryTable = param.assetScanDirectoryTable || {};
+	param.assetScanDirectoryTable.audio = param.assetScanDirectoryTable.audio || ["audio"];
+	param.assetScanDirectoryTable.image = param.assetScanDirectoryTable.image || ["image"];
+	param.assetScanDirectoryTable.script = param.assetScanDirectoryTable.script || ["script"];
+	param.assetScanDirectoryTable.text = param.assetScanDirectoryTable.text || ["text"];
 
 	param.assetExtension = param.assetExtension || {};
 	param.assetExtension.text = param.assetExtension.text || [];
@@ -109,22 +109,25 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 				noOmitPackagejson: param.noOmitPackagejson,
 				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath
 			});
-			conf.vacuum(param.assetScanDir, param.assetExtension);
+			conf.vacuum(param.assetScanDirectoryTable, param.assetExtension);
 			return new Promise<void>((resolve, reject) => {
 				switch (param.target) {
 				case "image":
-					conf.scanAssetsImage(param.assetScanDir.image);
+					conf.scanAssetsImage(param.assetScanDirectoryTable.image);
 					break;
 				case "audio":
-					return conf.scanAssetsAudio(param.assetScanDir.audio).then(resolve, reject);
+					return conf.scanAssetsAudio(param.assetScanDirectoryTable.audio).then(resolve, reject);
 				case "script":
-					conf.scanAssetsScript(param.assetScanDir.script);
+					conf.scanAssetsScript(param.assetScanDirectoryTable.script);
 					break;
 				case "text":
-					conf.scanAssetsText(param.assetScanDir.text, param.assetExtension.text);
+					conf.scanAssetsText(param.assetScanDirectoryTable.text, param.assetExtension.text);
 					break;
 				case "all":
-					return conf.scanAssets(param.assetScanDir, param.assetExtension).then(resolve, reject);
+					return conf.scanAssets({
+						scanDirectoryTable: param.assetScanDirectoryTable,
+						extension: param.assetExtension
+					}).then(resolve, reject);
 				default:
 					return reject("scan asset " + param.target + ": unknown target " + param.target);
 				}

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -109,7 +109,7 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 				noOmitPackagejson: param.noOmitPackagejson,
 				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath
 			});
-			conf.vacuum(param.assetScanDir);
+			conf.vacuum(param.assetScanDir, param.assetExtension);
 			return new Promise<void>((resolve, reject) => {
 				switch (param.target) {
 				case "image":


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

akashic scan assetコマンドに、スキャン対象のアセットディレクトリの指定機能、スキャン対象ファイル拡張子の指定機能を追加します。
従来と同じコマンドで呼び出した場合、scanの挙動に変更はありません。

#### アセットディレクトリの指定
`---XXXAssetDir fooDir` オプションを指定した場合、そのアセットは指定したディレクトリ（ `fooDir` ）以下のファイルのみチェックします。オプションを指定しなかった場合、従来の image/audio/script/text ディレクトリが指定されたものとして扱います。
複数のディレクトリを対象にしたい場合、 `---XXXAssetDir fooDir ---XXXAssetDir barDir` と列挙することができます。

`---XXXAssetDir` で指定されなかったディレクトリは、アセットファイルの実体の有無に関わらず、game.jsonの記述は変更されません。

#### スキャン対象ファイル拡張子
`---textAssetExtension json txt` オプションを指定した場合、その拡張子（ `txt` ）のファイルだけをテキストアセットとして扱います。それ以外の拡張子のファイルはアセットとしてgame.jsonに書き込まれず、既にあるファイルはgame.jsonから削除されます。


## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

### その他
`--XXXassetDir` オプションは指定されなかったディレクトリのアセットについての記述を更新しませんが、 `--textAssetExtension` オプションは指定されなかった拡張子のアセット記述を削除します。ユーザにとって、これが直感的でない可能性があります。
