### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@3.0.0-beta.5, engineFiles@2.1.40, engineFiles@1.1.14)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": "0.5.8",
-    "@akashic/headless-driver": "1.1.15",
+    "@akashic/headless-driver": "1.1.16",
     "@akashic/trigger": "1.0.0",
     "chalk": "2.4.2",
     "chokidar": "2.1.8",


### PR DESCRIPTION
※本PRは自動生成されたものです。

# akashic-cli-serve
* engineFilesV3: 3.0.0-beta.5
* engineFilesV2: 2.1.40
* engineFilesV1: 1.1.14
* headless-driver: 1.1.16
* akashic-gameview-web: 2.1.0
* amflow: ~1.0.0
* playlog: ~2.0.0
* trigger: 1.0.0

