### PR TITLE
fix: Invalid node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          -version: ${{ matrix.node }}
+          node-version: ${{ matrix.node }}
       - name: Cache node modules
         uses: actions/cache@v2
         env:


### PR DESCRIPTION
## このPullRequestが解決する内容
Github Actions のワークフロー内の `node-version` の値が誤っていたため修正します。