### PR TITLE
akashic-cli-xxx を revnovate の bump 対象から外す対応

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,17 @@
   "version": "independent",
   "command": {
     "publish": {
+      "ignoreChanges": [
+        "**/spec/**",
+        "**/.storybook/**",
+        "package*.json",
+        "jest.config.js",
+        "tslint.json",
+        ".gitignore",
+        ".npmrc",
+        ".eslintignore",
+        ".eslintrc.js"
+      ],
       "allowBranch": [
         "master"
       ]


### PR DESCRIPTION
### 概要
* renovateの更新やテストコードのみの更新によって、akashic-cli-xxx のバージョンが上がってしまう(また場合によっては他パッケージのマイナーバージョンアップに巻き込まれてしまう)という問題が発生しているので、これを解決するためにpacage.json、テストコード、設定ファイルをbump upの対象から外す対応を行いました。
  * package.jsonについてはpublishされなくなるわけではなく、src以下などのプロダクトコードが追加・変更等された時に一緒にpublishされます。package.jsonのみの修正の時package.jsonはpublishされませんが、その時にプロダクトに影響はない(影響ある時はプロダクトコード自体修正しているため)と判断してこの対応を行いましたが、影響があるケースがある場合は教えていただきたいです。

### やったこと
* lerna.jsonのignoreChangesにpacage.json、テストコード、設定ファイル等を追加