### PR TITLE
Changed to use package-lock.json in install and uninstall

### DIFF
--- a/packages/akashic-cli-install/spec/installSpec.js
+++ b/packages/akashic-cli-install/spec/installSpec.js
@@ -11,17 +11,14 @@ describe("install()", function () {
 	it("handles npm install failure", function (done) {
 		mockfs({});
 		var logger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
-		var shrinkwrapCalled = false;
 		var dummyNpm = {
-			install: function (names) { return Promise.reject("InstallFail:" + names); },
-			shrinkwrap: function (names) { shrinkwrapCalled = true; return Promise.resolve(); }
+			install: function (names) { return Promise.reject("InstallFail:" + names); }
 		};
 		Promise.resolve()
 			.then(() => promiseInstall({ moduleNames: ["bar"], logger: logger, debugNpm: dummyNpm }))
 			.then(done.fail)
 			.catch((err) => {
 				expect(err).toBe("InstallFail:bar");
-				expect(shrinkwrapCalled).toBe(false);
 			})
 			.then(() => cmn.ConfigurationFile.read("./game.json", logger))
 			.then((content) => {
@@ -104,7 +101,6 @@ describe("install()", function () {
 		};
 
 		mockfs(mockFsContent);
-		var shrinkwrapCalled = false;
 		var dummyNpm = {
 			install: function (names) {
 				names = (names instanceof Array) ? names : [names];
@@ -114,10 +110,6 @@ describe("install()", function () {
 				});
 
 				mockfs(mockFsContent.somedir);
-				return Promise.resolve();
-			},
-			shrinkwrap: function () {
-				shrinkwrapCalled = true;
 				return Promise.resolve();
 			}
 		};
@@ -144,8 +136,6 @@ describe("install()", function () {
 					"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
 				);
 				warnLogs = []; // 初期化
-				expect(shrinkwrapCalled).toBe(true);
-				shrinkwrapCalled = false;
 			})
 			.then(() => promiseInstall({ moduleNames: ["dummy2@1.0.1"], cwd: "./somedir", plugin: 12, logger: logger, debugNpm: dummyNpm }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
@@ -168,7 +158,6 @@ describe("install()", function () {
 					"dummy": "node_modules/dummy/main.js",
 					"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js"
 				});
-				expect(shrinkwrapCalled).toBe(true);
 				warnLogs = []; // 初期化
 			})
 			.then(() => promiseInstall({ moduleNames: ["noOmitPackagejson@0.0.0"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, noOmitPackagejson: true }))
@@ -249,8 +238,7 @@ describe("install()", function () {
 				++installCallCount;
 				// npm install (引数なし) が呼ばれることを確認するため、引数があったらreject。
 				return names ? Promise.reject() : Promise.resolve();
-			},
-			shrinkwrap: function () { return Promise.resolve(); }
+			}
 		};
 		Promise.resolve()
 			.then(() => promiseInstall({ cwd: ".", logger: logger, debugNpm: dummyNpm }))

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -87,8 +87,7 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 						return npm.link(param.moduleNames);
 					} else {
 						return Promise.resolve()
-							.then(() => npm.install(param.moduleNames))
-							.then(() => npm.shrinkwrap());
+							.then(() => npm.install(param.moduleNames));
 					}
 				})
 				.then(() => {

--- a/packages/akashic-cli-uninstall/spec/src/uninstallSpec.ts
+++ b/packages/akashic-cli-uninstall/spec/src/uninstallSpec.ts
@@ -15,10 +15,8 @@ describe("uninstall()", function () {
 
 	it("handles npm failure", (done: any) => {
 		mockfs({});
-		var shrinkwrapCalled = false;
 		class DummyNpm extends cmn.PromisedNpm {
 			uninstall(names?: string[]) { return Promise.reject("UninstallFail:" + names); }
-			shrinkwrap(names?: string[]) { shrinkwrapCalled = true; return Promise.resolve(); }
 		}
 		var logger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 		Promise.resolve()
@@ -92,12 +90,10 @@ describe("uninstall()", function () {
 		class DummyNpm extends cmn.PromisedNpm {
 			uninstallLog: string[][];
 			unlinkLog: string[][];
-			shrinkwrapCount: number;
 			constructor() {
 				super({ logger });
 				this.uninstallLog = [];
 				this.unlinkLog = [];
-				this.shrinkwrapCount = 0;
 			}
 			uninstall(names?: string[]) {
 				this.uninstallLog.push(names);
@@ -115,7 +111,6 @@ describe("uninstall()", function () {
 				mockfs(mockfsContent.testdir.foo);
 				return Promise.resolve();
 			}
-			shrinkwrap(names?: string[]) { ++this.shrinkwrapCount; return Promise.resolve(); }
 		}
 		var dummyNpm = new DummyNpm();
 
@@ -130,7 +125,6 @@ describe("uninstall()", function () {
 			.then(() => cmn.ConfigurationFile.read("./testdir/foo/game.json", logger))
 			.then((content: cmn.GameConfiguration) => {
 				expect(dummyNpm.uninstallLog).toEqual([["foo"]]);
-				expect(dummyNpm.shrinkwrapCount).toBe(1);
 				var globalScripts = content.globalScripts;
 				expect(globalScripts).toEqual([
 					"node_modules/buzz/main.js",
@@ -153,7 +147,6 @@ describe("uninstall()", function () {
 			.then((content: cmn.GameConfiguration) => {
 				expect(dummyNpm.uninstallLog).toEqual([["foo"]]);
 				expect(dummyNpm.unlinkLog).toEqual([["buzz"]]);
-				expect(dummyNpm.shrinkwrapCount).toBe(1);  // unlink
 				var globalScripts = content.globalScripts;
 				expect(globalScripts).toEqual([]);
 				var moduleMainScripts = content.moduleMainScripts;

--- a/packages/akashic-cli-uninstall/src/uninstall.ts
+++ b/packages/akashic-cli-uninstall/src/uninstall.ts
@@ -67,8 +67,7 @@ export function promiseUninstall(param: UninstallParameterObject): Promise<void>
 						return npm.unlink(param.moduleNames);
 					} else {
 						return Promise.resolve()
-							.then(() => npm.uninstall(param.moduleNames))
-							.then(() => npm.shrinkwrap());
+							.then(() => npm.uninstall(param.moduleNames));
 					}
 				})
 				.then(() => {


### PR DESCRIPTION
## 概要

akashic-install, uninstall で `npm-shrinkwrap.json` をやめ `package-lock.json` を使用するよう変更します。

- `npm-shrinkwrap.json`, `package-lock.json` 共にロックファイルですが、 npm 5.x.x (Node v8バンドル)以降は`package-lock.json` が標準となっています。
