### PR TITLE
Add omitUnbundledJs parameter of export

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -13,5 +13,5 @@ export interface CliConfigExportHtml {
 	injects?: string[];
 	atsumaru?: boolean;
 	autoSendEvents?: string | boolean;
-	preserveUnbundleScript?: boolean;
+	unbundled?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -13,5 +13,5 @@ export interface CliConfigExportHtml {
 	injects?: string[];
 	atsumaru?: boolean;
 	autoSendEvents?: string | boolean;
-	preserveUnbundledScript?: boolean;
+	omitUnbundledJs?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -13,5 +13,5 @@ export interface CliConfigExportHtml {
 	injects?: string[];
 	atsumaru?: boolean;
 	autoSendEvents?: string | boolean;
-	unbundled?: boolean;
+	preserveUnbundledScript?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -13,4 +13,5 @@ export interface CliConfigExportHtml {
 	injects?: string[];
 	atsumaru?: boolean;
 	autoSendEvents?: string | boolean;
+	preserveUnbundleScript?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -9,5 +9,5 @@ export interface CliConfigExportZip {
 	babel?: boolean;
 	hashFilename?: number | boolean;
 	omitEmptyJs?: boolean;
-	preserveUnbundledScript?: boolean;
+	omitUnbundledJs?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -9,4 +9,5 @@ export interface CliConfigExportZip {
 	babel?: boolean;
 	hashFilename?: number | boolean;
 	omitEmptyJs?: boolean;
+	preserveUnbundleScript?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -9,5 +9,5 @@ export interface CliConfigExportZip {
 	babel?: boolean;
 	hashFilename?: number | boolean;
 	omitEmptyJs?: boolean;
-	preserveUnbundleScript?: boolean;
+	unbundled?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -9,5 +9,5 @@ export interface CliConfigExportZip {
 	babel?: boolean;
 	hashFilename?: number | boolean;
 	omitEmptyJs?: boolean;
-	unbundled?: boolean;
+	preserveUnbundledScript?: boolean;
 }


### PR DESCRIPTION
## 概要

export-html, export-zip に `omitUnbundledJs ` の追加。

`omitUnbundledJs ` は export-html の `--atsumaru`, export-zipの `--bundle`  オプションが指定された場合、デフォルトではバンドルされない js ファイルは出力されず game.json からも削除されるが、`omitUnbundledJs ` が真の時にはバンドルされない js ファイルは出力され game.json にも残る動作となる。 


**関連PR**
- export-zip:  https://github.com/akashic-games/akashic-cli/pull/341
- export-html: https://github.com/akashic-games/akashic-cli/pull/343