### PR TITLE
feat(scan): scan assets as array

### DIFF
--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -234,6 +234,12 @@ describe("Configuration", function () {
 					"_1.js": "var x = 1;",
 				},
 			},
+			"assets": {
+				"assets_d.png": DUMMY_1x1_PNG_DATA,
+				"assets_$.conf": "dummy",
+				"assets_.ogg": DUMMY_OGG_DATA,
+				"assets_1.js": "var x = 1;",
+			},
 		});
 
 		const conf = new cnf.Configuration({
@@ -257,25 +263,46 @@ describe("Configuration", function () {
 		// NOTE: 要素の順番は実装に依存する
 		expect(assets).toEqual([
 			{
-				type: "script",
-				path: "script/foo/_1.js",
-				global: true
+				"type": "script",
+				"path": "script/foo/_1.js",
+				"global": true
 			},
 			{
-				type: "text",
-				path: "text/foo/$.txt"
+				"type": "script",
+				"path": "assets/assets_1.js",
+				"global": true
 			},
 			{
-				type: "image",
-				path: "image/foo/d.png",
-				width: 1,
-				height: 1
+				"type": "text",
+				"path": "text/foo/$.txt"
 			},
 			{
-				type: "audio",
-				path: "audio/foo/_",
-				systemId: "sound",
-				duration: 1250
+				"type": "text",
+				"path": "assets/assets_$.conf"
+			},
+			{
+				"type": "image",
+				"path": "image/foo/d.png",
+				"width": 1,
+				"height": 1
+			},
+			{
+				"type": "image",
+				"path": "assets/assets_d.png",
+				"width": 1,
+				"height": 1
+			},
+			{
+				"type": "audio",
+				"path": "audio/foo/_",
+				"systemId": "sound",
+				"duration": 1250
+			},
+			{
+				"type": "audio",
+				"path": "assets/assets_",
+				"systemId": "sound",
+				"duration": 1250
 			}
 		]);
 	});

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -236,6 +236,7 @@ describe("Configuration", function () {
 			},
 			"assets": {
 				"assets_d.png": DUMMY_1x1_PNG_DATA,
+				"assets_#.yml": "dummy",
 				"assets_$.conf": "dummy",
 				"assets_.ogg": DUMMY_OGG_DATA,
 				"assets_1.js": "var x = 1;",
@@ -259,9 +260,8 @@ describe("Configuration", function () {
 			}
 		});
 
-		const assets = conf.getContent().assets as any;
 		// NOTE: 要素の順番は実装に依存する
-		expect(assets).toEqual([
+		expect(conf.getContent().assets as any).toEqual([
 			{
 				"type": "script",
 				"path": "script/foo/_1.js",
@@ -278,7 +278,69 @@ describe("Configuration", function () {
 			},
 			{
 				"type": "text",
+				"path": "assets/assets_#.yml"
+			},
+			{
+				"type": "text",
 				"path": "assets/assets_$.conf"
+			},
+			{
+				"type": "image",
+				"path": "image/foo/d.png",
+				"width": 1,
+				"height": 1
+			},
+			{
+				"type": "image",
+				"path": "assets/assets_d.png",
+				"width": 1,
+				"height": 1
+			},
+			{
+				"type": "audio",
+				"path": "audio/foo/_",
+				"systemId": "sound",
+				"duration": 1250
+			},
+			{
+				"type": "audio",
+				"path": "assets/assets_",
+				"systemId": "sound",
+				"duration": 1250
+			}
+		]);
+
+		await conf.scanAssets({
+			scanDirectoryTable: {
+				audio: ["audio"],
+				image: ["image"],
+				script: ["script"],
+				text: ["text"]
+			},
+			extension: {
+				text: ["txt", "yml"]
+			}
+		});
+
+		// NOTE: 要素の順番は実装に依存する
+		expect(conf.getContent().assets as any).toEqual([
+			{
+				"type": "script",
+				"path": "script/foo/_1.js",
+				"global": true
+			},
+			{
+				"type": "script",
+				"path": "assets/assets_1.js",
+				"global": true
+			},
+			{
+				"type": "text",
+				"path": "text/foo/$.txt"
+			},
+			{
+				"type": "text",
+				"path": "assets/assets_#.yml"
 			},
 			{
 				"type": "image",

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -205,6 +205,81 @@ describe("Configuration", function () {
 		}, done.fail);
 	});
 
+	it("scan assets as array if 'assets' filed of the game.json defined as array", async () => {
+		const gamejson = {
+			width: 320,
+			height: 240,
+			fps: 30,
+			assets: [] as any
+		};
+		mockfs({
+			"game.json": JSON.stringify(gamejson),
+			"image": {
+				"foo": {
+					"d.png": DUMMY_1x1_PNG_DATA,
+				},
+			},
+			"text": {
+				"foo": {
+					"$.txt": "dummy",
+				},
+			},
+			"audio": {
+				"foo": {
+					"_.ogg": DUMMY_OGG_DATA,
+				},
+			},
+			"script": {
+				"foo": {
+					"_1.js": "var x = 1;",
+				},
+			},
+		});
+
+		const conf = new cnf.Configuration({
+			content: gamejson,
+			logger: nullLogger,
+			basepath: "./"
+		});
+		await conf.scanAssets({
+			scanDirectoryTable: {
+				audio: ["audio"],
+				image: ["image"],
+				script: ["script"],
+				text: ["text"]
+			},
+			extension: {
+				text: []
+			}
+		});
+
+		const assets = conf.getContent().assets as any;
+		// NOTE: 要素の順番は実装に依存する
+		expect(assets).toEqual([
+			{
+				type: "script",
+				path: "script/foo/_1.js",
+				global: true
+			},
+			{
+				type: "text",
+				path: "text/foo/$.txt"
+			},
+			{
+				type: "image",
+				path: "image/foo/d.png",
+				width: 1,
+				height: 1
+			},
+			{
+				type: "audio",
+				path: "audio/foo/_",
+				systemId: "sound",
+				duration: 1250
+			}
+		]);
+	});
+
 	it("scan image assets info", function () {
 		var gamejson: any = {
 			assets: {

--- a/packages/akashic-cli-scan/spec/src/scanUtilsSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/scanUtilsSpec.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as mockfs from "mock-fs";
-import { scanAudioAssets, scanImageAssets } from "../../lib/scanUtils";
+import { scanAudioAssets, scanImageAssets, scanScriptAssets, scanTextAssets } from "../../lib/scanUtils";
 
 describe("scanUtils", () => {
 	const nullLogger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
@@ -17,8 +17,8 @@ describe("scanUtils", () => {
 			"game": {
 				"text": {
 					"foo": {
-						"$.txt": "dummy",
-					},
+						"$.json": "{}",
+					}
 				},
 				"audio": {
 					"foo": {
@@ -49,6 +49,64 @@ describe("scanUtils", () => {
 
 	afterEach(() => {
 		mockfs.restore();
+	});
+
+	it("scanScirptAssets()", async () => {
+		expect(
+			await scanScriptAssets(
+				"./game",
+				"script",
+				nullLogger
+			)
+		).toEqual([
+			{
+				type: "script",
+				path: "script/foo/_1.js",
+				global: true
+			}
+		]);
+
+		expect(
+			await scanScriptAssets(
+				"./game",
+				"assets",
+				nullLogger
+			)
+		).toEqual([
+			{
+				type: "script",
+				path: "assets/_.js",
+				global: true
+			}
+		]);
+	});
+
+	it("scanTextAssets()", async () => {
+		expect(
+			await scanTextAssets(
+				"./game",
+				"text",
+				nullLogger
+			)
+		).toEqual([
+			{
+				type: "text",
+				path: "text/foo/$.json"
+			}
+		]);
+
+		expect(
+			await scanTextAssets(
+				"./game",
+				"assets",
+				nullLogger
+			)
+		).toEqual([
+			{
+				type: "text",
+				path: "assets/_.txt"
+			}
+		]);
 	});
 
 	it("scanImageAssets()", async () => {

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -119,6 +119,8 @@ export class Configuration extends cmn.Configuration {
 			content.assets = assetArray as any;
 			return;
 		}
+
+		// TODO: 全体的に async/await を使うようにする
 		return Promise.resolve()
 			.then(() => this.scanAssetsAudio(info.scanDirectoryTable.audio))
 			.then(() => {

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -93,17 +93,17 @@ export class Configuration extends cmn.Configuration {
 				const assets = await scanScriptAssets(base, dir, this._logger);
 				assetArray.push(...assets);
 			}
+			const textAssetFilterRe =
+				info.extension.text && info.extension.text.length
+					? new RegExp(info.extension.text.join("|"), "i")
+					: null;
 			for (const dir of textDir) {
 				const assets = await scanTextAssets(
 					base,
 					dir,
 					this._logger,
-					p => {
-						if (info.extension.text && info.extension.text.length) {
-							return (new RegExp(info.extension.text.join("|"), "i")).test(p);
-						}
-						return textAssetFilter(p);
-					});
+					p => textAssetFilterRe ? textAssetFilterRe.test(p) : textAssetFilter(p)
+				);
 				assetArray.push(...assets);
 			}
 			for (const dir of imageDir) {

--- a/packages/akashic-cli-scan/src/Configuration.ts
+++ b/packages/akashic-cli-scan/src/Configuration.ts
@@ -6,7 +6,7 @@ import { getAudioDuration } from "./getAudioDuration";
 import { imageSize } from "image-size";
 import { ISize } from "image-size/dist/types/interface";
 import { AssetScanDirectoryTable, AssetExtension } from "./scan";
-import { scanAudioAssets, scanImageAssets, scanScriptAssets, scanTextAssets } from "./scanUtils";
+import { scanAudioAssets, scanImageAssets, scanScriptAssets, scanTextAssets, textAssetFilter } from "./scanUtils";
 
 export function isImageFilePath(p: string): boolean { return /.*\.(png|gif|jpg|jpeg)$/i.test(p); }
 export function isAudioFilePath(p: string): boolean { return /.*\.(ogg|aac|mp4)$/i.test(p); }
@@ -94,7 +94,16 @@ export class Configuration extends cmn.Configuration {
 				assetArray.push(...assets);
 			}
 			for (const dir of textDir) {
-				const assets = await scanTextAssets(base, dir, this._logger, createTextAssetExtensionFilter(info.extension.text));
+				const assets = await scanTextAssets(
+					base,
+					dir,
+					this._logger,
+					p => {
+						if (info.extension.text && info.extension.text.length) {
+							return (new RegExp(info.extension.text.join("|"), "i")).test(p);
+						}
+						return textAssetFilter(p);
+					});
 				assetArray.push(...assets);
 			}
 			for (const dir of imageDir) {

--- a/packages/akashic-cli-scan/src/scanUtils.ts
+++ b/packages/akashic-cli-scan/src/scanUtils.ts
@@ -6,6 +6,19 @@ import { getAudioDuration } from "./getAudioDuration";
 
 export type AssetFilter = (path: string) => boolean;
 
+export function scriptAssetFilter(p: string): boolean {
+	return /.*\.js$/i.test(p);
+}
+
+export function textAssetFilter(p: string): boolean {
+	// NOTE: その他ファイルはすべてスクリプトアセットとして扱う
+	return !(
+		scriptAssetFilter(p) ||
+		imageAssetFilter(p) ||
+		audioAssetFilter(p)
+	);
+}
+
 export function imageAssetFilter(p: string): boolean {
 	return /.*\.(png|gif|jp(?:e)?g)$/i.test(p);
 }
@@ -22,6 +35,41 @@ export interface AudioDurationInfo {
 }
 
 export type AudioDurationInfoMap = { [path: string]: AudioDurationInfo };
+
+export async function scanScriptAssets(
+	baseDir: string,
+	dir: string,
+	_logger?: cmn.Logger,
+	filter: AssetFilter = scriptAssetFilter
+): Promise<cmn.AssetConfiguration[]> {
+	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
+	return relativeFilePaths
+		.map(relativeFilePath => {
+			return {
+				type: "script",
+				path: cmn.Util.makeUnixPath(path.join(dir, relativeFilePath)),
+				global: true
+			};
+		})
+		.filter(asset => asset != null);
+}
+
+export async function scanTextAssets(
+	baseDir: string,
+	dir: string,
+	_logger?: cmn.Logger,
+	filter: AssetFilter = textAssetFilter
+): Promise<cmn.AssetConfiguration[]> {
+	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
+	return relativeFilePaths
+		.map(relativeFilePath => {
+			return {
+				type: "text",
+				path: cmn.Util.makeUnixPath(path.join(dir, relativeFilePath))
+			};
+		})
+		.filter(asset => asset != null);
+}
 
 export async function scanImageAssets(
 	baseDir: string,

--- a/packages/akashic-cli-scan/src/scanUtils.ts
+++ b/packages/akashic-cli-scan/src/scanUtils.ts
@@ -11,7 +11,7 @@ export function scriptAssetFilter(p: string): boolean {
 }
 
 export function textAssetFilter(p: string): boolean {
-	// NOTE: その他ファイルはすべてスクリプトアセットとして扱う
+	// NOTE: その他ファイルはすべてテキストアセットとして扱う
 	return !(
 		scriptAssetFilter(p) ||
 		imageAssetFilter(p) ||


### PR DESCRIPTION
## このPullRequestが解決する内容
game.json の `assets` フィールドが配列で定義されていた場合、アセットのスキャン結果を配列として取り込むように変更します。