### PR TITLE
fix: loading timing of sandboxConfig

### DIFF
--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -7,7 +7,8 @@ import {
 	RunnerDeleteApiResponse,
 	RunnerPostApiResponse,
 	RunnerPatchApiResponse,
-	ContentsGetApiResponse,
+	ContentGetAllApiResponse,
+	ContentGetApiResponse,
 	SandboxConfigApiResponse,
 	OptionsApiResponse
 } from "../../common/types/ApiResponse";
@@ -71,8 +72,12 @@ export const resumeRunner = async(runnerId: string): Promise<RunnerPatchApiRespo
 	return await ApiRequest.patch<RunnerPatchApiResponse>(`/api/runners/${runnerId}`, {status: "running"});
 };
 
-export const getContents = async(): Promise<ContentsGetApiResponse> => {
-	return await ApiRequest.get<ContentsGetApiResponse>(`/contents/`);
+export const getContents = async (): Promise<ContentGetAllApiResponse> => {
+	return await ApiRequest.get<ContentGetAllApiResponse>(`/contents/`);
+};
+
+export const getContent = async (contentId: string): Promise<ContentGetApiResponse> => {
+	return await ApiRequest.get<ContentGetApiResponse>(`/contents/${contentId}`);
 };
 
 export const getGameConfiguration = async(contentId: number): Promise<GameConfiguration> => {

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -155,6 +155,7 @@ export class Operator {
 	}
 
 	restartWithNewPlay = async (): Promise<void> => {
+		await this.store.contentStore.updateSandboxConfig(this.store.currentPlay.content.locator);
 		const play = await this._createServerLoop(this.store.currentPlay.content.locator);
 		await this.store.currentPlay.deleteAllServerInstances();
 		await ApiClient.broadcast(this.store.currentPlay.playId, { type: "switchPlay", nextPlayId: play.playId });

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -155,7 +155,7 @@ export class Operator {
 	}
 
 	restartWithNewPlay = async (): Promise<void> => {
-		await this.store.contentStore.updateSandboxConfig(this.store.currentPlay.content.locator);
+		await this.store.currentPlay.content.updateSandboxConfig();
 		const play = await this._createServerLoop(this.store.currentPlay.content.locator);
 		await this.store.currentPlay.deleteAllServerInstances();
 		await ApiClient.broadcast(this.store.currentPlay.playId, { type: "switchPlay", nextPlayId: play.playId });

--- a/packages/akashic-cli-serve/src/client/store/ContentEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/ContentEntity.ts
@@ -2,6 +2,7 @@ import { action, observable } from "mobx";
 import { SandboxConfig } from "../../common/types/SandboxConfig";
 import { ContentDesc } from "../../common/types/ContentDesc";
 import { ClientContentLocator } from "../common/ClientContentLocator";
+import * as ApiClient from "../api/ApiClient";
 
 export class ContentEntity {
 	readonly locator: ClientContentLocator;
@@ -21,5 +22,10 @@ export class ContentEntity {
 	@action
 	setSandboxConfig(config: SandboxConfig): void {
 		this.sandboxConfig = config;
+	}
+
+	async updateSandboxConfig(): Promise<void> {
+		const res = await ApiClient.getContent(this.locator.contentId);
+		this.setSandboxConfig(res.data.sandboxConfig || {});
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/ContentEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/ContentEntity.ts
@@ -1,4 +1,4 @@
-import { observable } from "mobx";
+import { action, observable } from "mobx";
 import { SandboxConfig } from "../../common/types/SandboxConfig";
 import { ContentDesc } from "../../common/types/ContentDesc";
 import { ClientContentLocator } from "../common/ClientContentLocator";
@@ -16,5 +16,10 @@ export class ContentEntity {
 		Object.keys(args).forEach(key => {
 			this.argumentsTable[key] = JSON.stringify(args[key], null, 2);
 		});
+	}
+
+	@action
+	setSandboxConfig(config: SandboxConfig): void {
+		this.sandboxConfig = config;
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/ContentStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/ContentStore.ts
@@ -33,13 +33,6 @@ export class ContentStore {
 		return content;
 	}
 
-	async updateSandboxConfig(locData: ContentLocatorData): Promise<void> {
-		const loc = ClientContentLocator.instantiate(locData);
-		const res = await ApiClient.getContent(loc.contentId);
-		const content = this.contents.get(loc.asAbsoluteUrl());
-		content.setSandboxConfig(res.data.sandboxConfig || {});
-	}
-
 	private async _initialize(): Promise<void> {
 		const res = await ApiClient.getContents();
 		res.data.forEach(desc => {

--- a/packages/akashic-cli-serve/src/client/store/ContentStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/ContentStore.ts
@@ -33,6 +33,13 @@ export class ContentStore {
 		return content;
 	}
 
+	async updateSandboxConfig(locData: ContentLocatorData): Promise<void> {
+		const loc = ClientContentLocator.instantiate(locData);
+		const res = await ApiClient.getContent(loc.contentId);
+		const content = this.contents.get(loc.asAbsoluteUrl());
+		content.setSandboxConfig(res.data.sandboxConfig || {});
+	}
+
 	private async _initialize(): Promise<void> {
 		const res = await ApiClient.getContents();
 		res.data.forEach(desc => {

--- a/packages/akashic-cli-serve/src/common/types/ApiResponse.ts
+++ b/packages/akashic-cli-serve/src/common/types/ApiResponse.ts
@@ -52,7 +52,7 @@ export interface RunnerPatchApiResponseData {
 	status: "running" | "paused";
 }
 
-export type ContentsGetApiResponseData = ContentDesc[];
+export type ContentGetApiResponseData = ContentDesc;
 
 export interface SandboxConfigApiResponseData extends SandboxConfig {
 }
@@ -67,6 +67,7 @@ export type PlayTokenPostApiResponse = ApiResponse<PlayTokenPostApiResponseData>
 export type RunnerPostApiResponse = ApiResponse<RunnerPostApiResponseData>;
 export type RunnerDeleteApiResponse = ApiResponse<RunnerDeleteApiResponseData>;
 export type RunnerPatchApiResponse = ApiResponse<RunnerPatchApiResponseData>;
-export type ContentsGetApiResponse = ApiResponse<ContentsGetApiResponseData>;
+export type ContentGetAllApiResponse = ApiResponse<ContentGetApiResponseData[]>;
+export type ContentGetApiResponse = ApiResponse<ContentGetApiResponseData>;
 export type SandboxConfigApiResponse = ApiResponse<SandboxConfigApiResponseData>;
 export type OptionsApiResponse = ApiResponse<OptionsApiResponseData>;

--- a/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
@@ -12,8 +12,7 @@ import { serverGlobalConfig } from "../common/ServerGlobalConfig";
 
 export const createHandlerToCreateRunner = (
 	playStore: PlayStore,
-	runnerStore: RunnerStore,
-	targetDirs: string[]
+	runnerStore: RunnerStore
 ): express.RequestHandler => {
 	return async (req, res, next) => {
 		try {
@@ -27,7 +26,7 @@ export const createHandlerToCreateRunner = (
 			const isActive = Boolean(req.body.isActive);
 			const token = req.body.token;
 			const amflow = playStore.createAMFlow(playId);
-			const runner = await runnerStore.createAndStartRunner({ playId, isActive, token, amflow, targetDirs, contentId });
+			const runner = await runnerStore.createAndStartRunner({ playId, isActive, token, amflow, contentId });
 			responseSuccess<RunnerPostApiResponseData>(res, 200, { playId: runner.playId, runnerId: runner.runnerId });
 		} catch (e) {
 			next(e);

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -6,7 +6,7 @@ import {
 	RunnerPauseTestbedEvent,
 	RunnerResumeTestbedEvent
 } from "../../common/types/TestbedEvent";
-import { SandboxConfigs } from "./SandboxConfigs";
+import { loadSandboxConfigJs } from "./SandboxConfigs";
 import { serverGlobalConfig } from "../common/ServerGlobalConfig";
 
 export interface RunnerStoreParameterObject {
@@ -39,7 +39,7 @@ export class RunnerStore {
 	}
 
 	async createAndStartRunner(params: CreateAndStartRunnerParameterObject): Promise<RunnerV1 | RunnerV2> {
-		const sandboxConfig = SandboxConfigs.getInstance().getConfig(params.contentId);
+		const sandboxConfig = loadSandboxConfigJs(params.contentId);
 		const externalAssets = (sandboxConfig ? sandboxConfig.externalAssets : undefined) === undefined ? [] : sandboxConfig.externalAssets;
 		const allowedUrls = this.createAllowedUrls(params.contentId, externalAssets);
 

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -6,8 +6,8 @@ import {
 	RunnerPauseTestbedEvent,
 	RunnerResumeTestbedEvent
 } from "../../common/types/TestbedEvent";
-import { loadSandboxConfigJs } from "./SandboxConfigs";
 import { serverGlobalConfig } from "../common/ServerGlobalConfig";
+import * as sandboxConfigs from "./SandboxConfigs";
 
 export interface RunnerStoreParameterObject {
 	runnerManager: RunnerManager;
@@ -39,7 +39,7 @@ export class RunnerStore {
 	}
 
 	async createAndStartRunner(params: CreateAndStartRunnerParameterObject): Promise<RunnerV1 | RunnerV2> {
-		const sandboxConfig = loadSandboxConfigJs(params.contentId);
+		const sandboxConfig = sandboxConfigs.get(params.contentId);
 		const externalAssets = (sandboxConfig ? sandboxConfig.externalAssets : undefined) === undefined ? [] : sandboxConfig.externalAssets;
 		const allowedUrls = this.createAllowedUrls(params.contentId, externalAssets);
 

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -6,7 +6,7 @@ import {
 	RunnerPauseTestbedEvent,
 	RunnerResumeTestbedEvent
 } from "../../common/types/TestbedEvent";
-import { loadSandboxConfigJs } from "./SandboxConfigs";
+import { SandboxConfigs } from "./SandboxConfigs";
 import { serverGlobalConfig } from "../common/ServerGlobalConfig";
 
 export interface RunnerStoreParameterObject {
@@ -18,7 +18,6 @@ export interface CreateAndStartRunnerParameterObject {
 	isActive: boolean;
 	token: string;
 	amflow: AMFlowClient;
-	targetDirs: string[];
 	contentId: string;
 }
 
@@ -40,10 +39,7 @@ export class RunnerStore {
 	}
 
 	async createAndStartRunner(params: CreateAndStartRunnerParameterObject): Promise<RunnerV1 | RunnerV2> {
-		// TODO: allowedUrls を作成するための sandbox.config.js の load や引数の targetDirs 等は SandboxConfig の反映タイミング修正で不要となる可能性がある。
-		// TODO: targetDirsを渡さなくても、contentIdから解決できるようにする。
-		const sandboxConfigDir = params.targetDirs[parseInt(params.contentId, 10)];
-		const sandboxConfig = loadSandboxConfigJs(sandboxConfigDir);
+		const sandboxConfig = SandboxConfigs.getInstance().getConfig(params.contentId);
 		const externalAssets = (sandboxConfig ? sandboxConfig.externalAssets : undefined) === undefined ? [] : sandboxConfig.externalAssets;
 		const allowedUrls = this.createAllowedUrls(params.contentId, externalAssets);
 

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -35,7 +35,7 @@ export function loadSandboxConfigJs(contentId: string, targetDir?: string): Sand
 
 function validateConfig(config: SandboxConfig): void {
 	const externalAssets = (config ? config.externalAssets : undefined) === undefined ? [] : config.externalAssets;
-	if ( externalAssets) {
+	if (externalAssets) {
 		// sandbox.config.js の externalAssets に値がある場合は (string|regexp)[] でなければエラーとする
 		if (!(externalAssets instanceof Array)) {
 			throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
@@ -44,7 +44,7 @@ function validateConfig(config: SandboxConfig): void {
 		if ( externalAssets.length > 0) {
 			const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
 			if (found) {
-				throw new BadRequestError({ errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
+				throw new BadRequestError({errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
 			}
 		}
 	}

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -35,7 +35,7 @@ export function loadSandboxConfigJs(contentId: string, targetDir?: string): Sand
 
 function validateConfig(config: SandboxConfig): void {
 	const externalAssets = (config ? config.externalAssets : undefined) === undefined ? [] : config.externalAssets;
-	if (externalAssets) {
+	if ( externalAssets) {
 		// sandbox.config.js の externalAssets に値がある場合は (string|regexp)[] でなければエラーとする
 		if (!(externalAssets instanceof Array)) {
 			throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
@@ -44,7 +44,7 @@ function validateConfig(config: SandboxConfig): void {
 		if (externalAssets.length > 0) {
 			const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
 			if (found) {
-				throw new BadRequestError({ errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${found}` });
+				throw new BadRequestError({errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }`});
 			}
 		}
 	}

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -32,8 +32,6 @@ export class SandboxConfigs {
 				this.validateConfig(this._configs[contentId]);
 			} else if (event === "unlink") {
 				this._configs[contentId] = {};
-			} else {
-				// do nothing.
 			}
 		});
 	}

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -24,13 +24,17 @@ export class SandboxConfigs {
 	 */
 	loadSandboxConfigJs(targetDir: string, contentId: string): void {
 		const configPath = path.resolve(targetDir, "sandbox.config.js");
-		this._configs[contentId] = dynamicRequire<SandboxConfig>(configPath, true) || {};
-		this.validateConfig(this._configs[contentId]);
-
 		const watcher = chokidar.watch(configPath, { persistent: true });
-		watcher.on("change", () => {
-			this._configs[contentId] = dynamicRequire<SandboxConfig>(configPath, true);
-			this.validateConfig(this._configs[contentId]);
+		watcher.on("all", (event, path) => {
+			// watch後、初回読み込みは add イベントで行われる。
+			if (event === "add" || event === "change") {
+				this._configs[contentId] = dynamicRequire<SandboxConfig>(configPath, true);
+				this.validateConfig(this._configs[contentId]);
+			} else if (event === "unlink") {
+				this._configs[contentId] = {};
+			} else {
+				// do nothing.
+			}
 		});
 	}
 

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -41,10 +41,10 @@ function validateConfig(config: SandboxConfig): void {
 			throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
 		}
 
-		if (externalAssets.length > 0) {
+		if ( externalAssets.length > 0) {
 			const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
 			if (found) {
-				throw new BadRequestError({errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }`});
+				throw new BadRequestError({ errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
 			}
 		}
 	}

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -4,59 +4,47 @@ import { SandboxConfig } from "../../common/types/SandboxConfig";
 import { dynamicRequire } from "./dynamicRequire";
 import { BadRequestError } from "../common/ApiError";
 
-export class SandboxConfigs {
-	private static _instance: SandboxConfigs;
+const configs: { [key: string]: SandboxConfig } = {};
 
-	static getInstance(): SandboxConfigs {
-		if (!this._instance) {
-			this._instance = new SandboxConfigs();
-		}
-		return this._instance;
-	}
-	private _configs: { [key: string]: SandboxConfig } = {};
-
-	/**
-	 * sandbox.config.jsを読み込み、ファイルの監視を行う。
-	 * 読み込んだ内容は、コンテンツIDで紐付け保持する。
-	 *
-	 * @param targetDir 対象ディレクトリ
-	 * @param contentId コンテンツID
-	 */
-	loadSandboxConfigJs(targetDir: string, contentId: string): void {
+/**
+ * sandbox.config.jsを読み込み内容を返す。
+ * 読み込んだ内容はコンテンツIDで紐付け保持する。
+ * 初回読み込み後はファイル監視を行い、監視イベントにて保持内容を更新する。
+ *
+ * @param contentId コンテンツID
+ * @param targetDir 対象ディレクトリ
+ */
+export function loadSandboxConfigJs(contentId: string, targetDir?: string): SandboxConfig {
+	if (!configs[contentId] && targetDir) {
 		const configPath = path.resolve(targetDir, "sandbox.config.js");
+		configs[contentId] = dynamicRequire<SandboxConfig>(configPath, true) || {};
+		validateConfig(configs[contentId]);
+
 		const watcher = chokidar.watch(configPath, { persistent: true });
 		watcher.on("all", (event, path) => {
-			// watch後、初回読み込みは add イベントで行われる。
-			if (event === "add" || event === "change") {
-				this._configs[contentId] = dynamicRequire<SandboxConfig>(configPath, true);
-				this.validateConfig(this._configs[contentId]);
+			if ((event === "add" && !Object.keys(configs[contentId]).length) || event === "change") {
+				configs[contentId] = dynamicRequire<SandboxConfig>(path, true);
+				validateConfig(configs[contentId]);
 			} else if (event === "unlink") {
-				this._configs[contentId] = {};
+				configs[contentId] = {};
 			}
 		});
 	}
+	return configs[contentId];
+}
 
-	/**
-	 * コンテンツIDに紐づく、sandboxConfigを返す。
-	 * @param contentId コンテンツID
-	 */
-	getConfig(contentId: string): SandboxConfig {
-		return this._configs[contentId];
-	}
+function validateConfig(config: SandboxConfig): void {
+	const externalAssets = (config ? config.externalAssets : undefined) === undefined ? [] : config.externalAssets;
+	if (externalAssets) {
+		// sandbox.config.js の externalAssets に値がある場合は (string|regexp)[] でなければエラーとする
+		if (!(externalAssets instanceof Array)) {
+			throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
+		}
 
-	private validateConfig(config: SandboxConfig): void {
-		const externalAssets = (config ? config.externalAssets : undefined) === undefined ? [] : config.externalAssets;
-		if (externalAssets) {
-			// sandbox.config.js の externalAssets に値がある場合は (string|regexp)[] でなければエラーとする
-			if (!(externalAssets instanceof Array)) {
-				throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
-			}
-
-			if (externalAssets.length > 0) {
-				const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
-				if (found) {
-					throw new BadRequestError({errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
-				}
+		if (externalAssets.length > 0) {
+			const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
+			if (found) {
+				throw new BadRequestError({ errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${found}` });
 			}
 		}
 	}

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -55,10 +55,10 @@ function validateConfig(config: SandboxConfig): void {
 			throw new BadRequestError({ errorMessage: "Invalid externalAssets, Not Array" });
 		}
 
-		if (externalAssets.length > 0) {
+		if ( externalAssets.length > 0) {
 			const found = externalAssets.find((url: any) => typeof url !== "string" && !(url instanceof RegExp));
 			if (found) {
-				throw new BadRequestError({ errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
+				throw new BadRequestError({errorMessage: `Invalid externalAssets, The value is neither a string or regexp. value:${ found }` });
 			}
 		}
 	}

--- a/packages/akashic-cli-serve/src/server/domain/dynamicRequire.ts
+++ b/packages/akashic-cli-serve/src/server/domain/dynamicRequire.ts
@@ -1,6 +1,7 @@
-export function dynamicRequire<T>(path: string): T | null {
+export function dynamicRequire<T>(path: string, isDeleteCache?: boolean): T | null {
 	let ret: T | null = null;
 	try {
+		if (isDeleteCache) delete require.cache[path];
 		ret = require(path) as T;
 	} catch (e) {
 		if (e.code !== "MODULE_NOT_FOUND")

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -148,7 +148,7 @@ export async function run(argv: any): Promise<void> {
 	app.use("^\/$", (req, res, next) => res.redirect("/public/"));
 	app.use("/public/", express.static(path.join(__dirname, "..", "..", "www", "public")));
 	app.use("/internal/", express.static(path.join(__dirname, "..", "..", "www", "internal")));
-	app.use("/api/", createApiRouter({ playStore, runnerStore, amflowManager, io, targetDirs}));
+	app.use("/api/", createApiRouter({ playStore, runnerStore, amflowManager, io}));
 	app.use("/contents/", createContentsRouter({ targetDirs }));
 	app.use("/health-check/", createHealthCheckRouter({ playStore }));
 

--- a/packages/akashic-cli-serve/src/server/route/ApiRoute.ts
+++ b/packages/akashic-cli-serve/src/server/route/ApiRoute.ts
@@ -25,7 +25,6 @@ export interface ApiRouterParameterObject {
 	runnerStore: RunnerStore;
 	amflowManager: SocketIOAMFlowManager;
 	io: socketio.Server;
-	targetDirs: string[];
 }
 
 export const createApiRouter = (params: ApiRouterParameterObject): express.Router => {
@@ -41,7 +40,7 @@ export const createApiRouter = (params: ApiRouterParameterObject): express.Route
 	apiRouter.post("/plays/:playId(\\d+)/broadcast", createHandlerToBroadcast(params.io));
 	apiRouter.get("/plays/:playId(\\d+)/playlog", createHandlerToGetPlaylog(params.playStore));
 
-	apiRouter.post("/runners", createHandlerToCreateRunner(params.playStore, params.runnerStore, params.targetDirs));
+	apiRouter.post("/runners", createHandlerToCreateRunner(params.playStore, params.runnerStore));
 	apiRouter.delete("/runners/:runnerId", createHandlerToDeleteRunner(params.runnerStore));
 	apiRouter.patch("/runners/:runnerId", createHandlerToPatchRunner(params.runnerStore));
 

--- a/packages/akashic-cli-serve/src/server/route/ContentsRoute.ts
+++ b/packages/akashic-cli-serve/src/server/route/ContentsRoute.ts
@@ -2,7 +2,6 @@ import * as express from "express";
 import { createHandlerToGetContent, createHandlerToGetContents, createHandlerToGetEngineConfig } from "../controller/ContentController";
 import { createScriptAssetController } from "../controller/ScriptAssetController";
 import { createHandlerToGetSandboxConfig } from "../controller/SandboxConfigController";
-import { SandboxConfigs } from "../domain/SandboxConfigs";
 
 export interface ContentsRouterParameterObject {
 	targetDirs: string[];
@@ -11,7 +10,6 @@ export interface ContentsRouterParameterObject {
 export const createContentsRouter = (params: ContentsRouterParameterObject): express.Router => {
 	const targetDirs = params.targetDirs;
 	const contentsRouter = express.Router();
-	const sandboxConfigs = SandboxConfigs.getInstance();
 
 	// --debug-untrusted の動作用に、localhost と 127.0.0.1 のリクエストはクロスドメインでも許す
 	// (ref. GameViewManger#getDefaultUntrustedFrameUrl())
@@ -27,7 +25,6 @@ export const createContentsRouter = (params: ContentsRouterParameterObject): exp
 		contentsRouter.get(`/${i}/content/:scriptName(*.js$)`, createScriptAssetController(targetDirs[i]));
 		contentsRouter.use(`/${i}/content`, express.static(targetDirs[i]));
 		contentsRouter.use(`/${i}/raw`, express.static(targetDirs[i]));
-		sandboxConfigs.loadSandboxConfigJs(targetDirs[i], i.toString());
 	}
 
 	contentsRouter.get(`/`, createHandlerToGetContents(targetDirs));


### PR DESCRIPTION
## 修正内容

**sandbox.config.js の変更が (サーバ再起動まで) 反映されない問題の修正** 

- `sandbox.config.js` の読み込むタイミングを修正
  - server 起動後に1度ファイルを読み込む。以後はファイル監視を行い、変更時のみ読み込む。
  - 読み込んだ内容は、contentIdをkeyに保持する。
    - `RunnerStore#createAndStartRunner()`でも `sandbox.config.js` を読み込んでいたロジックをやめ、保持しているオブジェクトから取得するよう修正。

- `/contents/:contentId/` APIを新規作成
  - パラメータ `contentId` に紐づくコンテンツの情報を返す。
  - 新規プレイボタン押下後に実行し、contentStroeのsandboxConfigObjectを更新する。

- dynamicRequireに キャッシュを削除するオプション引数の追加