### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@3.0.0-beta.2, engineFiles@2.1.38, engineFiles@1.1.14)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": "0.4.1",
-    "@akashic/headless-driver": "1.0.2",
+    "@akashic/headless-driver": "1.1.0",
     "@akashic/trigger": "0.1.7",
     "chalk": "2.4.2",
     "chokidar": "2.1.8",


### PR DESCRIPTION
※本PRは自動生成されたものです。

**※headles-driverのマイナーバージョンが更新されたので、修正箇所を確認してください。**

# akashic-cli-serve
* engineFilesV3: 3.0.0-beta.2
* engineFilesV2: 2.1.38
* engineFilesV1: 1.1.14
* headless-driver: 1.1.0
* akashic-gameview-web: 2.0.0
* amflow: ~1.0.0
* playlog: ~2.0.0
* trigger: 0.1.7

