### PR TITLE
Fix _getPackageNameFromTgzFile() in akashic-cli-install

### DIFF
--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -144,12 +144,14 @@ export function install(param: InstallParameterObject, cb: (err: any) => void): 
 
 
 function _getPackageNameFromTgzFile(fileName: string): string {
-	let data: string;
+	let buf: Buffer;
 	const onentry = (entry: tar.FileStat) => {
 		const splitPath = entry.header.path.split("/");
 		// splitPath[0] は解凍後のディレクトリ名が入る。そのディレクトリ直下のpackage.jsonのみを対象とする。
 		if (splitPath[1] === "package.json") {
-			entry.on("data", c => data = c.toString());
+			let data: Uint8Array[]  = [];
+			entry.on("data", c => data.push(c));
+			entry.on("finish", () =>  buf = Buffer.concat(data) );
 		}
 	};
 	tar.t({
@@ -157,6 +159,7 @@ function _getPackageNameFromTgzFile(fileName: string): string {
 		file: fileName,
 		sync: true
 	});
-	const json = JSON.parse(data);
+
+	const json = JSON.parse(buf.toString());
 	return json.name;
 }

--- a/packages/akashic-cli-install/src/install.ts
+++ b/packages/akashic-cli-install/src/install.ts
@@ -149,9 +149,9 @@ function _getPackageNameFromTgzFile(fileName: string): string {
 		const splitPath = entry.header.path.split("/");
 		// splitPath[0] は解凍後のディレクトリ名が入る。そのディレクトリ直下のpackage.jsonのみを対象とする。
 		if (splitPath[1] === "package.json") {
-			let data: Uint8Array[]  = [];
-			entry.on("data", c => data.push(c));
-			entry.on("finish", () =>  buf = Buffer.concat(data) );
+			let chunks: Uint8Array[]  = [];
+			entry.on("data", c => chunks.push(c));
+			entry.on("finish", () => buf = Buffer.concat(chunks));
 		}
 	};
 	tar.t({


### PR DESCRIPTION
## 概要

akashic-cli-install の tgz でのインストール時に失敗する問題を修正。
package.json 読み込み部分で 1 chunk しか読み込んでいなかったため、データ量が大きい場合に不完全なデータとなっていた。
読み込み完了時に 全 chunk を結合して渡すよう修正。