### PR TITLE
fix to be able to build and test

### DIFF
--- a/packages/akashic-cli-init/templates-src-v3/typescript-base/package.json
+++ b/packages/akashic-cli-init/templates-src-v3/typescript-base/package.json
@@ -15,9 +15,9 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@akashic/akashic-cli-export-html": "~0.7.57",
-    "@akashic/akashic-cli-export-zip": "~0.6.43",
-    "@akashic/akashic-cli-scan": "~0.5.38",
+    "@akashic/akashic-cli-export-html": "0.7.57",
+    "@akashic/akashic-cli-export-zip": "0.6.43",
+    "@akashic/akashic-cli-scan": "0.5.38",
     "@akashic/akashic-engine": "~3.0.0-beta.27",
     "@akashic/akashic-sandbox": "~0.16.18",
     "@types/jest": "26.0.9",

--- a/packages/akashic-cli-init/templates-src/typescript-base/package.json
+++ b/packages/akashic-cli-init/templates-src/typescript-base/package.json
@@ -16,9 +16,9 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@akashic/akashic-cli-export-html": "~0.7.57",
-    "@akashic/akashic-cli-export-zip": "~0.6.43",
-    "@akashic/akashic-cli-scan": "~0.5.38",
+    "@akashic/akashic-cli-export-html": "0.7.57",
+    "@akashic/akashic-cli-export-zip": "0.6.43",
+    "@akashic/akashic-cli-scan": "0.5.38",
     "@akashic/akashic-engine": "~2.6.4",
     "@akashic/akashic-sandbox": "~0.16.18",
     "@types/jest": "26.0.9",


### PR DESCRIPTION
### 概要
現在の`akashic-cli-~`の最新版は壊れているため再publishが必要なのですが、現状のままだとakashic-cli-initのテンプレートが`akashic-cli-~`の最新版をインストールしてしまってpublish時にビルドが落ちてしまうため、ビルドを通すために最新版の1つ前のものを指定するように修正しました。