### PR TITLE
prohibit major update of dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "updateTypes": ["major"],
       "depTypeList": ["devDependencies"],
       "groupName": "dev dependencies"
+    },
+    {
+      "updateTypes": ["major"],
+      "depTypeList": ["dependencies"],
+      "enabled": false
     }
   ],
   "ignorePaths": [

--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,7 @@
     {
       "updateTypes": ["major"],
       "depTypeList": ["dependencies"],
-      "enabled": false
+      "draftPR": true
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
### 概要
* https://github.com/akashic-games/akashic-cli/pull/358 でdevDependenciesのモジュールのみrenovateでのメジャーバージョン更新が行われるよう対応しましたが、実際にはdenpendenciesのモジュールでもメジャーバージョン更新が行われていました。これはrenovate.jsonでメジャーバージョン更新に対する`enabled: false`が外れたためと考えられるので、dependenciesのメジャーバージョン更新に対して`enabled: false`を付与する対応を行いました