### PR TITLE
【akashic-cli-serve】内部コンポーネントの更新(engineFiles@3.0.0-beta.11, engineFiles@2.1.48, engineFiles@1.1.16)

### DIFF
--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": "0.5.54",
-    "@akashic/headless-driver": "1.3.4",
+    "@akashic/headless-driver": "1.4.0",
     "@akashic/trigger": "1.0.0",
     "chalk": "4.1.0",
     "chokidar": "3.4.3",


### PR DESCRIPTION
※本PRは自動生成されたものです。

**※headles-driverのマイナーバージョンが更新されたので、修正箇所を確認してください。**

# akashic-cli-serve
* engineFilesV3: 3.0.0-beta.11
* engineFilesV2: 2.1.48
* engineFilesV1: 1.1.16
* headless-driver: 1.4.0
* akashic-gameview-web: 3.0.0
* amflow: ~3.0.0
* playlog: ~3.1.0
* trigger: 1.0.0

