### PR TITLE
feat(export-html): add GameExternalStorage impl

### DIFF
--- a/packages/akashic-cli-export-html/spec/gameExternalStorageSpec.js
+++ b/packages/akashic-cli-export-html/spec/gameExternalStorageSpec.js
@@ -1,0 +1,511 @@
+// TODO: このテストは将来的には外部で実行するようにする
+
+const GameExternalStorage = require("../tmp/export/build/storage/GameExternalStorage").GameExternalStorage;
+
+// NOTE: 簡易 KVS 実装
+class KVS {
+	data = {};
+
+	getItem(key) {
+		return this.data[key] || null;
+	}
+
+	setItem(key, value) {
+		this.data[key] = value;
+	}
+}
+
+function promisize(storage) {
+	return {
+		read: req =>
+			new Promise((res, rej) => storage.read(req, (e, r) => e ? rej(e) : res(r))),
+		write: req =>
+			new Promise((res, rej) => storage.write(req, (e, r) => e ? rej(e) : res(r)))
+	};
+}
+
+describe("gameStorageSpec", () => {
+	test("basic", async () => {
+		const kvs = new KVS();
+		const storage = new GameExternalStorage({
+			kvs,
+			playId: "testPlayId",
+			gameCode: "dummyGameCode"
+		});
+
+		const { read, write } = promisize(storage);
+
+		const writeResponse1 = await write(
+			{
+				key: "highScore",
+				type: "ordered-number",
+				data: [
+					{
+						playerId: "foo",
+						value: 100
+					},
+					{
+						playerId: "bar",
+						value: 20
+					},
+					{
+						playerId: "hoge",
+						value: 50
+					},
+					{
+						playerId: "fuga",
+						value: -10
+					}
+				]
+			}
+		);
+		expect(writeResponse1).toBeNull();
+
+		expect(await read(
+			{
+				key: "highScore",
+				type: "ordered-number",
+				order: "desc",
+				limit: 2,
+				offset: 1
+			}
+		)).toEqual(
+			{
+				data: [
+					{
+						playerId: "hoge",
+						value: 50,
+					},
+					{
+						playerId: "bar",
+						value: 20,
+					}
+				],
+				gameCode: undefined,
+				key: "highScore",
+				type: "ordered-number",
+				playScope: undefined
+			}
+		);
+
+		expect(await read(
+			{
+				key: "highScore",
+				type: "ordered-number",
+				order: "asc",
+				limit: 100,
+				offset: 0
+			}
+		)).toEqual(
+			{
+				data: [
+					{
+						playerId: "fuga",
+						value: -10
+					},
+					{
+						playerId: "bar",
+						value: 20
+					},
+					{
+						playerId: "hoge",
+						value: 50
+					},
+					{
+						playerId: "foo",
+						value: 100
+					}
+				],
+				gameCode: undefined,
+				key: "highScore",
+				type: "ordered-number",
+				playScope: undefined
+			}
+		);
+
+		const writeResponse2 = await write(
+			{
+				key: "userData",
+				type: "general",
+				data: [
+					{
+						playerId: "foo",
+						value: { property: 1 }
+					},
+					{
+						playerId: "bar",
+						value: { property: 2 }
+					},
+					{
+						playerId: "hoge",
+						value: { property: 3 }
+					},
+					{
+						playerId: "fuga",
+						value: { property: 4 }
+					}
+				]
+			}
+		);
+		expect(writeResponse2).toBeNull();
+
+		expect(await read(
+			{
+				key: "userData",
+				type: "general",
+				playerIds: ["hoge", "foo"]
+			}
+		)).toEqual(
+			{
+				data: [
+					{
+						playerId: "hoge",
+						value: { property: 3 },
+					},
+					{
+						playerId: "foo",
+						value: { property: 1 },
+					}
+				],
+				gameCode: undefined,
+				key: "userData",
+				type: "general",
+				playScope: undefined
+			}
+		);
+
+		expect(await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "asc"
+			}
+		)).toEqual(
+			{
+				data: [],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+
+		expect(await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "asc"
+			}
+		)).toEqual(
+			{
+				data: [],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+	});
+
+	test("min/max; normal", async () => {
+		const kvs = new KVS();
+		const storage = new GameExternalStorage({
+			kvs,
+			playId: "testPlayId",
+			gameCode: "dummyGameCode"
+		});
+		const { read, write } = promisize(storage);
+
+		// 予め初期値を書き込み
+		const writeRes1 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 0
+					},
+					{
+						playerId: "bar",
+						value: 0
+					}
+				]
+			}
+		);
+		expect(writeRes1).toBeNull();
+
+		const result1 = await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "asc"
+			}
+		);
+		expect(result1).toEqual(
+			{
+				data: [
+					{
+						playerId: "foo",
+						value: 0
+					},
+					{
+						playerId: "bar",
+						value: 0
+					}
+				],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+
+		const writeRes2 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 5
+					},
+					{
+						playerId: "bar",
+						value: 20
+					}
+				],
+				writeType: "incr"
+			}
+		);
+		expect(writeRes2).toBeNull();
+
+		const result2 = await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "asc"
+			}
+		);
+		expect(result2).toEqual(
+			{
+				data: [
+					{
+						playerId: "foo",
+						value: 5
+					},
+					{
+						playerId: "bar",
+						value: 20
+					}
+				],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+
+		const writeRes3 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 10
+					},
+					{
+						playerId: "bar",
+						value: 10
+					}
+				],
+				writeType: "incr"
+			}
+		);
+		expect(writeRes3).toBeNull();
+
+		const result3 = await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "asc"
+			}
+		);
+		expect(result3).toEqual(
+			{
+				data: [
+					{
+						playerId: "foo",
+						value: 15
+					},
+					{
+						playerId: "bar",
+						value: 30
+					}
+				],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+	});
+
+	test("min/max; abnormal", async () => {
+		const kvs = new KVS();
+		const storage = new GameExternalStorage({
+			kvs,
+			playId: "testPlayId",
+			gameCode: "dummyGameCode"
+		});
+		const { read, write } = promisize(storage);
+
+		const writeRes1 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 5
+					},
+					{
+						playerId: "bar",
+						value: 20
+					}
+				]
+			}
+		);
+		expect(writeRes1).toBeNull();
+
+		const writeRes2 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 5
+					},
+					{
+						playerId: "bar",
+						value: 1000
+					}
+				],
+				writeType: "incr",
+				min: 0,
+				max: 99
+			}
+		);
+		expect(writeRes2).toEqual(
+			{
+				failed: [
+					{
+						gameCode: undefined,
+						playScope: undefined,
+						key: "item/portion",
+						playerId: "bar",
+						type: "number",
+						failureType: "exceedMax",
+						message: "exceedMax (message T.B.D)"
+					}
+				]
+			}
+		);
+
+		const result2 = await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "desc"
+			}
+		);
+		expect(result2).toEqual(
+			{
+				data: [
+					{
+						playerId: "bar",
+						value: 20, // incr した結果 (20 + 1000) が max (99) を超えていたら反映されない
+					},
+					{
+						playerId: "foo",
+						value: 10 // incr した結果 (5 + 5) が max (99) を超えていなければ反映される
+					}
+				],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+
+		const writeRes3 = await write(
+			{
+				key: "item/portion",
+				type: "number",
+				data: [
+					{
+						playerId: "foo",
+						value: 100
+					},
+					{
+						playerId: "bar",
+						value: 5
+					}
+				],
+				writeType: "decr",
+				min: 0,
+				max: 99
+			}
+		);
+		expect(writeRes3).toEqual(
+			{
+				failed: [
+					{
+						gameCode: undefined,
+						playScope: undefined,
+						key: "item/portion",
+						playerId: "foo",
+						type: "number",
+						failureType: "subceedMin",
+						message: "subceedMin (message T.B.D)"
+					}
+				]
+			}
+		);
+
+		const result3 = await read(
+			{
+				key: "item/portion",
+				type: "number",
+				limit: 100,
+				order: "desc"
+			}
+		);
+		expect(result3).toEqual(
+			{
+				data: [
+					{
+						playerId: "bar",
+						value: 15, // decr した結果 (20 - 5) が min (0) を下回っていなければ反映される
+					},
+					{
+						playerId: "foo",
+						value: 10 // decr した結果 (10 - 100) が min (0) を下回っていたら反映されない
+					}
+				],
+				gameCode: undefined,
+				key: "item/portion",
+				type: "number",
+				playScope: undefined
+			}
+		);
+	});
+});

--- a/packages/akashic-cli-export-html/src/export/storage/GameExternalStorage.ts
+++ b/packages/akashic-cli-export-html/src/export/storage/GameExternalStorage.ts
@@ -1,0 +1,221 @@
+import * as types from "./content-storage-types";
+import { KVSLike } from "./KVSLike";
+
+export interface GameExternalStorageParameterObject {
+	kvs: KVSLike;
+	playId: string;
+	gameCode: string;
+}
+
+interface GameExternalStorageDataTable {
+	[playerId: string]: types.StorageData;
+}
+
+export class GameExternalStorage implements types.GameExternalStorageLike {
+	apiVersion: number = 1; // 現状固定
+	protected static kvsPrefix: string = "__akashic_game_storage__";
+	protected kvs: KVSLike;
+	protected playId: string;
+	protected gameCode: string;
+	protected dataTable: GameExternalStorageDataTable = Object.create(null);
+
+	constructor({kvs: storage, playId, gameCode}: GameExternalStorageParameterObject) {
+		this.kvs = storage;
+		this.playId = playId;
+		this.gameCode = gameCode;
+	}
+
+	read(
+		req: types.GameExternalStorageReadRequest,
+		callback: (error: Error | null, response: types.GameExternalStorageReadResponse | null) => void
+	): void {
+		try {
+			const result = this._readSync(req);
+			setImmediate(() => callback(null, result));
+		} catch (e) {
+			setImmediate(() => callback(e, null));
+		}
+	}
+
+	write(
+		req: types.GameExternalStorageWriteRequest,
+		callback: (error: Error | null, response: types.GameExternalStorageWriteResponse | null) => void
+	): void {
+		try {
+			const result = this._writeSync(req);
+			setImmediate(() => callback(null, result));
+		} catch (e) {
+			setImmediate(() => callback(e, null));
+		}
+	}
+
+	private _readSync(req: types.GameExternalStorageReadRequest): types.GameExternalStorageReadResponse | null {
+		const { gameCode, playScope, key, playerIds, type } = req;
+		const limit = req.limit ?? types.DEFAULT_STORAGE_READ_REQUEST_LIMIT;
+		const offset = req.offset ?? types.DEFAULT_STORAGE_READ_REQUEST_OFFSET;
+		const order = req.order ?? "unspecified";
+		if (playerIds && order !== "unspecified")
+			throw new Error("could not be specified both playerIds and specified order");
+		if (!playerIds && order === "unspecified")
+			throw new Error("neither playerIds nor specified order given");
+		if (order !== "unspecified" && (typeof limit !== "number" || limit < 0))
+			throw new Error("invalid limit");
+		if ((order === "asc" || order === "desc") && (type !== "number" && type !== "ordered-number"))
+			throw new Error("asc/desc can be specified only for number");
+		if (playerIds && type === "ordered-number")
+			throw new Error(`could not read value for key ${req.key} specified playerIds and ordered-number`);
+
+		const dataTable = this.getDataTableFromKVS(playScope, req) ?? Object.create(null);
+
+		if (playerIds) {
+			const data = playerIds.map(playerId => {
+				const value = playerId in dataTable ? dataTable[playerId] : null;
+				return { playerId, value };
+			});
+			return { gameCode, playScope, key, data, type };
+		}
+
+		const data = Object.keys(dataTable).map(playerId => ({ playerId, value: dataTable[playerId] }));
+
+		// asc/desc は JSON 上では効率的に実装できないので、全件取得したものをソートして limit 件切り出す。
+		// 最適化された実装は declare() 時点で type: "number" を踏まえた適切なデータ構造を採用できるはず。
+		switch (order) {
+		case "asc":
+			// order が asc/desc なら spec.type が number なのは上で確認済み、
+			// かつ spec.type と一致しない値は書き込まないのを write() が保証しているので、常に `as number` できる。
+			// (あるいは、TypeScript にこの invariant を推論させられないので明示的なキャストが必要)
+			data.sort((a, b) => (a.value as number) - (b.value as number));
+			return { gameCode, playScope, key, type, data: data.slice(offset, offset + limit) };
+		case "desc":
+			data.sort((a, b) => (b.value as number) - (a.value as number));
+			return { gameCode, playScope, key, type, data: data.slice(offset, offset + limit) };
+		default:
+			return { gameCode, playScope, key, type, data: data.slice(offset, offset + limit) };
+		}
+	}
+
+	private _writeSync(req: types.GameExternalStorageWriteRequest): types.GameExternalStorageWriteResponse | null {
+		const { gameCode, key, playScope, data, type } = req;
+		const writeType = req.writeType ?? "overwrite";
+		const min = req.min ?? types.STORAGE_MIN_NUMBER;
+		const max = req.max ?? types.STORAGE_MAX_NUMBER;
+
+		if (type !== "number" && type !== "ordered-number") {
+			if (writeType === "incr" || writeType === "decr")
+				throw new Error("incr/decr cannot be used for type " + type);
+		}
+
+		const dataTable = this.getDataTableFromKVS(playScope, req) ?? Object.create(null);
+
+		const failed: types.GameExternalStorageWriteFailureInfo[] = data.map(({playerId, value}) => {
+			if (typeof value !== "number") {
+				if (value != null && type !== "string" && type !== "general") {
+					throw new Error(`type mismatch: the value ${value} for player ${playerId} does not match the type ${type}`);
+				}
+				dataTable[playerId] = value;
+				return null;
+			}
+
+			if (type !== "number" && type !== "ordered-number") {
+				throw new Error(`type mismatch: the value ${value} for player ${playerId} does not match the type ${type}`);
+			}
+
+			const needsCalc = (writeType === "incr" || writeType === "decr");
+
+			let current: types.StorageValue | null = null;
+			if (needsCalc) {
+				if (playerId in dataTable) {
+					current = dataTable[playerId];
+				} else if (typeof current !== "number") {
+					throw new Error(`no value for key ${key} of player ${playerId}`);
+				}
+			}
+
+			const calculated =
+				// current が number でなければ incr/decr でないことは上でチェック済みなのでキャストできる
+				(writeType === "incr") ? (current as number) + value :
+					(writeType === "decr") ? (current as number) - value :
+						value;
+
+			const clamped = Math.min(max, Math.max(min, calculated));
+
+			const diff = calculated - clamped;
+			if (diff < 0) {
+				return {
+					gameCode,
+					playScope,
+					key,
+					playerId,
+					type,
+					failureType: "subceedMin" as types.StorageWriteFailureType,
+					message: "subceedMin (message T.B.D)"
+				};
+			} else if (diff > 0) {
+				return {
+					gameCode,
+					playScope,
+					key,
+					playerId,
+					type,
+					failureType: "exceedMax" as types.StorageWriteFailureType,
+					message: "exceedMax (message T.B.D)"
+				};
+			} else {
+				dataTable[playerId] = calculated;
+				return null;
+			}
+		}).filter((failed: types.GameExternalStorageWriteFailureInfo): failed is types.GameExternalStorageWriteFailureInfo => failed != null);
+
+		this.setDataTableToKVS(playScope, req, dataTable);
+
+		return failed.length ? { failed } : null;
+	}
+
+	private getDataTableFromKVS(
+		playScope: types.StoragePlayScope,
+		loc: types.GameExternalStorageLocator,
+	): GameExternalStorageDataTable | null {
+		const str = this.kvs.getItem(
+			GameExternalStorage.kvsPrefix +
+			this._resolvePlayId(playScope) +
+			"__" +
+			this._locatorIdOf(loc) +
+			"__"
+		);
+		try {
+			const data = JSON.parse(str);
+			return data;
+		} catch (_e) {}
+		return null;
+	}
+
+	private setDataTableToKVS(
+		playScope: types.StoragePlayScope,
+		loc: types.GameExternalStorageLocator,
+		data: GameExternalStorageDataTable
+	): void {
+		this.kvs.setItem(
+			GameExternalStorage.kvsPrefix +
+			this._resolvePlayId(playScope) +
+			"__" +
+			this._locatorIdOf(loc) +
+			"__",
+			JSON.stringify(data)
+		)
+	}
+
+	private _resolvePlayId(playScope: types.StoragePlayScope | undefined): string {
+		switch (playScope) {
+			case "play":
+				return this.playId;
+			case "rootPlay":
+				return "$ROOTPLAY";
+			case "global": default:
+				return "$GLOBAL";
+			}
+	}
+
+	private _locatorIdOf(loc: types.GameExternalStorageLocator): string {
+		return this.gameCode + "___" + loc.key;
+	}
+}

--- a/packages/akashic-cli-export-html/src/export/storage/KVSLike.ts
+++ b/packages/akashic-cli-export-html/src/export/storage/KVSLike.ts
@@ -1,0 +1,4 @@
+export interface KVSLike {
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+}

--- a/packages/akashic-cli-export-html/src/export/storage/content-storage-types/GameExternalStorageLike.ts
+++ b/packages/akashic-cli-export-html/src/export/storage/content-storage-types/GameExternalStorageLike.ts
@@ -1,0 +1,161 @@
+// TODO: このファイルは将来的には外部から参照するようにする
+
+import {
+	StoragePlayScope,
+	StorageValueType,
+	StorageReadOrder,
+	StorageWriteType,
+	StorageData,
+	StorageWriteFailureType
+} from "./types";
+
+/**
+ * GameExternalStorageReadRequest.limitのデフォルト値
+ */
+export const DEFAULT_STORAGE_READ_REQUEST_LIMIT: number = 10;
+
+/**
+ * GameExternalStorageReadRequest.offsetのデフォルト値
+ */
+export const DEFAULT_STORAGE_READ_REQUEST_OFFSET: number = 0;
+
+/**
+ * ストレージの領域を識別する情報。
+ *
+ * この値ごとにデータを保存する領域が定まる。
+ */
+export interface GameExternalStorageLocator {
+	/**
+	 * 保存先の gameCode　。
+	 * 省略された場合、このゲームのゲームコード。
+	 */
+	gameCode?: string;
+
+	/**
+	 * 保存先のプレイスコープ。
+	 * 省略された場合、 "global" 。
+	 */
+	playScope?: StoragePlayScope;
+
+	/**
+	 * 保存先を識別する文字列。
+	 *
+	 * (TODO 制限明記。文字数、文字種制限など。あるなら)
+	 */
+	key: string;
+
+	/**
+	 * 値の型。
+	 *
+	 * 型まで含めて一つの領域が定まる、すなわち型が違えば別の領域として扱われることに注意。
+	 *
+	 * type が `"ordered-number"` 以外の場合、この値と playerId で一つのデータ (write() された value) にアクセスできる。
+	 * type が `"ordered-number"` の場合、この値が定まると範囲指定された複数のデータ (write() された value) にアクセスできる。
+	 */
+	type: StorageValueType;
+}
+
+export interface GameExternalStorageReadRequest extends GameExternalStorageLocator {
+	/**
+	 * 誰の値を読み込むか。
+	 * playerIdsが指定された場合、type が "ordered-number" である場合、エラー。
+	 * order と両方指定された場合、エラー。
+	 * order と両方指定されなかった場合、エラー。
+	 */
+	playerIds?: string[];
+
+	/**
+	 * 読み込み順。結果はこの順でソートされ、 limit 個分取得される。
+	 * playerIds と両方指定された場合、エラー。order が指定され type が "ordered-number" でない場合、エラー。
+	 * playerIds と両方指定されなかった場合、エラー。
+	 */
+	order?: StorageReadOrder;
+
+	/**
+	 * 読み込む個数。
+	 * 指定された場合、order が指定されていなければエラー。 0 未満の場合、エラー。
+	 * 省略された場合、order が指定されている場合のみ、DEFAULT_STORAGE_READ_REQUEST_LIMIT 。
+	 */
+	limit?: number;
+
+	/**
+	 * 読み込み開始位置。
+	 * 指定された場合、order が指定されていなければエラー。 0 未満の場合、エラー。
+	 * 省略された場合、order が指定されている場合のみ、DEFAULT_STORAGE_READ_REQUEST_OFFSET 。
+	 */
+	offset?: number;
+}
+
+export interface GameExternalStorageWriteRequest extends GameExternalStorageLocator {
+	/** プレイヤー別の書き込むデータ。 */
+	data: StorageData[];
+
+	/** 書き込みタイプ。詳細は型定義を参照。 */
+	writeType?: StorageWriteType;
+
+	/**
+	 * 最小値。
+	 *
+	 * 書き込まれる結果がこの値より小さくなる場合、書き込みに失敗する。
+	 * (エラーではないことに注意。コールバックの引数 response の failed[i].failureType が "subceedMin" になる)
+	 * type が "number" でない時、無視される。
+	 * 省略された場合、 STORAGE_MIN_NUMBER 。
+	 */
+	min?: number;
+
+	/**
+	 * 最大値。
+	 *
+	 * 書き込まれる結果がこの値より大きくなる場合、書き込みに失敗する。
+	 * (エラーではないことに注意。コールバックの引数 response の failed[i].failureType が "exceedMax" になる)
+	 * type が "number" でない時、無視される。
+	 * 省略された場合、 STORAGE_MAX_NUMBER 。
+	 */
+	max?: number;
+}
+
+export interface GameExternalStorageReadResponse extends GameExternalStorageLocator {
+	/**
+	 * 読み込み結果。
+	 *
+	 * `playerIds` による `read()` の結果である時、順序は `playerIds` に対応する。
+	 * (すなわち `playerIds[i]` は `data[i].playerId` と一致する)
+	 *
+	 * `order` による `read()` の結果である時、順序は `order` で指定された順である。
+	 */
+	data: StorageData[];
+}
+
+/**
+ * 書き込み失敗情報。
+ * 誰のどの領域への書き込みがなぜ失敗したか。
+ * ゲームコンテンツがこれを参照してリトライできる必要がある。
+ */
+export interface GameExternalStorageWriteFailureInfo extends GameExternalStorageLocator {
+	playerId: string;
+	failureType: StorageWriteFailureType;
+
+	/** 自然言語による失敗の説明。デバッグ用であるため空文字が入る可能性もある */
+	message: string;
+}
+
+export interface GameExternalStorageWriteResponse {
+	failed: GameExternalStorageWriteFailureInfo[];
+}
+
+export interface GameExternalStorageLike {
+	apiVersion: number; // 現時点では常に 1 。
+
+	/**
+	 * 永続化領域から読み込む。
+	 *
+	 * req.playerIds[i] に対応する値がない場合、response.data[i].value は null である。
+	 * req.offset が大きすぎる場合、 response.data は [] である。
+	 */
+	read(req: GameExternalStorageReadRequest, callback: (error: Error | null, response: GameExternalStorageReadResponse | null) => void): void;
+
+	/**
+	 * 永続化領域に書き込む。
+	 */
+	write(req: GameExternalStorageWriteRequest, callback: (error: Error | null, response: GameExternalStorageWriteResponse | null) => void): void;
+}

--- a/packages/akashic-cli-export-html/src/export/storage/content-storage-types/index.ts
+++ b/packages/akashic-cli-export-html/src/export/storage/content-storage-types/index.ts
@@ -1,0 +1,4 @@
+// TODO: このファイルは将来的には外部から参照するようにする
+
+export * from "./types";
+export * from "./GameExternalStorageLike";

--- a/packages/akashic-cli-export-html/src/export/storage/content-storage-types/types.ts
+++ b/packages/akashic-cli-export-html/src/export/storage/content-storage-types/types.ts
@@ -1,0 +1,84 @@
+// TODO: このファイルは将来的には外部から参照するようにする
+
+/**
+ * 値のプレイに関するスコープ。
+ * 同一 playerId 同一 key でも、プレイスコープが異なる値は区別される。
+ *
+ * - "play": プレイごとにユニークな領域
+ * - "rootPlay": もっとも祖先のプレイにユニークな領域
+ * - "global": プレイに紐づかない領域
+ */
+export type StoragePlayScope = "play" | "rootPlay" | "global";
+
+/**
+ * ストレージに保存される値の型。
+ */
+export type StorageValue = number | string | Object | null;
+
+/**
+ * ストレージに保存される値の種類。
+ *
+ * "number", "ordered-number" は [-(2 ** 30), 2**30) の数値。
+ * "string" は 文字列。(TODO 制限明記。何文字(？)以下など。)
+ * "general" は JSON として妥当なその他のオブジェクト。
+ */
+export type StorageValueType = "number" | "ordered-number" | "string" | "general";
+
+/**
+ * 値の読み込み順。
+ *
+ * - "asc": 昇順。type が `"ordered-number"` でない時、エラー。
+ * - "desc": 降順。type が `"ordered-number"` でない時、エラー。
+ * - "unspecified": 指定しない。デフォルト。
+ */
+export type StorageReadOrder = "asc" | "desc" | "unspecified";
+
+/**
+ * 書き込みのタイプ (書き込む値の解釈)。
+ *
+ * - "incr": 指定された値を現在値に加えた値を書き込む。 type が `"number" | "ordered-number"` でない時エラー。
+ * - "decr": 指定された値を現在値から引いた値を書き込む。 type が `"number" | "ordered-number"` でない時エラー。
+ * - "overwrite": 指定された値を書き込む。デフォルト。
+ */
+export type StorageWriteType = "incr" | "decr" | "overwrite";
+
+/**
+ * "number" の最小値。
+ */
+export const STORAGE_MIN_NUMBER: number = -1073741824; // -(2 ** 30)
+
+/**
+ * "number" の最大値。
+ */
+export const STORAGE_MAX_NUMBER: number = 1073741823; // (2 ** 30) - 1;
+
+export interface StorageData {
+	/**
+	 * 誰の値か。
+	 * いずれかのインスタンスの g.game.selfId に与えられる文字列または空文字列 "" (プレイヤーに紐づけない場合) でなければならない。
+	 */
+	playerId: string;
+
+	/**
+	 * 書き込む値、または読み込まれた値。
+	 *
+	 * 書き込みで利用する場合、この値の解釈は `StorageWriteType` に依存することに注意。(e.g. "incr" ならこの値を加算する)
+	 */
+	value: StorageValue;
+}
+
+/**
+ * 書き込み条件。
+ * `GameExternalStorageLike` ではサポートされないことに注意。
+ *
+ * - "greaterThan": 指定値が現在値より大きい時にのみ書き込む。type が "number" でない時エラー。
+ * - "lessThan": 指定値が現在値未満の時のみ書き込む。type が "number" でない時エラー。
+ * - "none": 条件なく書き込む。デフォルト。
+ */
+export type StorageWriteCondition = "greaterThan" | "lessThan" | "none";
+
+/**
+ * 書き込み失敗の種別。
+ * それぞれ min を下回った、max を超過した、許可されていない。
+ */
+export type StorageWriteFailureType = "subceedMin" | "exceedMax" | "notPermitted";

--- a/packages/akashic-cli-export-html/src/export/tsconfig.json
+++ b/packages/akashic-cli-export-html/src/export/tsconfig.json
@@ -10,6 +10,7 @@
   },
   "files": [
     "./../../node_modules/@akashic/akashic-engine/lib/main.d.ts",
+    "./storage/GameExternalStorage.ts",
     "./LocalScriptAsset.ts",
     "./LocalTextAsset.ts",
     "./LocalScriptAssetV3.ts",

--- a/packages/akashic-cli-export-html/templates/template-export-html-v3/js/sandbox.js
+++ b/packages/akashic-cli-export-html/templates/template-export-html-v3/js/sandbox.js
@@ -78,6 +78,7 @@ window.addEventListener("load", function() {
 					resize(game);
 				});
 			}
+			injectGameExternalStorage(game);
 		});
 
 		function resize(game) {
@@ -139,6 +140,10 @@ window.addEventListener("load", function() {
 			} catch (error) {
 				console.error(error);
 			}
+		}
+
+		function injectGameExternalStorage(game) {
+			// TODO: game.external.contentStorage に GameExternalStorage を inject する。
 		}
 	}
 });


### PR DESCRIPTION
## このPullRequestが解決する内容
* ストレージ実装 (`GameExternalStorage`) を追加します。

## このPullRequestが解決しない内容
`g.game.external.contentStorage` に挿入する部分は未実装です。動作は単体テストでのみ確認しています。