### PR TITLE
akashic-cli-serveのプロセス終了時にサーバーとソケットを閉じる処理を追加

### DIFF
--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -159,6 +159,16 @@ export function run(argv: any): void {
 	runnerStore.onRunnerPause.add(arg => { io.emit("runnerPause", arg); });
 	runnerStore.onRunnerResume.add(arg => { io.emit("runnerResume", arg); });
 
+	const close = () => {
+		httpServer.close();
+		io.close();
+		console.log(chalk.green(`Stop hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
+		process.exit(0);
+	};
+
+	process.on("SIGINT", close);
+	process.on("SIGTERM", close);
+
 	httpServer.listen(serverGlobalConfig.port, () => {
 		if (serverGlobalConfig.port < 1024) {
 			getSystemLogger().warn("Akashic Serve is a development server which is not appropriate for public release. " +

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -160,10 +160,16 @@ export function run(argv: any): void {
 	runnerStore.onRunnerResume.add(arg => { io.emit("runnerResume", arg); });
 
 	const close = () => {
-		httpServer.close();
-		io.close();
-		console.log(chalk.green(`Stop hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
-		process.exit(0);
+		httpServer.close((err?: Error) => {
+			if (err) {
+				console.log(chalk.red(`Failed to stop server(host: ${serverGlobalConfig.hostname}, port:${serverGlobalConfig.port}).`));
+				process.exit(1);
+			}
+			io.close(() => {
+				console.log(chalk.green(`Stop hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
+				process.exit(0);
+			});
+		});
 	};
 
 	process.on("SIGINT", close);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -162,7 +162,9 @@ export function run(argv: any): void {
 	const close = () => {
 		httpServer.close((err?: Error) => {
 			if (err) {
-				console.log(chalk.red(`Failed to stop server(host: ${serverGlobalConfig.hostname}, port:${serverGlobalConfig.port}).`));
+				console.error(
+					chalk.red(`Failed to stop server(host: ${serverGlobalConfig.hostname}, port: ${serverGlobalConfig.port}). ${err.message}`)
+				);
 				process.exit(1);
 			}
 			io.close(() => {


### PR DESCRIPTION
### 概要
掲題の通りです。

### やったこと
* `SIGINT`と`SIGTERM`を受け取った時にサーバーとソケットを閉じる処理をイベントハンドラに登録