### PR TITLE
akashic-cli-serveでplaylogを予め読み込んだplayを作成できるようにした

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -55,11 +55,10 @@ export class Operator {
 		const query = queryString.parse(window.location.search);
 		let play: PlayEntity = null;
 		if (query.playId != null) {
-			const target = store.playStore.plays[query.playId as string];
-			if (!target) {
+			play = store.playStore.plays[query.playId as string];
+			if (!play) {
 				throw new Error(`play(id: ${query.playId}) is not found.`);
 			}
-			play = target;
 		} else if (contentLocator) {
 			play = await this._createServerLoop(contentLocator);
 		} else {
@@ -149,9 +148,6 @@ export class Operator {
 				}
 			}
 		});
-		if (params != null && params.isReplay) {
-			play.handlePlayDurationStateChange(false, 0);
-		}
 		store.setCurrentLocalInstance(instance);
 		if (params != null && params.joinsSelf) {
 			store.currentPlay.join(store.player.id, store.player.name);

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -54,17 +54,17 @@ export class Operator {
 		const store = this.store;
 		const query = queryString.parse(window.location.search);
 		let play: PlayEntity = null;
-		if (contentLocator && !query.playId) {
+		if (query.playId != null) {
+			const target = store.playStore.plays[query.playId as string];
+			if (!target) {
+				throw new Error(`play(id: ${query.playId}) is not found.`);
+			}
+			play = target;
+		} else if (contentLocator) {
 			play = await this._createServerLoop(contentLocator);
 		} else {
 			const plays = store.playStore.playsList();
-			if (query.playId) {
-				const target = plays.filter(play => play.playId === query.playId);
-				if (target.length === 0) {
-					throw new Error(`play(id: ${query.playId}) is not found.`);
-				}
-				play = target[0];
-			} else if (plays.length > 0) {
+			if (plays.length > 0) {
 				play = plays[plays.length - 1];
 			} else {
 				const loc = store.contentStore.defaultContent().locator;
@@ -118,7 +118,7 @@ export class Operator {
 			playId: play.playId,
 			playToken: tokenResult.data.playToken,
 			playlogServerUrl: "dummy-playlog-server-url",
-			executionMode: params.isReplay ? "replay" : "passive",
+			executionMode: params != null && params.isReplay ? "replay" : "passive",
 			player: store.player,
 			argument: params != null ? params.instanceArgument : undefined,
 			proxyAudio: store.appOptions.proxyAudio,
@@ -149,7 +149,7 @@ export class Operator {
 				}
 			}
 		});
-		if (params.isReplay) {
+		if (params != null && params.isReplay) {
 			play.handlePlayDurationStateChange(false, 0);
 		}
 		store.setCurrentLocalInstance(instance);

--- a/packages/akashic-cli-serve/src/common/TimeKeeper.ts
+++ b/packages/akashic-cli-serve/src/common/TimeKeeper.ts
@@ -46,4 +46,9 @@ export class TimeKeeper {
 		}
 		this.pausedTime = this.now();
 	}
+
+	setFinishedTime(time: number): void {
+		this.origin = Date.now();
+		this.pausedTime = time;
+	}
 }

--- a/packages/akashic-cli-serve/src/common/TimeKeeper.ts
+++ b/packages/akashic-cli-serve/src/common/TimeKeeper.ts
@@ -5,7 +5,7 @@ export class TimeKeeper {
 	offset: number;
 
 	constructor() {
-		this.origin = null;
+		this.origin = Date.now();
 		this.pausedTime = 0;
 		this.rate = 1;
 		this.offset = 0;
@@ -16,9 +16,6 @@ export class TimeKeeper {
 	}
 
 	now(): number {
-		if (this.origin === null) {
-			return 0;
-		}
 		return (this.isPausing()) ? this.pausedTime : ((Date.now() - this.origin) * this.rate + this.offset);
 	}
 
@@ -45,10 +42,5 @@ export class TimeKeeper {
 			return;
 		}
 		this.pausedTime = this.now();
-	}
-
-	setFinishedTime(time: number): void {
-		this.origin = Date.now();
-		this.pausedTime = time;
 	}
 }

--- a/packages/akashic-cli-serve/src/server/common/types/DumpedPlaylog.ts
+++ b/packages/akashic-cli-serve/src/server/common/types/DumpedPlaylog.ts
@@ -1,0 +1,7 @@
+import { TickList } from "@akashic/playlog";
+import { StartPoint } from "@akashic/amflow";
+
+export interface DumpedPlaylog {
+	tickList: TickList;
+	startPoints: StartPoint[];
+}

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -76,6 +76,36 @@ export class PlayStore {
 		return playId;
 	}
 
+	/**
+	 * 指定のplayIdのplayに指定したplaylogを読み込ませる
+	 */
+	async loadPlaylog(playId: string, playlog: any): Promise<void> {
+		const token = await this.createPlayToken(playId, true);
+		const amflow = await this.createAMFlow(playId);
+		amflow.open(playId, e => {
+			if (e) {
+				throw e;
+			}
+			amflow.authenticate(token, e => {
+				if (e) {
+					throw e;
+				}
+				if (playlog.startPoints && playlog.startPoints instanceof Array) {
+					amflow.putStartPoint(playlog.startPoints[0], e => {
+						if (e) {
+							throw e;
+						}
+						if (playlog.tickList && playlog.tickList instanceof Array) {
+							playlog.tickList[2].forEach((tick: any) => {
+								amflow.sendTick(tick);
+							});
+						}
+					});
+				}
+			});
+		});
+	}
+
 	getPlay(playId: string): Play {
 		return this.playManager.getPlay(playId);
 	}

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -177,7 +177,7 @@ export class PlayStore {
 		// クライアント側にdurationとしてplaylogに記録されている終了時間を渡す必要があるので、そのための設定を行う
 		const timeKeeper = this.playEntities[playId].timeKeeper;
 		const finishedTime = this.calculataFinishedTime(playlog);
-		timeKeeper.setFinishedTime(finishedTime);
+		timeKeeper.setTime(finishedTime);
 	}
 
 	// コンテンツの終了時間をplaylogから算出する

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -175,7 +175,7 @@ export class PlayStore {
 		await new Promise((resolve, reject) => amflow.open(playId, (e: Error) => e ? reject(e) : resolve()));
 		await new Promise((resolve, reject) => amflow.authenticate(token, (e: Error) => e ? reject(e) : resolve()));
 		await new Promise((resolve, reject) => amflow.putStartPoint(playlog.startPoints[0], (e: Error) => e ? reject(e) : resolve()));
-		playlog.tickList[2].forEach((tick: any) => {
+		playlog.tickList[2].forEach((tick) => {
 			amflow.sendTick(tick);
 		});
 		amflow.destroy();

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -89,25 +89,12 @@ export class PlayStore {
 	async loadPlaylog(playId: string, playlog: Playlog): Promise<void> {
 		const token = await this.createPlayToken(playId, true);
 		const amflow = await this.createAMFlow(playId);
-		try {
-			await new Promise((resolve, reject) => amflow.open(playId, e => e ? reject(e) : resolve()))
-				.then(() => {
-					return new Promise((resolve, reject) => amflow.authenticate(token, e => e ? reject(e) : resolve()));
-				})
-				.then(() => {
-					return new Promise((resolve, reject) => amflow.putStartPoint(playlog.startPoints[0], (e: Error) => {
-						if (e) {
-							return reject(e);
-						}
-						playlog.tickList[2].forEach((tick: any) => {
-							amflow.sendTick(tick);
-						});
-						resolve();
-					}));
-				});
-		} catch (e) {
-			throw e;
-		}
+		await new Promise((resolve, reject) => amflow.open(playId, (e: Error) => e ? reject(e) : resolve()));
+		await new Promise((resolve, reject) => amflow.authenticate(token, (e: Error) => e ? reject(e) : resolve()));
+		await new Promise((resolve, reject) => amflow.putStartPoint(playlog.startPoints[0], (e: Error) => e ? reject(e) : resolve()));
+		playlog.tickList[2].forEach((tick: any) => {
+			amflow.sendTick(tick);
+		});
 	}
 
 	getPlay(playId: string): Play {

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -187,7 +187,7 @@ export class PlayStore {
 		const replayLastAge = playlog.tickList[1];
 		const ticksWithEvents = playlog.tickList[2];
 		let replayLastTime = null;
-		for (let i = ticksWithEvents.length - 1; i >= 0; --i) {
+		loop: for (let i = ticksWithEvents.length - 1; i >= 0; --i) {
 			const tick = ticksWithEvents[i];
 			const pevs = tick[1] || [];
 			for (let j = 0; j < pevs.length; ++j) {
@@ -195,7 +195,7 @@ export class PlayStore {
 					const timestamp = pevs[j][3]; // Timestamp
 					// Timestamp の時刻がゲームの開始時刻より小さかった場合は相対時刻とみなす
 					replayLastTime = (timestamp < replayStartTime ? timestamp + replayStartTime : timestamp) + (replayLastAge - tick[0]) * 1000 / fps;
-					break;
+					break loop;
 				}
 			}
 		}

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -169,7 +169,7 @@ export async function run(argv: any): Promise<void> {
 			process.exit(1);
 		}
 		const playlog = require(absolutePath);
-		// 現状指定されるplaylogは1つの想定なので、contentIdは必ず0になる
+		// 現状 playlog は一つしか受け取らない。それは contentId: 0 のコンテンツの playlog として扱う。
 		const contentLocator = new ServerContentLocator({contentId: "0"});
 		try {
 			loadedPlaylogPlayId = await playStore.createPlay(contentLocator, playlog);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -43,7 +43,7 @@ export async function run(argv: any): Promise<void> {
 		.option("-A, --no-auto-start", `Wait automatic startup of contents.`)
 		.option("-s, --target-service <service>",
 			`Simulate the specified service. arguments: ${Object.values(ServiceType)}`)
-		.option("-P, --playlog-path <playlogPath>", `Specify path of playlog-json. arguments: .`)
+		.option("--playlog <playlog>", `Specify path of playlog-json. arguments: .`)
 		.option("--debug-untrusted", `An internal debug option`)
 		.option("--debug-proxy-audio", `An internal debug option`)
 		.parse(argv);
@@ -162,13 +162,13 @@ export async function run(argv: any): Promise<void> {
 	runnerStore.onRunnerResume.add(arg => { io.emit("runnerResume", arg); });
 
 	let loadedPlaylogPlayId: string;
-	if (commander.playlogPath) {
-		const actualPath = path.join(process.cwd(), commander.playlogPath);
-		if (!fs.existsSync(actualPath)) {
-			getSystemLogger().error(`Can not find ${actualPath}`);
+	if (commander.playlog) {
+		const absolutePath = path.join(process.cwd(), commander.playlog);
+		if (!fs.existsSync(absolutePath)) {
+			getSystemLogger().error(`Can not find ${absolutePath}`);
 			process.exit(1);
 		}
-		const playlog = require(actualPath);
+		const playlog = require(absolutePath);
 		// 現状指定されるplaylogは1つの想定なので、contentIdは必ず0になる
 		const contentLocator = new ServerContentLocator({contentId: "0"});
 		loadedPlaylogPlayId = await playStore.createPlay(contentLocator);
@@ -186,7 +186,7 @@ export async function run(argv: any): Promise<void> {
 		// サーバー起動のログに関してはSystemLoggerで使用していない色を使いたいので緑を選択
 		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
 		if (loadedPlaylogPlayId) {
-			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), commander.playlogPath)}).`);
+			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), commander.playlog)}).`);
 			const url = `http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/public?playId=${loadedPlaylogPlayId}&mode=replay`;
 			console.log(`if access ${url}, you can show this play.`);
 		}

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -43,7 +43,7 @@ export async function run(argv: any): Promise<void> {
 		.option("-A, --no-auto-start", `Wait automatic startup of contents.`)
 		.option("-s, --target-service <service>",
 			`Simulate the specified service. arguments: ${Object.values(ServiceType)}`)
-		.option("--playlog <playlog>", `Specify path of playlog-json. arguments: .`)
+		.option("--playlog <playlog>", `Specify path of playlog-json. default: .`)
 		.option("--debug-untrusted", `An internal debug option`)
 		.option("--debug-proxy-audio", `An internal debug option`)
 		.parse(argv);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -168,10 +168,10 @@ export async function run(argv: any): Promise<void> {
 			getSystemLogger().error(`Can not find ${absolutePath}`);
 			process.exit(1);
 		}
-		const playlog = require(absolutePath);
 		// 現状 playlog は一つしか受け取らない。それは contentId: 0 のコンテンツの playlog として扱う。
 		const contentLocator = new ServerContentLocator({contentId: "0"});
 		try {
+			const playlog = require(absolutePath);
 			loadedPlaylogPlayId = await playStore.createPlay(contentLocator, playlog);
 		} catch (e) {
 			getSystemLogger().error(e.message);


### PR DESCRIPTION
### やったこと
* サーバー側でplaylogが書かれたjsonファイルを読み込むためのオプション`--playlogPath`を追加
  * このオプションで読み込めるのはplay1つ分のみ
* クライアント側で新たにplayIdとmodeというクエリパラメーターを追加
  * playIdにplaylogを読み込んでいるplayのidを、modeにreplayを指定してアクセスした場合そのplaylogがリプレイモードで再生されるようになっている