### PR TITLE
Fix server-external-script option in serve

### DIFF
--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -104,7 +104,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 	let gameExternalFactory: () => any = () => undefined;
 	if (commander.serverExternalScript) {
 		try {
-			gameExternalFactory = require(path.join(process.cwd(), commander.serverExternalScript));
+			gameExternalFactory = require(path.resolve(commander.serverExternalScript));
 		} catch (e) {
 			getSystemLogger().error(`Failed to evaluating --server-external-script (${commander.serverExternalScript}): ${e}`);
 			process.exit(1);


### PR DESCRIPTION
## 概要

akashic-cli-serve の `--server-external-script` オプションで、絶対パスが渡された場合にエラーとなる問題を修正。