### PR TITLE
Fix akashic-install does not warn moduleMainScripts in AEv3

### DIFF
--- a/packages/akashic-cli-install/src/Configuration.ts
+++ b/packages/akashic-cli-install/src/Configuration.ts
@@ -34,7 +34,7 @@ export class Configuration extends cmn.Configuration {
 		this._logger.info("Adding file paths to moduleMainScripts...");
 		var moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsonFiles);
 		if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
-			if (! this._content.moduleMainScripts && sandboxRuntime !== "3") {
+			if (! this._content.moduleMainScripts && (sandboxRuntime === "1" || sandboxRuntime === "2")) {
 				this._logger.warn(
 					"Newly added the moduleMainScripts property to game.json." +
 					"This property, introduced by akashic-cli@>=1.12.2, is NOT supported by older versions of Akashic Engine." +

--- a/packages/akashic-cli-install/src/Configuration.ts
+++ b/packages/akashic-cli-install/src/Configuration.ts
@@ -30,11 +30,11 @@ export class Configuration extends cmn.Configuration {
 		}
 	}
 
-	addToModuleMainScripts(packageJsonFiles: string[]): void {
+	addToModuleMainScripts(packageJsonFiles: string[], sandboxRuntime: string): void {
 		this._logger.info("Adding file paths to moduleMainScripts...");
 		var moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsonFiles);
 		if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
-			if (! this._content.moduleMainScripts) {
+			if (! this._content.moduleMainScripts && sandboxRuntime !== "3") {
 				this._logger.warn(
 					"Newly added the moduleMainScripts property to game.json." +
 					"This property, introduced by akashic-cli@>=1.12.2, is NOT supported by older versions of Akashic Engine." +

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -106,7 +106,7 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 					conf.addToGlobalScripts(filePaths);
 					const packageJsonFiles = cmn.NodeModules.listPackageJsonsFromScriptsPath(".", filePaths);
 					if (packageJsonFiles) {
-						const sandboxRuntime = conf._content.environment && conf._content.environment["sandbox-runtime"] ? conf._content.environment["sandbox-runtime"] : null;
+						const sandboxRuntime = conf._content.environment && conf._content.environment["sandbox-runtime"] ? conf._content.environment["sandbox-runtime"] : "1";
 						conf.addToModuleMainScripts(packageJsonFiles, sandboxRuntime);
 					}
 				})

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -106,7 +106,8 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 					conf.addToGlobalScripts(filePaths);
 					const packageJsonFiles = cmn.NodeModules.listPackageJsonsFromScriptsPath(".", filePaths);
 					if (packageJsonFiles) {
-						conf.addToModuleMainScripts(packageJsonFiles);
+						const sandboxRuntime = conf._content.environment["sandbox-runtime"];
+						conf.addToModuleMainScripts(packageJsonFiles, sandboxRuntime);
 					}
 				})
 				.then(() => {

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -106,7 +106,7 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 					conf.addToGlobalScripts(filePaths);
 					const packageJsonFiles = cmn.NodeModules.listPackageJsonsFromScriptsPath(".", filePaths);
 					if (packageJsonFiles) {
-						const sandboxRuntime = conf._content.environment["sandbox-runtime"];
+						const sandboxRuntime = conf._content.environment && conf._content.environment["sandbox-runtime"] ? conf._content.environment["sandbox-runtime"] : null;
 						conf.addToModuleMainScripts(packageJsonFiles, sandboxRuntime);
 					}
 				})


### PR DESCRIPTION
## 概要

v3 (sandbox-runtime: "3")コンテンツの場合、akashic-install の `moduleMainScripts` 追加時の警告をださないよう修正