### PR TITLE
Add ServiceType

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -1,3 +1,5 @@
+import { ServiceType } from "../ServiceType";
+
 export interface CliConfigExportZip {
 	cwd?: string;
 	quiet?: boolean;
@@ -10,5 +12,5 @@ export interface CliConfigExportZip {
 	hashFilename?: number | boolean;
 	omitEmptyJs?: boolean;
 	omitUnbundledJs?: boolean;
-	targetService?: string;
+	targetService?: ServiceType;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -1,9 +1,11 @@
+import { ServiceType } from "../ServiceType";
+
 export interface CliConfigServe {
 	hostname?: string;
 	port?: number;
 	autoStart?: boolean;
 	verbose?: boolean;
-	targetService?: string;
+	targetService?: ServiceType;
 	debugPlaylog?: string;
 	debugUntrusted?: boolean;
 	debugProxyAudio?: boolean;

--- a/packages/akashic-cli-commons/src/GameConfiguration.ts
+++ b/packages/akashic-cli-commons/src/GameConfiguration.ts
@@ -1,3 +1,5 @@
+import { ServiceType } from "./ServiceType";
+
 /**
  * 各アセット定義。
  * game.json の "assets" の各要素の型。
@@ -80,6 +82,6 @@ export interface ExportZipInfo {
 		babel?: boolean;
 		hashFilename?: number | boolean;
 		omitEmptyJs?: boolean;
-		targetService?: string;
+		targetService?: ServiceType;
 	};
 }

--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -4,5 +4,4 @@
  * atsumaru: RPGアツマール
  * none: サービスなし
  */
-
 export type ServiceType = "nicolive" | "atsumaru" | "none" ;

--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -1,7 +1,8 @@
-/**
+/*
  * 対象のサービス
  * nicolive: ニコニコ生放送
  * atsumaru: RPGアツマール
  * none: サービスなし
  */
-export type ServiceType = "nicolive" | "atsumaru" | "none" ;
+export const SERVICE_TYPES = ["nicolive", "atsumaru", "none"] as const;
+export type ServiceType = typeof SERVICE_TYPES[number];

--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -1,0 +1,8 @@
+/**
+ * 対象のサービス
+ * nicolive: ニコニコ生放送
+ * atsumaru: RPGアツマール
+ * none: サービスなし
+ */
+
+export type ServiceType = "nicolive" | "atsumaru" | "none" ;

--- a/packages/akashic-cli-commons/src/index.ts
+++ b/packages/akashic-cli-commons/src/index.ts
@@ -35,8 +35,8 @@ import * as Renamer from "./Renamer";
 export { Renamer };
 import * as LintUtil from "./LintUtil";
 export { LintUtil };
-import { ServiceType } from "./ServiceType";
-export { ServiceType };
+import { ServiceType, SERVICE_TYPES } from "./ServiceType";
+export { ServiceType, SERVICE_TYPES };
 
 import { CliConfigExportHtml } from "./CliConfig/CliConfigExportHtml";
 export { CliConfigExportHtml };

--- a/packages/akashic-cli-commons/src/index.ts
+++ b/packages/akashic-cli-commons/src/index.ts
@@ -35,6 +35,8 @@ import * as Renamer from "./Renamer";
 export { Renamer };
 import * as LintUtil from "./LintUtil";
 export { LintUtil };
+import { ServiceType } from "./ServiceType";
+export { ServiceType };
 
 import { CliConfigExportHtml } from "./CliConfig/CliConfigExportHtml";
 export { CliConfigExportHtml };


### PR DESCRIPTION
## 概要

`export-zip` や `serve` の `--target-service` オプションで使用する `ServiceType` を `akashic-cli-commons` に持つように変更します。

**関連PR**
export-zip: https://github.com/akashic-games/akashic-cli/pull/435