### PR TITLE
fix: sandbox.config.js in autoSendEvents is deprecated

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -169,9 +169,13 @@ export class Operator {
 
 		// autoSendEvents
 		const sandboxConfig = this.store.contentStore.findOrRegister(contentLocator).sandboxConfig || {};
-		const { events, autoSendEvents } = sandboxConfig;
+		const { events, autoSendEvents, autoSendEventName } = sandboxConfig;
 		if (events && autoSendEvents && events[autoSendEvents] instanceof Array) {
+			// TODO: `autoSendEvents` は deprecated となった。互換性のためこのパスを残しているが、`autoSendEvents` の削除時にこのパスも削除する。
+			console.warn("[deprecated] sandbox.config.js in `autoSendEvents` is deprecated. Use `autoSendEventName`");
 			events[autoSendEvents].forEach((pev: any) => play.amflow.enqueueEvent(pev));
+		} else if (events && autoSendEventName && events[autoSendEventName] instanceof Array) {
+			events[autoSendEventName].forEach((pev: any) => play.amflow.enqueueEvent(pev));
 		}
 
 		return play;

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -172,7 +172,7 @@ export class Operator {
 		const { events, autoSendEvents, autoSendEventName } = sandboxConfig;
 		if (events && autoSendEvents && events[autoSendEvents] instanceof Array) {
 			// TODO: `autoSendEvents` は deprecated となった。互換性のためこのパスを残しているが、`autoSendEvents` の削除時にこのパスも削除する。
-			console.warn("[deprecated] sandbox.config.js in `autoSendEvents` is deprecated. Use `autoSendEventName`");
+			console.warn("[deprecated] `autoSendEvents` in sandbox.config.js is deprecated. Please use `autoSendEventName`.");
 			events[autoSendEvents].forEach((pev: any) => play.amflow.enqueueEvent(pev));
 		} else if (events && autoSendEventName && events[autoSendEventName] instanceof Array) {
 			events[autoSendEventName].forEach((pev: any) => play.amflow.enqueueEvent(pev));

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -170,12 +170,12 @@ export class Operator {
 		// autoSendEvents
 		const sandboxConfig = this.store.contentStore.findOrRegister(contentLocator).sandboxConfig || {};
 		const { events, autoSendEvents, autoSendEventName } = sandboxConfig;
-		if (events && autoSendEvents && events[autoSendEvents] instanceof Array) {
+		if (events && autoSendEventName && events[autoSendEventName] instanceof Array) {
+			events[autoSendEventName].forEach((pev: any) => play.amflow.enqueueEvent(pev));
+		} else if (events && autoSendEvents && events[autoSendEvents] instanceof Array) {
 			// TODO: `autoSendEvents` は deprecated となった。互換性のためこのパスを残しているが、`autoSendEvents` の削除時にこのパスも削除する。
 			console.warn("[deprecated] `autoSendEvents` in sandbox.config.js is deprecated. Please use `autoSendEventName`.");
 			events[autoSendEvents].forEach((pev: any) => play.amflow.enqueueEvent(pev));
-		} else if (events && autoSendEventName && events[autoSendEventName] instanceof Array) {
-			events[autoSendEventName].forEach((pev: any) => play.amflow.enqueueEvent(pev));
 		}
 
 		return play;

--- a/packages/akashic-cli-serve/src/common/types/SandboxConfig.ts
+++ b/packages/akashic-cli-serve/src/common/types/SandboxConfig.ts
@@ -1,5 +1,9 @@
 export interface SandboxConfig {
+	/**
+	 * @deprecated 非推奨。将来削除する予定。
+	 */
 	autoSendEvents?: string;
+	autoSendEventName?: string;
 	backgroundImage?: string;
 	showMenu?: boolean;
 	events?: { [name: string]: any };

--- a/packages/akashic-cli-serve/src/common/types/SandboxConfig.ts
+++ b/packages/akashic-cli-serve/src/common/types/SandboxConfig.ts
@@ -1,6 +1,7 @@
 export interface SandboxConfig {
 	/**
 	 * @deprecated 非推奨。将来削除する予定。
+	 * autoSendEventName の使用が正となる。autoSendEventName が存在する場合にこの値は無視される。
 	 */
 	autoSendEvents?: string;
 	autoSendEventName?: string;


### PR DESCRIPTION
## 修正内容

**sandbox.config.jsの `autoSendEvents` をdeprecatedとする。**

- `autoSendEvents` が利用された場合、console.logにてdeprecatedeである 警告メッセージを表示し、 `autoSendEventName` の利用を推奨する。
- 互換性保持のため、`autoSendEvents` のパスは残す