### PR TITLE
Add a command to rescan Asset IDs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-script:
-- npm install
-- npm test
 language: node_js
+
 node_js:
-- 8
-- 10
+  - 8
+  - 10
+
+install: travis_wait 20 npm install # TODO: 一時的にタイムアウトを伸ばす
+
+script:
+  - npm test

--- a/packages/akashic-cli-scan/package-lock.json
+++ b/packages/akashic-cli-scan/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-cli-scan",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1609,7 +1609,7 @@ describe("Configuration", function () {
 		}, done.fail);
 	});
 
-	it("can rescan Asset IDs", async () => {
+	it("can update already defined Asset IDs", async () => {
 		const gamejson = {
 			width: 1,
 			height: 1,
@@ -1661,7 +1661,7 @@ describe("Configuration", function () {
 			content: gamejson,
 			logger: nullLogger,
 			basepath: process.cwd(),
-			rescanAssetIds: false,
+			forceUpdateAssetIds: false,
 			resolveAssetIdsFromPath: true
 		});
 
@@ -1671,7 +1671,7 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["txt"]).not.toBe(undefined);
 		expect(conf.getContent().assets["script"]).not.toBe(undefined);
 
-		conf._rescanAssetIds = true;
+		conf._forceUpdateAssetIds = true;
 		await conf.scanAssets();
 		expect(conf.getContent().assets["image/foo/dummy"]).not.toBe(undefined);
 		expect(conf.getContent().assets["audio/some/se"]).not.toBe(undefined);

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1729,7 +1729,7 @@ describe("Configuration", function () {
 		}, done.fail);
 	});
 
-	it("can update already defined Asset IDs", async () => {
+	it("can update previously defined Asset IDs", async () => {
 		const gamejson = {
 			width: 1,
 			height: 1,
@@ -1785,21 +1785,34 @@ describe("Configuration", function () {
 			resolveAssetIdsFromPath: true
 		});
 
-		await conf.scanAssets();
+		const scanDirectoryTable = {
+			audio: ["audio"],
+			image: ["image"],
+			script: ["script"],
+			text: ["text"]
+		};
+		const extension = {
+			audio: ["ogg"],
+			image: ["png"],
+			script: ["js"],
+			text: ["txt"]
+		};
+
+		await conf.scanAssets({scanDirectoryTable, extension});
 		expect(conf.getContent().assets["chara"]).not.toBe(undefined);
 		expect(conf.getContent().assets["se"]).not.toBe(undefined);
 		expect(conf.getContent().assets["txt"]).not.toBe(undefined);
 		expect(conf.getContent().assets["script"]).not.toBe(undefined);
 
 		conf._forceUpdateAssetIds = true;
-		await conf.scanAssets();
+		await conf.scanAssets({scanDirectoryTable, extension});
 		expect(conf.getContent().assets["image/foo/dummy"]).not.toBe(undefined);
 		expect(conf.getContent().assets["audio/some/se"]).not.toBe(undefined);
 		expect(conf.getContent().assets["text/foo/textdata"]).not.toBe(undefined);
 		expect(conf.getContent().assets["script/foo/script"]).not.toBe(undefined);
 
 		conf._resolveAssetIdsFromPath = false;
-		await conf.scanAssets();
+		await conf.scanAssets({scanDirectoryTable, extension});
 		expect(conf.getContent().assets["dummy"]).not.toBe(undefined);
 		expect(conf.getContent().assets["se"]).not.toBe(undefined);
 		expect(conf.getContent().assets["textdata"]).not.toBe(undefined);

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1608,5 +1608,82 @@ describe("Configuration", function () {
 			done();
 		}, done.fail);
 	});
+
+	it("can rescan Asset IDs", async () => {
+		const gamejson = {
+			width: 1,
+			height: 1,
+			assets: {
+				"chara": {
+					"type": "image",
+					"path": "image/foo/dummy.png",
+					"width": 1,
+					"height": 1
+				},
+				"se": {
+					"type": "audio",
+					"path": "audio/some/se"
+				},
+				"txt": {
+					"type": "text",
+					"path": "text/foo/textdata.txt"
+				},
+				"script": {
+					"type": "script",
+					"path": "script/foo/script.js"
+				}
+			}
+		};
+		mockfs({
+			"game.json": JSON.stringify(gamejson),
+			"image": {
+				"foo": {
+					"dummy.png": DUMMY_1x1_PNG_DATA
+				}
+			},
+			"audio": {
+				"some": {
+					"se.ogg": DUMMY_OGG_DATA
+				}
+			},
+			"text": {
+				"foo": {
+					"textdata.txt": "Lorem ipsum dolor sit amet, consectetur..."
+				}
+			},
+			"script": {
+				"foo": {
+					"script.js": "var x = 1;"
+				}
+			}
+		});
+		const conf = new cnf.Configuration({
+			content: gamejson,
+			logger: nullLogger,
+			basepath: process.cwd(),
+			rescanAssetIds: false,
+			resolveAssetIdsFromPath: true
+		});
+
+		await conf.scanAssets();
+		expect(conf.getContent().assets["chara"]).not.toBe(undefined);
+		expect(conf.getContent().assets["se"]).not.toBe(undefined);
+		expect(conf.getContent().assets["txt"]).not.toBe(undefined);
+		expect(conf.getContent().assets["script"]).not.toBe(undefined);
+
+		conf._rescanAssetIds = true;
+		await conf.scanAssets();
+		expect(conf.getContent().assets["image/foo/dummy"]).not.toBe(undefined);
+		expect(conf.getContent().assets["audio/some/se"]).not.toBe(undefined);
+		expect(conf.getContent().assets["text/foo/textdata"]).not.toBe(undefined);
+		expect(conf.getContent().assets["script/foo/script"]).not.toBe(undefined);
+
+		conf._resolveAssetIdsFromPath = false;
+		await conf.scanAssets();
+		expect(conf.getContent().assets["dummy"]).not.toBe(undefined);
+		expect(conf.getContent().assets["se"]).not.toBe(undefined);
+		expect(conf.getContent().assets["textdata"]).not.toBe(undefined);
+		expect(conf.getContent().assets["script"]).not.toBe(undefined);
+	});
 });
 

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -432,7 +432,7 @@ export class Configuration extends cmn.Configuration {
 		if (from === to) {
 			return;
 		}
-		this._logger.info(`Detected change of the Aset ID from ${from} to ${to}`);
+		this._logger.info(`Detected change of the Asset ID from ${from} to ${to}`);
 		this._content.assets[to] = this._content.assets[from];
 		delete this._content.assets[from];
 	}

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -106,7 +106,8 @@ export class Configuration extends cmn.Configuration {
 							newAssetId = basename;
 							_assertAssetFilenameValid(newAssetId);
 						}
-						this._moveAssetDeclaration(aid, newAssetId);
+						if (aid !== newAssetId)
+							this._moveAssetDeclaration(aid, newAssetId);
 					}
 
 					const decl = assets[newAssetId];
@@ -171,7 +172,8 @@ export class Configuration extends cmn.Configuration {
 								} else {
 									newAssetId = basename;
 								}
-								this._moveAssetDeclaration(aid, newAssetId);
+								if (aid !== newAssetId)
+									this._moveAssetDeclaration(aid, newAssetId);
 							}
 							if (!this._resolveAssetIdsFromPath) {
 								_assertAssetFilenameValid(newAssetId);
@@ -232,7 +234,8 @@ export class Configuration extends cmn.Configuration {
 						} else {
 							newAssetId = basename;
 						}
-						this._moveAssetDeclaration(aid, newAssetId);
+						if (aid !== newAssetId)
+							this._moveAssetDeclaration(aid, newAssetId);
 					}
 					if (!this._resolveAssetIdsFromPath)
 						_assertAssetFilenameValid(newAssetId);
@@ -430,6 +433,7 @@ export class Configuration extends cmn.Configuration {
 
 	private _moveAssetDeclaration(from: string, to: string): void {
 		if (from === to) {
+			this._logger.warn(`Cannot move declaration of the same Asset ID (${from})`);
 			return;
 		}
 		this._logger.info(`Detected change of the Asset ID from ${from} to ${to}`);

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -106,7 +106,7 @@ export class Configuration extends cmn.Configuration {
 							newAssetId = basename;
 							_assertAssetFilenameValid(newAssetId);
 						}
-						this._swapAssetId(aid, newAssetId);
+						this._moveAssetDeclaration(aid, newAssetId);
 					}
 
 					const decl = assets[newAssetId];
@@ -171,7 +171,7 @@ export class Configuration extends cmn.Configuration {
 								} else {
 									newAssetId = basename;
 								}
-								this._swapAssetId(aid, newAssetId);
+								this._moveAssetDeclaration(aid, newAssetId);
 							}
 							if (!this._resolveAssetIdsFromPath) {
 								_assertAssetFilenameValid(newAssetId);
@@ -232,7 +232,7 @@ export class Configuration extends cmn.Configuration {
 						} else {
 							newAssetId = basename;
 						}
-						this._swapAssetId(aid, newAssetId);
+						this._moveAssetDeclaration(aid, newAssetId);
 					}
 					if (!this._resolveAssetIdsFromPath)
 						_assertAssetFilenameValid(newAssetId);
@@ -428,7 +428,7 @@ export class Configuration extends cmn.Configuration {
 			});
 	}
 
-	private _swapAssetId(from: string, to: string): void {
+	private _moveAssetDeclaration(from: string, to: string): void {
 		if (from === to) {
 			return;
 		}

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -50,14 +50,14 @@ export interface ConfigurationParameterObject extends cmn.ConfigurationParameter
 	noOmitPackagejson?: boolean;
 	debugNpm?: cmn.PromisedNpm;
 	resolveAssetIdsFromPath?: boolean;
-	rescanAssetIds?: boolean;
+	forceUpdateAssetIds?: boolean;
 }
 
 export class Configuration extends cmn.Configuration {
 	_basepath: string;
 	_noOmitPackagejson: boolean;
 	_resolveAssetIdsFromPath: boolean;
-	_rescanAssetIds: boolean;
+	_forceUpdateAssetIds: boolean;
 	_npm: cmn.PromisedNpm;
 
 	constructor(param: ConfigurationParameterObject) {
@@ -65,7 +65,7 @@ export class Configuration extends cmn.Configuration {
 		this._basepath = param.basepath;
 		this._noOmitPackagejson = param.noOmitPackagejson;
 		this._resolveAssetIdsFromPath = param.resolveAssetIdsFromPath;
-		this._rescanAssetIds = param.rescanAssetIds;
+		this._forceUpdateAssetIds = param.forceUpdateAssetIds;
 		this._npm = param.debugNpm ? param.debugNpm : new cmn.PromisedNpm({ logger: param.logger });
 	}
 
@@ -98,7 +98,7 @@ export class Configuration extends cmn.Configuration {
 			if (aidSet && aidSet.length > 0) {
 				aidSet.forEach((aid: string) => {
 					let newAssetId = aid;
-					if (this._rescanAssetIds) {
+					if (this._forceUpdateAssetIds) {
 						const basename = path.basename(f, path.extname(f));
 						if (this._resolveAssetIdsFromPath) {
 							newAssetId = cmn.Util.makeUnixPath(path.join("image", path.dirname(f), basename));
@@ -164,7 +164,7 @@ export class Configuration extends cmn.Configuration {
 						aidSet.forEach((aid: string) => {
 							const f = durationMap[current].path;
 							let newAssetId = aid;
-							if (this._rescanAssetIds) {
+							if (this._forceUpdateAssetIds) {
 								const basename = path.basename(f);
 								if (this._resolveAssetIdsFromPath) {
 									newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(f), basename));
@@ -225,7 +225,7 @@ export class Configuration extends cmn.Configuration {
 			if (aidSet && aidSet.length > 0) {
 				aidSet.forEach((aid: string) => {
 					let newAssetId = aid;
-					if (this._rescanAssetIds) {
+					if (this._forceUpdateAssetIds) {
 						const basename = path.basename(f, path.extname(f));
 						if (this._resolveAssetIdsFromPath) {
 							newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,7 +16,7 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
-	.option("--rescan-asset-id", "Rescan only Asset IDs")
+	.option("--rescan-asset-id", "Rescan Asset IDs")
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
 		promiseScanAsset({

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,7 +16,7 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
-	.option("--update-asset-id", "Update previously defined Asset IDs")
+	.option("--update-asset-id", "Update previously registered Asset IDs")
 	.option("--imageAssetDir <dir>", "specify ImageAsset directory", commanderArgsCoordinater)
 	.option("--audioAssetDir <dir>", "specify AudioAsset directory", commanderArgsCoordinater)
 	.option("--scriptAssetDir <dir>", "specify ScriptAsset directory", commanderArgsCoordinater)

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,9 +16,16 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
+	.option("--rescan-asset-id", "Rescan only Asset IDs")
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
-		promiseScanAsset({ target: target, cwd: opts.cwd, logger: logger, resolveAssetIdsFromPath: opts.usePathAssetId })
+		promiseScanAsset({
+			target: target,
+			cwd: opts.cwd,
+			logger: logger,
+			resolveAssetIdsFromPath: opts.usePathAssetId,
+			rescanAssetIds: opts.rescanAssetId
+		})
 			.catch((err: any) => {
 				logger.error(err);
 				process.exit(1);

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -16,7 +16,7 @@ commander
 	.option("-C, --cwd <dir>", "The directory incluedes game.json")
 	.option("-q, --quiet", "Suppress output")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
-	.option("--rescan-asset-id", "Rescan Asset IDs")
+	.option("--update-asset-id", "Update previously defined Asset IDs")
 	.action((target: string, opts: any = {}) => {
 		var logger = new ConsoleLogger({ quiet: opts.quiet });
 		promiseScanAsset({
@@ -24,7 +24,7 @@ commander
 			cwd: opts.cwd,
 			logger: logger,
 			resolveAssetIdsFromPath: opts.usePathAssetId,
-			rescanAssetIds: opts.rescanAssetId
+			forceUpdateAssetIds: opts.updateAssetId
 		})
 			.catch((err: any) => {
 				logger.error(err);

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -34,10 +34,10 @@ export interface ScanAssetParameterObject {
 	resolveAssetIdsFromPath?: boolean;
 
 	/**
-	 * アセットIDを再度スキャンし直すかどうか。
+	 * アセットIDを強制的にスキャンし直すかどうか。
 	 * 省略された場合、 `false` 。
 	 */
-	rescanAssetIds?: boolean;
+	forceUpdateAssetIds?: boolean;
 }
 
 export function _completeScanAssetParameterObject(param: ScanAssetParameterObject): void {
@@ -45,7 +45,7 @@ export function _completeScanAssetParameterObject(param: ScanAssetParameterObjec
 	param.cwd = param.cwd || process.cwd();
 	param.logger = param.logger || new cmn.ConsoleLogger();
 	param.resolveAssetIdsFromPath = !!param.resolveAssetIdsFromPath;
-	param.rescanAssetIds = !!param.rescanAssetIds;
+	param.forceUpdateAssetIds = !!param.forceUpdateAssetIds;
 }
 
 export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void> {
@@ -60,7 +60,7 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 				basepath: ".",
 				noOmitPackagejson: param.noOmitPackagejson,
 				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath,
-				rescanAssetIds: param.rescanAssetIds
+				forceUpdateAssetIds: param.forceUpdateAssetIds
 			});
 			conf.vacuum();
 			return new Promise<void>((resolve, reject) => {
@@ -140,7 +140,7 @@ export interface ScanNodeModulesParameterObject {
 	 * アセットIDを再度スキャンし直すかどうか。
 	 * 省略された場合、 `false` 。
 	 */
-	rescanAssetIds?: boolean;
+	forceUpdateAssetIds?: boolean;
 }
 
 export function _completeScanNodeModulesParameterObject(param: ScanNodeModulesParameterObject): void {
@@ -148,7 +148,7 @@ export function _completeScanNodeModulesParameterObject(param: ScanNodeModulesPa
 	param.logger = param.logger || new cmn.ConsoleLogger();
 	param.fromEntryPoint = param.fromEntryPoint || false;
 	param.resolveAssetIdsFromPath = !!param.resolveAssetIdsFromPath;
-	param.rescanAssetIds = !!param.rescanAssetIds;
+	param.forceUpdateAssetIds = !!param.forceUpdateAssetIds;
 }
 
 export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): Promise<void> {
@@ -164,7 +164,7 @@ export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): P
 				debugNpm: param.debugNpm,
 				noOmitPackagejson: !!param.noOmitPackagejson,
 				resolveAssetIdsFromPath: !!param.resolveAssetIdsFromPath,
-				rescanAssetIds: !!param.rescanAssetIds
+				forceUpdateAssetIds: !!param.forceUpdateAssetIds
 			});
 			return Promise.resolve()
 				.then(() => (param.fromEntryPoint ? conf.scanGlobalScriptsFromEntryPoint() : conf.scanGlobalScripts()))

--- a/packages/akashic-cli-scan/src/scan.ts
+++ b/packages/akashic-cli-scan/src/scan.ts
@@ -32,6 +32,12 @@ export interface ScanAssetParameterObject {
 	 * 省略された場合、 `false` 。
 	 */
 	resolveAssetIdsFromPath?: boolean;
+
+	/**
+	 * アセットIDを再度スキャンし直すかどうか。
+	 * 省略された場合、 `false` 。
+	 */
+	rescanAssetIds?: boolean;
 }
 
 export function _completeScanAssetParameterObject(param: ScanAssetParameterObject): void {
@@ -39,6 +45,7 @@ export function _completeScanAssetParameterObject(param: ScanAssetParameterObjec
 	param.cwd = param.cwd || process.cwd();
 	param.logger = param.logger || new cmn.ConsoleLogger();
 	param.resolveAssetIdsFromPath = !!param.resolveAssetIdsFromPath;
+	param.rescanAssetIds = !!param.rescanAssetIds;
 }
 
 export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void> {
@@ -52,7 +59,8 @@ export function promiseScanAsset(param: ScanAssetParameterObject): Promise<void>
 				logger: param.logger,
 				basepath: ".",
 				noOmitPackagejson: param.noOmitPackagejson,
-				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath
+				resolveAssetIdsFromPath: param.resolveAssetIdsFromPath,
+				rescanAssetIds: param.rescanAssetIds
 			});
 			conf.vacuum();
 			return new Promise<void>((resolve, reject) => {
@@ -127,6 +135,12 @@ export interface ScanNodeModulesParameterObject {
 	 * 偽である場合、ファイル名から拡張子を除去した文字列がアセットIDとして利用される。
 	 */
 	resolveAssetIdsFromPath?: boolean;
+
+	/**
+	 * アセットIDを再度スキャンし直すかどうか。
+	 * 省略された場合、 `false` 。
+	 */
+	rescanAssetIds?: boolean;
 }
 
 export function _completeScanNodeModulesParameterObject(param: ScanNodeModulesParameterObject): void {
@@ -134,6 +148,7 @@ export function _completeScanNodeModulesParameterObject(param: ScanNodeModulesPa
 	param.logger = param.logger || new cmn.ConsoleLogger();
 	param.fromEntryPoint = param.fromEntryPoint || false;
 	param.resolveAssetIdsFromPath = !!param.resolveAssetIdsFromPath;
+	param.rescanAssetIds = !!param.rescanAssetIds;
 }
 
 export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): Promise<void> {
@@ -148,7 +163,8 @@ export function promiseScanNodeModules(param: ScanNodeModulesParameterObject): P
 				basepath: "." ,
 				debugNpm: param.debugNpm,
 				noOmitPackagejson: !!param.noOmitPackagejson,
-				resolveAssetIdsFromPath: !!param.resolveAssetIdsFromPath
+				resolveAssetIdsFromPath: !!param.resolveAssetIdsFromPath,
+				rescanAssetIds: !!param.rescanAssetIds
 			});
 			return Promise.resolve()
 				.then(() => (param.fromEntryPoint ? conf.scanGlobalScriptsFromEntryPoint() : conf.scanGlobalScripts()))


### PR DESCRIPTION
## このPullRequestが解決する内容
* akashic-cli にアセットIDを再スキャン (すでにスキャン済みのアセットのアセットIDを再解決) するオプション ~`--rescan-asset-id`~ `update-asset-id` を追加します。
* 別件で TravisCI の timeout を 20m に伸ばす対応 (206825d) を追加します。
