### PR TITLE
Fix installation of tgz file with akshic-cli-install

### DIFF
--- a/packages/akashic-cli-install/spec/installSpec.js
+++ b/packages/akashic-cli-install/spec/installSpec.js
@@ -74,7 +74,7 @@ describe("install()", function () {
 					name: "dummy",
 					version: "0.0.0",
 					main: "main.js",
-					dependencies: { "dummyChild": "*" }
+					dependencies: { "dummy": "*" }
 				}),
 				"main.js": [
 					"require('./foo');",

--- a/packages/akashic-cli-install/spec/installSpec.js
+++ b/packages/akashic-cli-install/spec/installSpec.js
@@ -74,9 +74,7 @@ describe("install()", function () {
 					name: "dummy",
 					version: "0.0.0",
 					main: "main.js",
-					dependencies: {
-						"dummy": "*",
-					}
+					dependencies: { "dummyChild": "*" }
 				}),
 				"main.js": [
 					"require('./foo');",
@@ -126,6 +124,7 @@ describe("install()", function () {
 		var dummyNpm = {
 			install: function (names) {
 				if (fs.existsSync("./somedir/game.json")) {
+					// restore()で前のデータが消えるので保持し後でマージする。
 					gameJson = JSON.parse(fs.readFileSync("./somedir/game.json", "utf-8").toString());
 				}
 				mockfs.restore(); // 同keyを含むObjectをmockし直すためrestore()を実行

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -71,6 +71,7 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 			.then(() => param.logger.info("Done!"))
 			.then(restoreDirectory, restoreDirectory);
 	}
+
 	const beforePackageJson = JSON.parse(fs.readFileSync(path.join(param.cwd, "package.json"), "utf-8"));
 	const beforeKeys = beforePackageJson.dependencies ? Object.keys(beforePackageJson.dependencies) : [];
 	const gameJsonPath = path.join(process.cwd(), "game.json");


### PR DESCRIPTION
## 内容

akashic-cli-install で `npm pack`で生成されたtgzファイルをインストールするとエラーとなる問題の解決。
(e.g. `akashic install ./anyModule.tgz`)

原因が、指定されたtgzファイルのパスが browserifyへ渡り、browserifyでエラーとなっている。

対応として、`npm i` の前と後の `package.json` の dependencies の差分を取得し、その差分のモジュール名を後続の処理に渡すように修正


動作確認として、モジュールAのtgzのファイルパス、モジュールBのモジュール名で実行し、game.json, package.jsonが更新されることを確認。
(e.g. `akashic install ../anyModule.tgz @akashic/bmpfont-generator`)

