### PR TITLE
Rename RPG-Atsumaru -> GAME-atsumaru

### DIFF
--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -1,7 +1,7 @@
 /*
  * 対象のサービス
  * nicolive: ニコニコ生放送
- * atsumaru: RPGアツマール
+ * atsumaru: GAMEアツマール
  * none: サービスなし
  */
 export const SERVICE_TYPES = ["nicolive", "atsumaru", "none"] as const;

--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -1,7 +1,7 @@
 /*
  * 対象のサービス
  * nicolive: ニコニコ生放送
- * atsumaru: GAMEアツマール
+ * atsumaru: ゲームアツマール
  * none: サービスなし
  */
 export const SERVICE_TYPES = ["nicolive", "atsumaru", "none"] as const;

--- a/packages/akashic-cli-export-html/src/app/cli.ts
+++ b/packages/akashic-cli-export-html/src/app/cli.ts
@@ -80,7 +80,7 @@ commander
 	.option("-i, --inject [fileName]", "specify injected file content into index.html", inject, [])
 	.option("--autoSendEvents [eventName]", "(deprecated)event name that send automatically when game start")
 	.option("-A, --auto-send-event-name [eventName]", "event name that send automatically when game start")
-	.option("-a, --atsumaru", "generate files that can be posted to RPG-atsumaru")
+	.option("-a, --atsumaru", "generate files that can be posted to GAME-atsumaru")
 	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.");
 
 export function run(argv: string[]): void {

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -11,7 +11,7 @@ export = (originalParam: g.GameMainParameterObject) => {
 	});
 	// セッションパラメーター
 	param.sessionParameter = {};
-	// コンテンツが動作している環境がRPGアツマール上かどうか
+	// コンテンツが動作している環境がGAMEアツマール上かどうか
 	param.isAtsumaru = typeof window !== "undefined" && typeof window.RPGAtsumaru !== "undefined";
 	// 乱数生成器
 	param.random = g.game.random;

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/_bootstrap.ts
@@ -11,7 +11,7 @@ export = (originalParam: g.GameMainParameterObject) => {
 	});
 	// セッションパラメーター
 	param.sessionParameter = {};
-	// コンテンツが動作している環境がGAMEアツマール上かどうか
+	// コンテンツが動作している環境がゲームアツマール上かどうか
 	param.isAtsumaru = typeof window !== "undefined" && typeof window.RPGAtsumaru !== "undefined";
 	// 乱数生成器
 	param.random = g.game.random;

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/main.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/main.ts
@@ -106,7 +106,7 @@ export function main(param: GameMainParameterObject): void {
 		});
 		const updateHandler = (): void => {
 			if (time <= 0) {
-				// GAMEアツマール環境であればランキングを表示します
+				// ゲームアツマール環境であればランキングを表示します
 				if (param.isAtsumaru) {
 					const boardId = 1;
 					window.RPGAtsumaru.experimental.scoreboards.setRecord(boardId, g.game.vars.gameState.score).then(function() {

--- a/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/main.ts
+++ b/packages/akashic-cli-init/templates-src/game-shin-ichiba-ranking/src/main.ts
@@ -106,7 +106,7 @@ export function main(param: GameMainParameterObject): void {
 		});
 		const updateHandler = (): void => {
 			if (time <= 0) {
-				// RPGアツマール環境であればランキングを表示します
+				// GAMEアツマール環境であればランキングを表示します
 				if (param.isAtsumaru) {
 					const boardId = 1;
 					window.RPGAtsumaru.experimental.scoreboards.setRecord(boardId, g.game.vars.gameState.score).then(function() {

--- a/packages/akashic-cli-init/templates-src/javascript-base/README.md
+++ b/packages/akashic-cli-init/templates-src/javascript-base/README.md
@@ -38,7 +38,7 @@ npm install
   * 基本的に`script/_bootstrap.js`を編集する必要はありません。
 * 基本的な使い方は javascript テンプレートと同じですが、このテンプレートでは `script/main.js` の `main` 関数の引数`param`に以下の値が新たに付与されています。
   * `param.sessionParameter`: [セッションパラメーター](https://akashic-games.github.io/guide/ranking.html#session-parameters)
-  * `param.isAtsumaru`:コンテンツが動作している環境がRPGアツマール上かどうかを表すbool値
+  * `param.isAtsumaru`:コンテンツが動作している環境がGAMEアツマール上かどうかを表すbool値
 * ランキングモードに対応したニコニコ新市場コンテンツの作り方の詳細については、[こちら](https://akashic-games.github.io/guide/ranking.html)を参照してください。
 
 ### アセットの更新方法

--- a/packages/akashic-cli-init/templates-src/javascript-base/README.md
+++ b/packages/akashic-cli-init/templates-src/javascript-base/README.md
@@ -38,7 +38,7 @@ npm install
   * 基本的に`script/_bootstrap.js`を編集する必要はありません。
 * 基本的な使い方は javascript テンプレートと同じですが、このテンプレートでは `script/main.js` の `main` 関数の引数`param`に以下の値が新たに付与されています。
   * `param.sessionParameter`: [セッションパラメーター](https://akashic-games.github.io/guide/ranking.html#session-parameters)
-  * `param.isAtsumaru`:コンテンツが動作している環境がGAMEアツマール上かどうかを表すbool値
+  * `param.isAtsumaru`:コンテンツが動作している環境がゲームアツマール上かどうかを表すbool値
 * ランキングモードに対応したニコニコ新市場コンテンツの作り方の詳細については、[こちら](https://akashic-games.github.io/guide/ranking.html)を参照してください。
 
 ### アセットの更新方法

--- a/packages/akashic-cli-init/templates-src/typescript-base/README.md
+++ b/packages/akashic-cli-init/templates-src/typescript-base/README.md
@@ -50,7 +50,7 @@ npm run build
   * 基本的に`src/_bootstrap.ts`を編集する必要はありません。
 * 基本的な使い方は typescript テンプレートと同じですが、このテンプレートでは `src/main.ts` の `main` 関数の引数`param`に以下の値が新たに付与されています。
   * `param.sessionParameter`: [セッションパラメーター](https://akashic-games.github.io/guide/ranking.html#session-parameters)
-  * `param.isAtsumaru`:コンテンツが動作している環境がRPGアツマール上かどうかを表すbool値
+  * `param.isAtsumaru`:コンテンツが動作している環境がGAMEアツマール上かどうかを表すbool値
 * ランキングモードに対応したニコニコ新市場コンテンツの作り方の詳細については、[こちら](https://akashic-games.github.io/guide/ranking.html)を参照してください。
 
 ### アセットの更新方法

--- a/packages/akashic-cli-init/templates-src/typescript-base/README.md
+++ b/packages/akashic-cli-init/templates-src/typescript-base/README.md
@@ -50,7 +50,7 @@ npm run build
   * 基本的に`src/_bootstrap.ts`を編集する必要はありません。
 * 基本的な使い方は typescript テンプレートと同じですが、このテンプレートでは `src/main.ts` の `main` 関数の引数`param`に以下の値が新たに付与されています。
   * `param.sessionParameter`: [セッションパラメーター](https://akashic-games.github.io/guide/ranking.html#session-parameters)
-  * `param.isAtsumaru`:コンテンツが動作している環境がGAMEアツマール上かどうかを表すbool値
+  * `param.isAtsumaru`:コンテンツが動作している環境がゲームアツマール上かどうかを表すbool値
 * ランキングモードに対応したニコニコ新市場コンテンツの作り方の詳細については、[こちら](https://akashic-games.github.io/guide/ranking.html)を参照してください。
 
 ### アセットの更新方法

--- a/packages/akashic-cli-serve/src/client/atsumaru/RPGAtsumaruApi.ts
+++ b/packages/akashic-cli-serve/src/client/atsumaru/RPGAtsumaruApi.ts
@@ -234,7 +234,7 @@ export class RPGAtsumaruApi implements RPGAtsumaruApiLike {
 		}
 	};
 
-	// アツマールAPIでexperimentalはdeprecated扱いになったが、GAMEアツマールでまだ対応しているのでserveでも利用できるようにしておく
+	// アツマールAPIでexperimentalはdeprecated扱いになったが、ゲームアツマールでまだ対応しているのでserveでも利用できるようにしておく
 	experimental = {
 		popups: {
 			displayCreatorInformationModal: this.popups.displayCreatorInformationModal

--- a/packages/akashic-cli-serve/src/client/atsumaru/RPGAtsumaruApi.ts
+++ b/packages/akashic-cli-serve/src/client/atsumaru/RPGAtsumaruApi.ts
@@ -234,7 +234,7 @@ export class RPGAtsumaruApi implements RPGAtsumaruApiLike {
 		}
 	};
 
-	// アツマールAPIでexperimentalはdeprecated扱いになったが、RPGアツマールでまだ対応しているのでserveでも利用できるようにしておく
+	// アツマールAPIでexperimentalはdeprecated扱いになったが、GAMEアツマールでまだ対応しているのでserveでも利用できるようにしておく
 	experimental = {
 		popups: {
 			displayCreatorInformationModal: this.popups.displayCreatorInformationModal

--- a/packages/akashic-cli-serve/src/client/atsumaru/ScoreboardData.ts
+++ b/packages/akashic-cli-serve/src/client/atsumaru/ScoreboardData.ts
@@ -1,4 +1,4 @@
-// RPGアツマールのスコアボードの情報
+// GAMEアツマールのスコアボードの情報
 export interface ScoreboardData {
 	myRecord: null | {
 	  isNewRecord: boolean,

--- a/packages/akashic-cli-serve/src/client/atsumaru/ScoreboardData.ts
+++ b/packages/akashic-cli-serve/src/client/atsumaru/ScoreboardData.ts
@@ -1,4 +1,4 @@
-// GAMEアツマールのスコアボードの情報
+// ゲームアツマールのスコアボードの情報
 export interface ScoreboardData {
 	myRecord: null | {
 	  isNewRecord: boolean,


### PR DESCRIPTION
## 概要

RPGアツマール が GAMEアツマール と改名となったため、実装に影響しないREADMEやコメント箇所を修正。