### PR TITLE
Add specification of assets directory in scan

### DIFF
--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1812,7 +1812,6 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["text/foo/textdata"]).not.toBe(undefined);
 		expect(conf.getContent().assets["script/foo/script"]).not.toBe(undefined);
 
-		conf._resolveAssetIdsFromPath = false;
 		conf._assetIdResolveMode = "basename";
 		await conf.scanAssets({scanDirectoryTable, extension});
 		expect(conf.getContent().assets["dummy"]).not.toBe(undefined);
@@ -1905,8 +1904,8 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["script"]).not.toBe(undefined);
 
 		conf._forceUpdateAssetIds = true;
-		conf._resolveAssetIdsFromPath = false;
 		conf._includeExtensionToAssetId = true;
+		conf._assetIdResolveMode = "basename";
 		await conf.scanAssets({scanDirectoryTable, extension});
 		expect(conf.getContent().assets["dummy.png"]).not.toBe(undefined);
 		expect(conf.getContent().assets["se"]).not.toBe(undefined);
@@ -1915,7 +1914,6 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["script.js"]).not.toBe(undefined);
 
 		conf._forceUpdateAssetIds = true;
-		conf._resolveAssetIdsFromPath = true;
 		conf._includeExtensionToAssetId = true;
 		conf._assetIdResolveMode = "path";
 		await conf.scanAssets({scanDirectoryTable, extension});
@@ -1926,7 +1924,6 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["script/foo/script.js"]).not.toBe(undefined);
 
 		conf._forceUpdateAssetIds = true;
-		conf._resolveAssetIdsFromPath = false;
 		conf._includeExtensionToAssetId = false;
 		conf._assetIdResolveMode = "basename";
 		await conf.scanAssets({scanDirectoryTable, extension});
@@ -2026,7 +2023,6 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets[genhashPath("assets/text/foo/textdata.txt")]).toBeDefined();
 
 		conf._forceUpdateAssetIds = true;
-		conf._resolveAssetIdsFromPath = true;
 		conf._includeExtensionToAssetId = true;
 		conf._assetIdResolveMode = "path";
 		await conf.scanAssetsDir();
@@ -2036,7 +2032,6 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets["assets/text/foo/textdata.txt"]).toBeDefined();
 
 		conf._forceUpdateAssetIds = true;
-		conf._resolveAssetIdsFromPath = false;
 		conf._includeExtensionToAssetId = false;
 		conf._assetIdResolveMode = "basename";
 		await conf.scanAssetsDir();
@@ -2044,6 +2039,5 @@ describe("Configuration", function () {
 		expect(conf.getContent().assets[genhashPath("assets/audio/some/se")]).toBeDefined();
 		expect(conf.getContent().assets[genhashPath("assets/script/foo/script.js")]).toBeDefined();
 		expect(conf.getContent().assets[genhashPath("assets/text/foo/textdata.txt")]).toBeDefined();
-
 	});
 });

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -6,7 +6,6 @@ import { getAudioDuration } from "./getAudioDuration";
 import { imageSize } from "image-size";
 import { ISize } from "image-size/dist/types/interface";
 import { AssetScanDirectoryTable, AssetExtension } from "./scan";
-import { file } from "mock-fs";
 
 export function _isImageFilePath(p: string): boolean { return /.*\.(png|gif|jpg|jpeg)$/i.test(p); }
 export function _isAudioFilePath(p: string): boolean { return /.*\.(ogg|aac|mp4)$/i.test(p); }

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -120,9 +120,10 @@ export class Configuration extends cmn.Configuration {
 			const files: string[] = readdirRecursive(path.join(this._basepath, "assets/"));
 			const audioPaths: string[] = [];
 			// scanAssets() で最後に実行されるため、assets ディレクトリでは mode が path でなければ mode を `hash` とする
+			// TODO: _assetIdResolveMode は引数として指定できるようにする
 			this._assetIdResolveMode = this._assetIdResolveMode === "path" ? "path" : "hash";
+			const revmap = cmn.Util.invertMap(this._content.assets, "path");
 			files.forEach((file) => {
-				const revmap = cmn.Util.invertMap(this._content.assets, "path");
 				const targetDir = path.join("assets/", path.dirname(file));
 
 				if (_isImageFilePath(file)) {
@@ -130,14 +131,13 @@ export class Configuration extends cmn.Configuration {
 				} else if (_isAudioFilePath(file)) {
 					audioPaths.push(path.join("assets/", file));
 				} else if (_isScriptAssetPath(file)) {
-					this._registerXXXAsset( targetDir + "/" + path.basename(file), revmap, "script");
+					this._registerXXXAsset(targetDir + "/" + path.basename(file), revmap, "script");
 				} else {
 					// image, auido, script 以外は text とする
 					this._registerXXXAsset(targetDir + "/" + path.basename(file), revmap, "text");
 				}
 			});
 
-			const revmap = cmn.Util.invertMap(this._content.assets, "path");
 			this._makeDurationMap(audioPaths, this._content.assets, revmap).then((durationMap: DurationMap) => {
 				for (var current in durationMap) {
 					if (!current) continue;
@@ -187,7 +187,7 @@ export class Configuration extends cmn.Configuration {
 		var assets = this._content.assets || (this._content.assets = {});
 		var revmap = cmn.Util.invertMap(assets, "path");
 		files.filter(filter).forEach((f: string) => {
-			this._registerXXXAsset( path.join(dir, f), revmap, type);
+			this._registerXXXAsset(path.join(dir, f), revmap, type);
 		});
 	}
 

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -208,7 +208,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(unixPath);
+						newAssetId = this._generateAssetsDirId(unixPath, revmap);
 					} else {
 						newAssetId = basename;
 						if (!this._includeExtensionToAssetId)
@@ -238,7 +238,7 @@ export class Configuration extends cmn.Configuration {
 		if (this._assetIdResolveMode === "path") {
 			aid = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 		} else if (this._assetIdResolveMode === "hash") {
-			aid = this._generateAssetsDirId(unixPath);
+			aid = this._generateAssetsDirId(unixPath, revmap);
 		} else {
 			aid = basename;
 			_assertAssetFilenameValid(aid);
@@ -270,7 +270,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(f), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(durationInfo.path);
+						newAssetId = this._generateAssetsDirId(durationInfo.path, revmap);
 					} else {
 						newAssetId = basename;
 					}
@@ -299,7 +299,7 @@ export class Configuration extends cmn.Configuration {
 		if (this._assetIdResolveMode === "path") {
 			aid = cmn.Util.makeUnixPath(path.join(path.dirname(f), basename));
 		} else if (this._assetIdResolveMode === "hash") {
-			aid = this._generateAssetsDirId(f);
+			aid = this._generateAssetsDirId(f, revmap);
 		} else {
 			aid = basename;
 			_assertAssetFilenameValid(aid);
@@ -327,7 +327,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(unixPath);
+						newAssetId = this._generateAssetsDirId(unixPath, revmap);
 					} else {
 						newAssetId = basename;
 						if (!this._includeExtensionToAssetId)
@@ -346,7 +346,7 @@ export class Configuration extends cmn.Configuration {
 			if (this._assetIdResolveMode === "path") {
 				aid = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 			} else if (this._assetIdResolveMode === "hash") {
-				aid = this._generateAssetsDirId(unixPath);
+				aid = this._generateAssetsDirId(unixPath, revmap);
 			} else {
 				aid = basename;
 				_assertAssetFilenameValid(aid);
@@ -549,10 +549,15 @@ export class Configuration extends cmn.Configuration {
 	}
 
 	/**
-	 * assets ディレクトリ配下のファイルの アッセトID を生成する
+	 * assets ディレクトリ配下のファイルの アッセトID を生成する。
+	 * 既に同 ID が存在する場合は生成は行わない。
 	 * `asset:xxxxxx` の形式とする。
 	 */
-	private  _generateAssetsDirId(filePath: string): string {
+	private _generateAssetsDirId(filePath: string, revmap: {[key: string]: string[]}): string {
+		if (revmap[filePath] && !this._isAssetsDir(revmap[filePath][0])) {
+			return revmap[filePath][0];
+		}
+
 		const hashPath = cmn.Renamer.hashFilepath(filePath, 6);
 		return "asset:" + path.basename(hashPath, path.extname(filePath));
 	}

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -6,6 +6,7 @@ import { getAudioDuration } from "./getAudioDuration";
 import { imageSize } from "image-size";
 import { ISize } from "image-size/dist/types/interface";
 import { AssetScanDirectoryTable, AssetExtension } from "./scan";
+import { file } from "mock-fs";
 
 export function _isImageFilePath(p: string): boolean { return /.*\.(png|gif|jpg|jpeg)$/i.test(p); }
 export function _isAudioFilePath(p: string): boolean { return /.*\.(ogg|aac|mp4)$/i.test(p); }
@@ -208,7 +209,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(unixPath, revmap);
+						newAssetId = this._generateAssetsDirId(unixPath);
 					} else {
 						newAssetId = basename;
 						if (!this._includeExtensionToAssetId)
@@ -238,7 +239,7 @@ export class Configuration extends cmn.Configuration {
 		if (this._assetIdResolveMode === "path") {
 			aid = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 		} else if (this._assetIdResolveMode === "hash") {
-			aid = this._generateAssetsDirId(unixPath, revmap);
+			aid = this._generateAssetsDirId(unixPath);
 		} else {
 			aid = basename;
 			_assertAssetFilenameValid(aid);
@@ -270,7 +271,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(f), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(durationInfo.path, revmap);
+						newAssetId = this._generateAssetsDirId(durationInfo.path);
 					} else {
 						newAssetId = basename;
 					}
@@ -299,7 +300,7 @@ export class Configuration extends cmn.Configuration {
 		if (this._assetIdResolveMode === "path") {
 			aid = cmn.Util.makeUnixPath(path.join(path.dirname(f), basename));
 		} else if (this._assetIdResolveMode === "hash") {
-			aid = this._generateAssetsDirId(f, revmap);
+			aid = this._generateAssetsDirId(f);
 		} else {
 			aid = basename;
 			_assertAssetFilenameValid(aid);
@@ -327,7 +328,7 @@ export class Configuration extends cmn.Configuration {
 					if (this._assetIdResolveMode === "path") {
 						newAssetId = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 					} else if (this._assetIdResolveMode === "hash") {
-						newAssetId = this._generateAssetsDirId(unixPath, revmap);
+						newAssetId = this._generateAssetsDirId(unixPath);
 					} else {
 						newAssetId = basename;
 						if (!this._includeExtensionToAssetId)
@@ -346,7 +347,7 @@ export class Configuration extends cmn.Configuration {
 			if (this._assetIdResolveMode === "path") {
 				aid = cmn.Util.makeUnixPath(path.join(path.dirname(unixPath), basename));
 			} else if (this._assetIdResolveMode === "hash") {
-				aid = this._generateAssetsDirId(unixPath, revmap);
+				aid = this._generateAssetsDirId(unixPath);
 			} else {
 				aid = basename;
 				_assertAssetFilenameValid(aid);
@@ -549,23 +550,13 @@ export class Configuration extends cmn.Configuration {
 	 * 別ファイルで既に同 ID が存在する場合は、ファイルにランダムな1文字を末尾足して ID を生成する。
 	 * `asset:xxxxxx` の形式とする。
 	 */
-	private _generateAssetsDirId(filePath: string, revmap: {[key: string]: string[]}): string {
+	private _generateAssetsDirId(filePath: string): string {
 		let hashId = "asset:" + path.basename(cmn.Renamer.hashFilepath(filePath, 6), path.extname(filePath));
-		while (this.isDuplicateHashId(filePath, hashId, revmap) ) {
+		while (!!this._content.assets[hashId] && this._content.assets[hashId].path !== filePath) {
 			filePath += Math.random().toString(32).substring(2, 3);
 			hashId = "asset:" + path.basename(cmn.Renamer.hashFilepath(filePath, 6), path.extname(filePath));
 		}
 		return hashId;
-	}
-
-	private isDuplicateHashId(filePath: string, hashId: string, revmap: { [key: string]: string[] }): boolean {
-		let ret = false;
-		Object.keys(revmap).forEach((k) => {
-			if (k && k !== filePath && !ret) {
-				ret = revmap[k].some(v => v === hashId);
-			}
-		});
-		return ret;
 	}
 }
 


### PR DESCRIPTION
## 概要

- `akashic-cli-scan` で  `assets/` ディレクトリを特別扱いとする。
  - `scan asset` された時、`assets/` ディレクトリ配下にある image, audio, scripts, text の全てのファイルをscanする。
  -  アセットID は assets_golup5vr のような `assets_xxxxx` 形式として自動生成され保証されないものとします。