### PR TITLE
Fix highlight in entityTree

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
@@ -163,6 +163,7 @@ declare module agv {
 		_localDb: { [id: number]: ae.ELike };
 		focusingCamera?: ae.CameraLike;
 		vars: any;
+		_modified: boolean;
 		scene(): ae.SceneLike;
 		render(camera?: ae.CameraLike): void;
 		tick(advanceAge: boolean, omittedTickCount?: number): boolean;

--- a/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
@@ -163,7 +163,7 @@ declare module agv {
 		_localDb: { [id: number]: ae.ELike };
 		focusingCamera?: ae.CameraLike;
 		vars: any;
-		_modified: boolean;
+		_modified?: boolean; // AEv3 でのみ存在
 		scene(): ae.SceneLike;
 		render(camera?: ae.CameraLike): void;
 		tick(advanceAge: boolean, omittedTickCount?: number): boolean;

--- a/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
@@ -60,7 +60,6 @@ export class ServeGameContent {
 		game.render = function (camera?: ae.CameraLike) {
 			const gameModified = game._modified;
 			const ret = renderOriginal.apply(this, arguments);
-
 			if ("_modified" in game && !gameModified) return; // AEv3 は画面更新が不要ならなにもしない。
 
 			// エンティティハイライト描画

--- a/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
@@ -58,8 +58,10 @@ export class ServeGameContent {
 		const renderOriginal = game.render;
 		const self = this;
 		game.render = function (camera?: ae.CameraLike) {
-			if ("_modified" in game && !game._modified) return; // AEv3 は画面更新が不要ならなにもしない。
+			const gameModified = game._modified;
 			const ret = renderOriginal.apply(this, arguments);
+
+			if ("_modified" in game && !gameModified) return; // AEv3 は画面更新が不要ならなにもしない。
 
 			// エンティティハイライト描画
 			// TODO 子孫要素の包含矩形描画 (or サイズ 0 のエンティティの表示方法検討
@@ -102,8 +104,7 @@ export class ServeGameContent {
 			return;
 		this._highlightedEntityId = eid;
 		if (this._game) {
-			// AEv3では _modified が false の場合は game#render() で画面更新しないため、2回目以降のハイライトが `CanvasRenderingContext2D#restore` により黒くなる。
-			// _modified を true に設定し、既存オブジェクトを描画させることでハイライトが黒くなる事象を回避する。
+			// AEv3 では _modified フラグが false の場合 render() が画面更新をスキップするため、 true を設定して必ず描画させる。
 			if ("_modified" in this._game)
 				this._game._modified = true;
 			this._game.render();  // tick が止まっているとrender()が来ないので明示的に呼ぶ


### PR DESCRIPTION
## 概要

v3 コンテンツのエンティティ検索のハイライトが 2回目以降は黒の fillRect となる問題の修正。
(インスタンスをポーズし、entityTree にて各エンティティにマウスオーバすると2回目以降に黒い fillRect で描画される。)

**原因**
AEv3 の場合、`game._modified` が false の場合、`Game#render()` は画面更新せず早期 return となる。
そのため、1回目にハイライトした fillRect を描画した後に2回目以降のハイライトを描画しようとすると、
1回目のハイライト描画の終わりの処理で CanvasRenderingContext2D#restore にて復元されているため fillStyle にデフォルトの黒が設定されてしまうためでした。
(pdi-browser の restore() で currentStyle が context と合っていない問題は別タスクで修正します。)

**修正**
AEv3の場合は、ハイライト前に `game._modified` を true に設定してから `game.render()` を呼ぶように修正。