### PR TITLE
Add serve startup options

### DIFF
--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@akashic/akashic-cli-commons": {
-      "version": "0.5.54",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.5.54.tgz",
-      "integrity": "sha512-00P/sTZo+ToglA/Mx7Tq/aWDn/DaDTUSVhSXcoS8NnQaOlwUjJT61gH5NR8Khj9uzAAsndWYOAyxEhlzW78yTA==",
+      "version": "0.5.55",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.5.55.tgz",
+      "integrity": "sha512-kUe8aHLkH3lBKsskjewKRSLdlpH0U0gMXM7WbKXY90gYg0I6eJ8guRBlQEd4lYi9pkXK8SC8YIXKN//dt3haKQ==",
       "requires": {
         "browserify": "17.0.0",
         "eslint": "7.13.0",
@@ -1882,9 +1882,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -4847,6 +4847,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -7346,9 +7356,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -7406,6 +7416,11 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
           "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -8112,6 +8127,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filelist": {
       "version": "1.0.1",
@@ -11603,6 +11625,13 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -14502,11 +14531,6 @@
       "dev": true,
       "optional": true
     },
-    "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-    },
     "send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
@@ -16943,7 +16967,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -24,7 +24,7 @@
     "akashic-cli-serve": "./bin/run"
   },
   "dependencies": {
-    "@akashic/akashic-cli-commons": "0.5.54",
+    "@akashic/akashic-cli-commons": "../akashic-cli-commons",
     "@akashic/headless-driver": "1.5.0",
     "@akashic/trigger": "1.0.0",
     "chalk": "4.1.0",
@@ -61,6 +61,7 @@
     "mobx": "5.15.7",
     "mobx-react": "6.3.1",
     "node-fetch": "2.6.1",
+    "open": "7.3.0",
     "query-string": "6.13.7",
     "react": "16.14.0",
     "react-dom": "16.14.0",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -24,7 +24,7 @@
     "akashic-cli-serve": "./bin/run"
   },
   "dependencies": {
-    "@akashic/akashic-cli-commons": "../akashic-cli-commons",
+    "@akashic/akashic-cli-commons": "0.5.55",
     "@akashic/headless-driver": "1.5.0",
     "@akashic/trigger": "1.0.0",
     "chalk": "4.1.0",

--- a/packages/akashic-cli-serve/src/client/api/Subscriber.ts
+++ b/packages/akashic-cli-serve/src/client/api/Subscriber.ts
@@ -27,6 +27,7 @@ export const onRunnerResume = new Trigger<RunnerResumeTestbedEvent>();
 export const onClientInstanceAppear = new Trigger<ClientInstanceAppearTestbedEvent>();
 export const onClientInstanceDisappear = new Trigger<ClientInstanceDisappearTestbedEvent>();
 export const onBroadcast = new Trigger<any>();
+export const onDisconnect = new Trigger<void>();
 
 const socket = socketInstance();
 socket.on("playCreate", (arg: PlayCreateTestbedEvent) => onPlayCreate.fire(arg));
@@ -41,4 +42,4 @@ socket.on("runnerResume", (arg: RunnerResumeTestbedEvent) => onRunnerResume.fire
 socket.on("clientInstanceAppear", (arg: ClientInstanceAppearTestbedEvent) => onClientInstanceAppear.fire(arg));
 socket.on("clientInstanceDisappear", (arg: ClientInstanceDisappearTestbedEvent) => onClientInstanceDisappear.fire(arg));
 socket.on("playBroadcast", (arg: PlayBroadcastTestbedEvent) => onBroadcast.fire(arg));
-socket.on("reconnect", () => location.reload());
+socket.on("disconnect", () => onDisconnect.fire());

--- a/packages/akashic-cli-serve/src/client/api/socketInstance.ts
+++ b/packages/akashic-cli-serve/src/client/api/socketInstance.ts
@@ -1,6 +1,5 @@
 const socket = io("ws://" + window.location.host, {
-	reconnectionAttempts: 1800,
-	reconnectionDelay: 1000
+	reconnectionAttempts: 1
 });
 
 export function socketInstance(): SocketIOClient.Socket {

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -6,7 +6,7 @@ export class PlayOperator {
 
 	constructor(store: Store) {
 		this.store = store;
-		Subscriber.onDisconnect.add(this.closeSubWindows);
+		Subscriber.onDisconnect.add(this.closeSubWindowsIfNeeded);
 	}
 
 	togglePauseActive = (pauses: boolean): void => {
@@ -31,8 +31,8 @@ export class PlayOperator {
 	}
 
 	openNewClientInstance = (): void => {
-		// ignoreSession は Mac Chrome の不具合(？)対策でやむなくつけているフラグ。 (ref. ../store/storage.ts)
-		console.log(`OPENWINDOW: width=${window.innerWidth},height=${window.innerHeight}`);
+		// Mac Chrome で正しく動作しないのと、親ウィンドウかどうかの判別をしたいことがあるので noopener は付けない。
+		// 代わりに ignoreSession を指定して自前でセッションストレージをウィンドウごとに使い分ける (ref. ../store/storage.ts)
 		window.open(
 			`${window.location.pathname}?ignoreSession=1`,
 			"_blank",
@@ -40,7 +40,7 @@ export class PlayOperator {
 		);
 	}
 
-	closeSubWindows = (): void => {
+	closeSubWindowsIfNeeded = (): void => {
 		// TODO: ゲームごとに、開いた window の位置とサイズ情報を閉じる直前で localStorage に保存し、
 		// 再度 window を開いた時に localStorage に情報があればそのサイズで window.open() したい。
 		if (this.store.appOptions.preserveDisconnected)  return;

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -6,7 +6,7 @@ export class PlayOperator {
 
 	constructor(store: Store) {
 		this.store = store;
-		Subscriber.onDisconnect.add(this.closeSubWindowsIfNeeded);
+		Subscriber.onDisconnect.add(this.closeThisWindowIfNeeded);
 	}
 
 	togglePauseActive = (pauses: boolean): void => {
@@ -40,7 +40,7 @@ export class PlayOperator {
 		);
 	}
 
-	closeSubWindowsIfNeeded = (): void => {
+	closeThisWindowIfNeeded = (): void => {
 		// TODO: ゲームごとに、開いた window の位置とサイズ情報を閉じる直前で localStorage に保存し、
 		// 再度 window を開いた時に localStorage に情報があればそのサイズで window.open() したい。
 		if (this.store.appOptions.preserveDisconnected)  return;

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -1,3 +1,4 @@
+import * as Subscriber from "../api/Subscriber";
 import { Store } from "../store/Store";
 
 export class PlayOperator {
@@ -5,6 +6,7 @@ export class PlayOperator {
 
 	constructor(store: Store) {
 		this.store = store;
+		Subscriber.onDisconnect.add(this.closeSubWindows);
 	}
 
 	togglePauseActive = (pauses: boolean): void => {
@@ -30,12 +32,22 @@ export class PlayOperator {
 
 	openNewClientInstance = (): void => {
 		// ignoreSession は Mac Chrome の不具合(？)対策でやむなくつけているフラグ。 (ref. ../store/storage.ts)
-		console.log(`OPENWINDOW: width=${window.innerWidth},height=${window.innerHeight},noopener`);
+		console.log(`OPENWINDOW: width=${window.innerWidth},height=${window.innerHeight}`);
 		window.open(
 			`${window.location.pathname}?ignoreSession=1`,
 			"_blank",
-			`width=${window.innerWidth},height=${window.innerHeight},noopener`
+			`width=${window.innerWidth},height=${window.innerHeight}`
 		);
+	}
+
+	closeSubWindows = (): void => {
+		// TODO: ゲームごとに、開いた window の位置とサイズ情報を閉じる直前で localStorage に保存し、
+		// 再度 window を開いた時に localStorage に情報があればそのサイズで window.open() したい。
+		if (this.store.appOptions.preserveDisconnected)  return;
+
+		if (window.opener) {
+			window.close();
+		}
 	}
 
 	sendRegisteredEvent = (eventName: string): void => {

--- a/packages/akashic-cli-serve/src/common/types/AppOptions.ts
+++ b/packages/akashic-cli-serve/src/common/types/AppOptions.ts
@@ -5,4 +5,5 @@ export interface AppOptions {
 	verbose: boolean;
 	proxyAudio: boolean;
 	targetService: ServiceType;
+	preserveDisconnected: boolean;
 }

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -11,6 +11,7 @@ export interface ServerGlobalConfig {
 	proxyAudio: boolean;
 	targetService: ServiceType;
 	allowExternal: boolean;
+	preserveDisconnected: boolean;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -26,5 +27,6 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	untrusted: false,
 	proxyAudio: false,
 	targetService: "none",
-	allowExternal: false
+	allowExternal: false,
+	preserveDisconnected: false
 };

--- a/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
@@ -9,7 +9,8 @@ export const handleToGetStartupOptions = (req: express.Request, res: express.Res
 			autoStart: serverGlobalConfig.autoStart,
 			verbose: serverGlobalConfig.verbose,
 			targetService: serverGlobalConfig.targetService,
-			proxyAudio: serverGlobalConfig.proxyAudio
+			proxyAudio: serverGlobalConfig.proxyAudio,
+			preserveDisconnected: serverGlobalConfig.preserveDisconnected
 		});
 	} catch (e) {
 		next(e);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -198,7 +198,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 			console.log(`if access ${url}, you can show this play.`);
 		}
 
-		if (cliConfigParam.openBrowser ) {
+		if (cliConfigParam.openBrowser) {
 			open(url);
 		}
 	});
@@ -222,8 +222,8 @@ export async function run(argv: any): Promise<void> {
 		.option("--debug-untrusted", `An internal debug option`)
 		.option("--debug-proxy-audio", `An internal debug option`)
 		.option("--allow-external", `Read the URL allowing external access from sandbox.config.js`)
-		.option("--no-open-browser", "No open browser at startup")
-		.option("--preserve-disconnected", "Preserve the state of window disconnected from the network")
+		.option("--no-open-browser", "Disable to open a browser window at startup")
+		.option("--preserve-disconnected", "Disable auto closing for disconnected windows.")
 		.parse(argv);
 
 	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), async (error, configuration) => {

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -191,7 +191,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 		}
 		let url = `http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/public`;
 		// サーバー起動のログに関してはSystemLoggerで使用していない色を使いたいので緑を選択
-		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on ${url}`));
+		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
 		if (loadedPlaylogPlayId) {
 			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), commander.debugPlaylog)}).`);
 			url += `?playId=${loadedPlaylogPlayId}&mode=replay`;

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -7,6 +7,7 @@ import * as bodyParser from "body-parser";
 import * as socketio from "socket.io";
 import * as commander from "commander";
 import * as chalk from "chalk";
+import * as open from "open";
 import { PlayManager, RunnerManager, setSystemLogger, getSystemLogger } from "@akashic/headless-driver";
 import { createApiRouter } from "./route/ApiRoute";
 import { RunnerStore } from "./domain/RunnerStore";
@@ -39,6 +40,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 
 	serverGlobalConfig.untrusted = !!cliConfigParam.debugUntrusted;
 	serverGlobalConfig.proxyAudio = !!cliConfigParam.debugProxyAudio;
+	serverGlobalConfig.preserveDisconnected = !!cliConfigParam.preserveDisconnected;
 
 	if (cliConfigParam.hostname) {
 		serverGlobalConfig.hostname = cliConfigParam.hostname;
@@ -187,12 +189,17 @@ async function cli(cliConfigParam: CliConfigServe) {
 			getSystemLogger().warn("Akashic Serve is a development server which is not appropriate for public release. " +
 				`We do not recommend to listen on a well-known port ${serverGlobalConfig.port}.`);
 		}
+		let url = `http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/public`;
 		// サーバー起動のログに関してはSystemLoggerで使用していない色を使いたいので緑を選択
-		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
+		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on ${url}`));
 		if (loadedPlaylogPlayId) {
 			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), commander.debugPlaylog)}).`);
-			const url = `http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/public?playId=${loadedPlaylogPlayId}&mode=replay`;
+			url += `?playId=${loadedPlaylogPlayId}&mode=replay`;
 			console.log(`if access ${url}, you can show this play.`);
+		}
+
+		if (cliConfigParam.openBrowser ) {
+			open(url);
 		}
 	});
 }
@@ -215,6 +222,8 @@ export async function run(argv: any): Promise<void> {
 		.option("--debug-untrusted", `An internal debug option`)
 		.option("--debug-proxy-audio", `An internal debug option`)
 		.option("--allow-external", `Read the URL allowing external access from sandbox.config.js`)
+		.option("--no-open-browser", "No open browser at startup")
+		.option("--preserve-disconnected", "Preserve the state of window disconnected from the network")
 		.parse(argv);
 
 	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), async (error, configuration) => {
@@ -234,7 +243,9 @@ export async function run(argv: any): Promise<void> {
 			debugUntrusted: commander.debugUntrusted ?? conf.debugUntrusted,
 			debugProxyAudio: commander.proxyAudio ?? conf.debugProxyAudio,
 			allowExternal: commander.allowExternal ?? conf.allowExternal,
-			targetDirs: commander.args.length > 0 ? commander.args : (conf.targetDirs ?? [process.cwd()])
+			targetDirs: commander.args.length > 0 ? commander.args : (conf.targetDirs ?? [process.cwd()]),
+			openBrowser: commander.openBrowser ?? conf.openBrowser,
+			preserveDisconnected: commander.preserveDisconnected ?? conf.preserveDisconnected
 		};
 		await cli(cliConfigParam);
 	});


### PR DESCRIPTION
## 概要

serve 起動時、ネットワーク切断時の挙動を修正
- serve 起動時にブラウザを自動で開くよう(デフォルト挙動)に修正。
   - 自動でブラウザを開かないようにする `--no-open-browser` オプションを追加。
   - ブラウザを開くため open というライブラリを追加。
- サーバとの切断時に開いている子ウィンドウを自動で閉じるよう修正。
  - 子ウィンドウを閉じない `--preserve-disconnected` オプションを追加。

また、#598 で対応したサーバ再起動時に再接続する機能と、自動でブラウザを開く機能が共存すると、同じ playId を持つタブが出来てしまう等の問題があるため、再接続機能を元に戻しています。

**関連PR**
#605 