### PR TITLE
Fix warning message of akashic-cli-stat

### DIFF
--- a/packages/akashic-cli-stat/spec/statSpec.js
+++ b/packages/akashic-cli-stat/spec/statSpec.js
@@ -126,8 +126,7 @@ describe("format stat result", () => {
 		"  game.json: 367B\n" +
 		"[*] TOTAL SIZE (using ogg): 8.43KB (8632B)\n" +
 		"[ ] TOTAL SIZE (using mp4): 6.29KB (6443B)\n" +
-		"[ ] TOTAL SIZE (using aac): 5.14KB (5267B)\n" +
-		"WARN: AAC (.aac) is deprecated. Use MP4(AAC) (.mp4) instead.\n";
+		"[ ] TOTAL SIZE (using aac): 5.14KB (5267B)\n";
 
 	it("will output following text", done => {
 		let buffer = "";
@@ -155,8 +154,7 @@ describe("format stat result - maximum mp4", () => {
 		"  game.json: 168B\n" +
 		"[ ] TOTAL SIZE (using ogg): 7.61KB (7795B)\n" +
 		"[*] TOTAL SIZE (using mp4): 9.48KB (9704B)\n" +
-		"[ ] TOTAL SIZE (using aac): 4.33KB (4430B)\n" +
-		"WARN: AAC (.aac) is deprecated. Use MP4(AAC) (.mp4) instead.\n";
+		"[ ] TOTAL SIZE (using aac): 4.33KB (4430B)\n";
 
 	it("will output following text", done => {
 		let buffer = "";

--- a/packages/akashic-cli-stat/spec/statSpec.js
+++ b/packages/akashic-cli-stat/spec/statSpec.js
@@ -125,8 +125,9 @@ describe("format stat result", () => {
 		"other: 367B (4%)\n" +
 		"  game.json: 367B\n" +
 		"[*] TOTAL SIZE (using ogg): 8.43KB (8632B)\n" +
+		"[ ] TOTAL SIZE (using aac): 5.14KB (5267B)\n" +
 		"[ ] TOTAL SIZE (using mp4): 6.29KB (6443B)\n" +
-		"[ ] TOTAL SIZE (using aac): 5.14KB (5267B)\n";
+		"WARN: MP4 (.mp4) is deprecated. Use AAC(.aac) instead.\n";
 
 	it("will output following text", done => {
 		let buffer = "";
@@ -153,8 +154,9 @@ describe("format stat result - maximum mp4", () => {
 		"other: 168B (2%)\n" +
 		"  game.json: 168B\n" +
 		"[ ] TOTAL SIZE (using ogg): 7.61KB (7795B)\n" +
+		"[ ] TOTAL SIZE (using aac): 4.33KB (4430B)\n" +
 		"[*] TOTAL SIZE (using mp4): 9.48KB (9704B)\n" +
-		"[ ] TOTAL SIZE (using aac): 4.33KB (4430B)\n";
+		"WARN: MP4 (.mp4) is deprecated. Use AAC(.aac) instead.\n";
 
 	it("will output following text", done => {
 		let buffer = "";
@@ -172,6 +174,7 @@ describe("format stat result - maximum mp4", () => {
 
 describe("format stat result - drop AAC", () => {
 	const expectedText =
+		"WARN: audio/dummy.aac, No such file.\n" +
 		"image: 144B (2%)\n" +
 		"text: 0B (0%)\n" +
 		"ogg audio: 7.45KB (88%)\n" +
@@ -180,7 +183,9 @@ describe("format stat result - drop AAC", () => {
 		"other: 367B (4%)\n" +
 		"  game.json: 367B\n" +
 		"[*] TOTAL SIZE (using ogg): 8.43KB (8632B)\n" +
-		"[ ] TOTAL SIZE (using mp4): 6.29KB (6443B)\n";
+		"[ ] TOTAL SIZE (using aac): 1005B (1005B)\n" +
+		"[ ] TOTAL SIZE (using mp4): 6.29KB (6443B)\n" +
+		"WARN: MP4 (.mp4) is deprecated. Use AAC(.aac) instead.\n";
 
 	it("will output following text", done => {
 		let buffer = "";

--- a/packages/akashic-cli-stat/src/stat.ts
+++ b/packages/akashic-cli-stat/src/stat.ts
@@ -125,16 +125,17 @@ function showSize(param: StatSizeParameterObject, sizeResult: SizeResult): void 
 			` (${sizeResult.totalSizeOgg()}B)`
 		);
 		param.logger.print(
-			`${mark(largestFileType === FileType.Mp4)} TOTAL SIZE (using mp4): ` +
-			sizeToString(sizeResult.totalSizeMp4()) +
-			` (${sizeResult.totalSizeMp4()}B)`
+			`${mark(largestFileType === FileType.Aac)} TOTAL SIZE (using aac): ` +
+			sizeToString(sizeResult.totalSizeAac()) +
+			` (${sizeResult.totalSizeAac()}B)`
 		);
-		if (sizeResult.aacAudioSize > 0) {
+		if (sizeResult.mp4AudioSize > 0) {
 			param.logger.print(
-				`${mark(largestFileType === FileType.Aac)} TOTAL SIZE (using aac): ` +
-				sizeToString(sizeResult.totalSizeAac()) +
-				` (${sizeResult.totalSizeAac()}B)`
+				`${mark(largestFileType === FileType.Mp4)} TOTAL SIZE (using mp4): ` +
+				sizeToString(sizeResult.totalSizeMp4()) +
+				` (${sizeResult.totalSizeMp4()}B)`
 			);
+			param.logger.warn("MP4 (.mp4) is deprecated. Use AAC(.aac) instead.");
 		}
 	} else {
 		param.logger.print(totalSize.toString());
@@ -205,12 +206,13 @@ function sizeOfAssets(param: StatSizeParameterObject, sizeResult: SizeResult): P
 
 					.then(() => fileSize(path.join(param.basepath, asset.path + ".mp4")))
 					.then(
-						size => { sizeResult.mp4AudioSize += size; })
+						size => { sizeResult.mp4AudioSize += size; },
+						() => {/* .mp4ファイルは存在すれば対応するが、deprecatedなのでファイルが存在しない場合でも警告を表示しない */ })
 
 					.then(() => fileSize(path.join(param.basepath, asset.path + ".aac")))
 					.then(
 						size => { sizeResult.aacAudioSize += size; },
-						() => {/* .aacファイルは存在すれば対応するが、deprecatedなのでファイルが存在しない場合でも警告を表示しない */});
+						() => { if (!param.raw) param.logger.warn(asset.path + ".aac, No such file."); });
 			default:
 				throw new Error(`${asset.type} is not a valid asset type name`);
 		}

--- a/packages/akashic-cli-stat/src/stat.ts
+++ b/packages/akashic-cli-stat/src/stat.ts
@@ -135,7 +135,6 @@ function showSize(param: StatSizeParameterObject, sizeResult: SizeResult): void 
 				sizeToString(sizeResult.totalSizeAac()) +
 				` (${sizeResult.totalSizeAac()}B)`
 			);
-			param.logger.warn("AAC (.aac) is deprecated. Use MP4(AAC) (.mp4) instead.");
 		}
 	} else {
 		param.logger.print(totalSize.toString());
@@ -206,8 +205,7 @@ function sizeOfAssets(param: StatSizeParameterObject, sizeResult: SizeResult): P
 
 					.then(() => fileSize(path.join(param.basepath, asset.path + ".mp4")))
 					.then(
-						size => { sizeResult.mp4AudioSize += size; },
-						() => {if (!param.raw) param.logger.warn(asset.path + ".mp4, No such file."); })
+						size => { sizeResult.mp4AudioSize += size; })
 
 					.then(() => fileSize(path.join(param.basepath, asset.path + ".aac")))
 					.then(


### PR DESCRIPTION
## 概要

akashic-cli-stat で、 `.aac` があると `.mp4` も必要という警告メッセージの削除。
