### PR TITLE
add test of akashic-li-init template in test/e2e.js

### DIFF
--- a/test/e2e.js
+++ b/test/e2e.js
@@ -65,17 +65,27 @@ try{
 	// ゲームディレクトリを作成しつつakashic-cli-initのテスト
 	console.log("test @akashic/akashic-cli-init");
 	shell.cd(`${targetDir}/game`);
-	execSync(`${akashicCliPath} init -y`);
+	execSync(`${akashicCliPath} init --type typescript -y`);
+	execSync("npm install");
+	execSync("npm run build");
+	execSync("npm test");
+	execSync("npm run lint");
 
 	const files = fs.readdirSync(`${targetDir}/game`);
 	assertContains(files, "audio");
 	assertContains(files, "image");
+	assertContains(files, "src");
 	assertContains(files, "script");
 	assertContains(files, "text");
-	assertContains(files, ".eslintrc.json");
 	assertContains(files, "game.json");
 	assertContains(files, "package.json");
 	assertContains(files, "README.md");
+	assertContains(files, "sandbox.config.js");
+	assertContains(files, ".eslintrc.js");
+	assertContains(files, ".gitignore");
+	assertContains(files, "jest.config.js");
+	assertContains(files, "tsconfig.jest.json");
+	assertContains(files, "tsconfig.json");
 
 	// 各akashic-cli-xxxモジュールのテスト
 	// TODO 出力確認

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -66,16 +66,10 @@ try{
 	console.log("test @akashic/akashic-cli-init");
 	shell.cd(`${targetDir}/game`);
 	execSync(`${akashicCliPath} init --type typescript -y`);
-	execSync("npm install");
-	execSync("npm run build");
-	execSync("npm test");
-	execSync("npm run lint");
-
 	const files = fs.readdirSync(`${targetDir}/game`);
 	assertContains(files, "audio");
 	assertContains(files, "image");
 	assertContains(files, "src");
-	assertContains(files, "script");
 	assertContains(files, "text");
 	assertContains(files, "game.json");
 	assertContains(files, "package.json");
@@ -86,6 +80,10 @@ try{
 	assertContains(files, "jest.config.js");
 	assertContains(files, "tsconfig.jest.json");
 	assertContains(files, "tsconfig.json");
+	execSync("npm install");
+	execSync("npm run build");
+	execSync("npm test");
+	execSync("npm run lint");
 
 	// 各akashic-cli-xxxモジュールのテスト
 	// TODO 出力確認
@@ -136,6 +134,9 @@ try{
 	process.exit(0);
 } catch (e) {
 	console.error(e);
-	console.log("Failed!");
+	if (e.output) {
+		console.error(e.output.toString());
+	}
+	console.error("Failed!");
 	process.exit(1);
 }


### PR DESCRIPTION
### 概要
* akashic-cliの結合テスト(test/e2e.js)でinitテンプレートの内容を精査するテストが無かったので追加しました。
  * 本来であれば、全テンプレートをチェックすべきだが、テストの起動時間を考慮してtypescriptテンプレートのみのテストとしました。
    * 他のtypescript～～テンプレートはこのテンプレートと同様のベースから生み出され、このテンプレートからjavascriptテンプレートのほとんどのファイルが生成されるので、このテンプレートのチェックだけで良いのではと判断しましたが必要であればjavascriptテンプレート辺りのチェックを追加します

### やったこと
* test/e2e.jsでakashic-cli-initのtypescriptテンプレートを生成してnpm scriptを実行するテストを追加