### PR TITLE
Add externalValue to the argument of RunnerManager#createRunner()

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@akashic/akashic-cli-commons": "0.5.3",
     "@akashic/headless-driver": "1.1.4",
+
     "@akashic/trigger": "0.1.7",
     "chalk": "2.4.2",
     "chokidar": "2.1.8",

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -51,28 +51,11 @@ export class RunnerStore {
 			amflow: params.amflow,
 			executionMode: params.isActive ? "active" : "passive",
 			playToken: params.token,
-			allowedUrls
+			allowedUrls,
+			externalValue: this.gameExternalFactory()
 		});
 		const runner = this.runnerManager.getRunner(runnerId);
-		const startRunnerPromise = this.runnerManager.startRunner(runner.runnerId);
-
-		// TODO headless-driver に game.external を与える機能を加え、それを利用する。
-		//
-		// 以下は無理やり game.external を与える暫定実装。startRunner() を await すると
-		// 間に合わない (エントリポイントどころか最初のシーンの loaded すら終わってしまう) ので、
-		// ここ (runner.driver が生成されている唯一のタイミング) でハンドラをかけている。
-		if (runner.engineVersion === "1") {
-			(runner as any).driver.gameCreatedTrigger.handle((game: any) => {
-				game.external = { ...this.gameExternalFactory(), ...game.external };
-				return true;
-			});
-		} else {
-			(runner as any).driver.gameCreatedTrigger.addOnce((game: any) => {
-				game.external = { ...this.gameExternalFactory(), ...game.external };
-			});
-		}
-
-		const game = await startRunnerPromise;
+		await this.runnerManager.startRunner(runner.runnerId);
 		this.onRunnerCreate.fire({ playId: params.playId, runnerId, isActive: params.isActive });
 		this.playIdTable[runnerId] = params.playId;
 		return runner;


### PR DESCRIPTION
## 内容

headless-driverにgame.externalを与える機能が 実装されたため、`RunnerStore#createAndStartRunner()` で game.external に代入していた箇所を削除し修正。

関連PR
headless-driver: https://github.com/akashic-games/akashic-cli/pull/294