### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@3.0.0-beta.9, engineFiles@2.1.47, engineFiles@1.1.16)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": "0.5.39",
-    "@akashic/headless-driver": "1.2.11",
+    "@akashic/headless-driver": "1.2.12",
     "@akashic/trigger": "1.0.0",
     "chalk": "4.1.0",
     "chokidar": "3.4.2",
@@ -79,7 +79,7 @@
     "whatwg-fetch": "3.4.1"
   },
   "optionalDependencies": {
-    "@akashic/akashic-gameview-web": "2.1.1"
+    "@akashic/akashic-gameview-web": "2.1.2"
   },
   "files": [
     "package.json",


### PR DESCRIPTION
※本PRは自動生成されたものです。

# akashic-cli-serve
* engineFilesV3: 3.0.0-beta.9
* engineFilesV2: 2.1.47
* engineFilesV1: 1.1.16
* headless-driver: 1.2.12
* akashic-gameview-web: 2.1.2
* amflow: ~3.0.0
* playlog: ~3.1.0
* trigger: 1.0.0

