### PR TITLE
Fix renovate error

### DIFF
--- a/packages/akashic-cli-export-html/src/app/cli.ts
+++ b/packages/akashic-cli-export-html/src/app/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigExportHtml, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { promiseExportHTML, ExportHTMLParameterObject } from "./exportHTML";
 import { promiseExportAtsumaru } from "./exportAtsumaru";
@@ -62,6 +62,7 @@ function cli(param: CliConfigExportHtml): void {
 		});
 }
 
+const commander = new Command();
 commander
 	.version(ver);
 
@@ -87,8 +88,9 @@ export function run(argv: string[]): void {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
 	const argvCopy = dropDeprecatedArgs(argv);
 	commander.parse(argvCopy);
+	const options = commander.opts();
 
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -96,20 +98,20 @@ export function run(argv: string[]): void {
 
 		const conf = configuration.commandOptions.export ? (configuration.commandOptions.export.html || {}) : {};
 		cli({
-			cwd: commander["cwd"] ?? conf.cwd,
-			force: commander["force"] ?? conf.force,
-			quiet: commander["quiet"] ?? conf.quiet,
-			output: commander["output"] ?? conf.output,
-			source: commander["source"] ?? conf.source,
-			strip: commander["strip"] ?? conf.strip,
-			minify: commander["minify"] ?? conf.minify,
-			bundle: commander["bundle"] ?? conf.bundle,
-			magnify: commander["magnify"] ?? conf.magnify,
-			hashFilename: commander["hashFilename"] ?? conf.hashFilename,
-			injects: commander["inject"] ?? conf.injects,
-			atsumaru: commander["atsumaru"] ?? conf.atsumaru,
-			autoSendEventName: commander["autoSendEventName"] ?? commander["autoSendEvents"] ?? conf.autoSendEventName ?? conf.autoSendEvents,
-			omitUnbundledJs: commander["omitUnbundledJs"] ?? conf.omitUnbundledJs
+			cwd: options["cwd"] ?? conf.cwd,
+			force: options["force"] ?? conf.force,
+			quiet: options["quiet"] ?? conf.quiet,
+			output: options["output"] ?? conf.output,
+			source: options["source"] ?? conf.source,
+			strip: options["strip"] ?? conf.strip,
+			minify: options["minify"] ?? conf.minify,
+			bundle: options["bundle"] ?? conf.bundle,
+			magnify: options["magnify"] ?? conf.magnify,
+			hashFilename: options["hashFilename"] ?? conf.hashFilename,
+			injects: options["inject"] ?? conf.injects,
+			atsumaru: options["atsumaru"] ?? conf.atsumaru,
+			autoSendEventName: options["autoSendEventName"] ?? options["autoSendEvents"] ?? conf.autoSendEventName ?? conf.autoSendEvents,
+			omitUnbundledJs: options["omitUnbundledJs"] ?? conf.omitUnbundledJs
 		});
 	});
 }

--- a/packages/akashic-cli-export-zip/src/cli.ts
+++ b/packages/akashic-cli-export-zip/src/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigExportZip, SERVICE_TYPES } from "@akashic/akashic-cli-commons";
 import { promiseExportZip } from "./exportZip";
 
@@ -45,6 +45,7 @@ export function cli(param: CliConfigExportZip): void {
 		});
 }
 
+const commander = new Command();
 commander
 	.version(ver);
 
@@ -67,32 +68,33 @@ export function run(argv: string[]): void {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
 	const argvCopy = dropDeprecatedArgs(argv);
 	commander.parse(argvCopy);
+	const options = commander.opts();
 
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
 		}
 
-		if (commander["targetService"] && !availableServices.includes(commander["targetService"])) {
-			console.error("Invalid --target-service option argument: " + commander["targetService"]);
+		if (options["targetService"] && !availableServices.includes(options["targetService"])) {
+			console.error("Invalid --target-service option argument: " + options["targetService"]);
 			process.exit(1);
 		}
 
 		const conf = configuration.commandOptions.export ? (configuration.commandOptions.export.zip || {}) : {};
 		cli({
-			cwd: commander["cwd"] ?? conf.cwd,
-			quiet: commander["quiet"] ?? conf.quiet,
-			output: commander["output"] ?? conf.output,
-			force: commander["force"] ?? conf.force,
-			strip: commander["strip"] ?? conf.strip,
-			minify: commander["minify"] ?? conf.minify,
-			hashFilename: commander["hashFilename"] ?? conf.hashFilename,
-			bundle: commander["bundle"] ?? conf.bundle,
-			babel: commander["es5Downpile"] ?? conf.babel,
-			omitEmptyJs: commander["omitEmptyJs"] ?? conf.omitEmptyJs,
-			omitUnbundledJs: commander["omitUnbundledJs"] ?? conf.omitUnbundledJs,
-			targetService: commander["targetService"] ?? conf.targetService
+			cwd: options["cwd"] ?? conf.cwd,
+			quiet: options["quiet"] ?? conf.quiet,
+			output: options["output"] ?? conf.output,
+			force: options["force"] ?? conf.force,
+			strip: options["strip"] ?? conf.strip,
+			minify: options["minify"] ?? conf.minify,
+			hashFilename: options["hashFilename"] ?? conf.hashFilename,
+			bundle: options["bundle"] ?? conf.bundle,
+			babel: options["es5Downpile"] ?? conf.babel,
+			omitEmptyJs: options["omitEmptyJs"] ?? conf.omitEmptyJs,
+			omitUnbundledJs: options["omitUnbundledJs"] ?? conf.omitUnbundledJs,
+			targetService: options["targetService"] ?? conf.targetService
 		});
 	});
 }

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigInit } from "@akashic/akashic-cli-commons";
 import { promiseInit } from "./init";
 import { listTemplates } from "./listTemplates";
@@ -25,6 +25,7 @@ function cli(param: CliConfigInit): void {
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
 	.version(ver);
 
@@ -40,8 +41,9 @@ commander
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
+	const options = commander.opts();
 
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -49,12 +51,12 @@ export function run(argv: string[]): void {
 
 		const conf = configuration.commandOptions.init || {};
 		cli({
-			cwd: commander.cwd ?? conf.cwd,
-			quiet: commander.quiet ?? conf.quiet,
-			type: commander.type ?? conf.type,
-			list: commander.list ?? conf.list,
-			yes: commander.yes ?? conf.yes,
-			force: commander.force ?? conf.force
+			cwd: options.cwd ?? conf.cwd,
+			quiet: options.quiet ?? conf.quiet,
+			type: options.type ?? conf.type,
+			list: options.list ?? conf.list,
+			yes: options.yes ?? conf.yes,
+			force: options.force ?? conf.force
 		});
 	});
 }

--- a/packages/akashic-cli-install/src/cli.ts
+++ b/packages/akashic-cli-install/src/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigInstall } from "@akashic/akashic-cli-commons";
 import { promiseInstall } from "./install";
 
@@ -19,6 +19,7 @@ function cli(param: CliConfigInstall): void {
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
 	.version(ver);
 
@@ -33,7 +34,8 @@ commander
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	const options = commander.opts();
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -42,11 +44,11 @@ export function run(argv: string[]): void {
 		const conf = configuration.commandOptions.install || {};
 		cli({
 			args: commander["args"] ?? conf.args,
-			cwd: commander["cwd"] ?? conf.cwd,
-			link: commander["link"] ?? conf.link,
-			quiet: commander["quiet"] ?? conf.quiet,
-			plugin: commander["plugin"] ?? conf.plugin,
-			omitPackagejson: commander["omitPackagejson"] ?? conf.omitPackagejson
+			cwd: options["cwd"] ?? conf.cwd,
+			link: options["link"] ?? conf.link,
+			quiet: options["quiet"] ?? conf.quiet,
+			plugin: options["plugin"] ?? conf.plugin,
+			omitPackagejson: options["omitPackagejson"] ?? conf.omitPackagejson
 		});
 	});
 }

--- a/packages/akashic-cli-modify/src/cli.ts
+++ b/packages/akashic-cli-modify/src/cli.ts
@@ -1,8 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigModify } from "@akashic/akashic-cli-commons";
 import { promiseModifyBasicParameter } from "./modify";
+
+const commander = new Command();
 
 function cliBasicParameter(target: string, value: string, opts: CliConfigModify): void {
 	var logger = new ConsoleLogger({ quiet: opts.quiet });
@@ -21,7 +23,7 @@ function defineCommand(commandName: string): void {
 		.option("-C, --cwd <dir>", "The directory incluedes game.json")
 		.option("-q, --quiet", "Suppress output")
 		.action((value: string, opts: CliConfigModify = {}) => {
-			CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+			CliConfigurationFile.read(path.join(opts["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 				if (error) {
 					console.error(error);
 					process.exit(1);

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -1,11 +1,11 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigScanAsset, CliConfigScanGlobalScripts } from "@akashic/akashic-cli-commons";
 import { promiseScanAsset, promiseScanNodeModules, watchAsset, ScanAssetParameterObject } from "./scan";
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
-
+const commander = new Command();
 commander
 	.description("Update various properties of game.json")
 	.version(ver);
@@ -28,7 +28,7 @@ commander
 	.option("--text-asset-dir <dir>", "specify TextAsset directory", commanderArgsCoordinater)
 	.option("--text-asset-extension <extension>", "specify TextAsset extension", commanderArgsCoordinater)
 	.action((target: string, opts: CliConfigScanAsset = {}) => {
-		CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+		CliConfigurationFile.read(path.join(opts["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 			if (error) {
 				console.error(error);
 				process.exit(1);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -5,7 +5,7 @@ import * as http from "http";
 import * as express from "express";
 import * as bodyParser from "body-parser";
 import * as socketio from "socket.io";
-import * as commander from "commander";
+import { Command, OptionValues } from "commander";
 import * as chalk from "chalk";
 import * as open from "open";
 import { PlayManager, RunnerManager, setSystemLogger, getSystemLogger } from "@akashic/headless-driver";
@@ -32,7 +32,7 @@ function convertToStrings(params: any[]): string[] {
 	});
 }
 
-async function cli(cliConfigParam: CliConfigServe) {
+async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues) {
 	if (cliConfigParam.port && isNaN(cliConfigParam.port)) {
 		console.error("Invalid --port option: " + cliConfigParam.port);
 		process.exit(1);
@@ -104,15 +104,15 @@ async function cli(cliConfigParam: CliConfigServe) {
 	}
 
 	let gameExternalFactory: () => any = () => undefined;
-	if (commander.serverExternalScript) {
+	if (cmdOptions.serverExternalScript) {
 		try {
-			gameExternalFactory = require(path.resolve(commander.serverExternalScript));
+			gameExternalFactory = require(path.resolve(cmdOptions.serverExternalScript));
 		} catch (e) {
-			getSystemLogger().error(`Failed to evaluating --server-external-script (${commander.serverExternalScript}): ${e}`);
+			getSystemLogger().error(`Failed to evaluating --server-external-script (${cmdOptions.serverExternalScript}): ${e}`);
 			process.exit(1);
 		}
 		if (typeof gameExternalFactory !== "function") {
-			getSystemLogger().error(`${commander.serverExternalScript}, given as --server-external-script, does not export a function`);
+			getSystemLogger().error(`${cmdOptions.serverExternalScript}, given as --server-external-script, does not export a function`);
 			process.exit(1);
 		}
 	}
@@ -193,7 +193,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 		// サーバー起動のログに関してはSystemLoggerで使用していない色を使いたいので緑を選択
 		console.log(chalk.green(`Hosting ${targetDirs.join(", ")} on http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`));
 		if (loadedPlaylogPlayId) {
-			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), commander.debugPlaylog)}).`);
+			console.log(`play(id: ${loadedPlaylogPlayId}) read playlog(path: ${path.join(process.cwd(), cmdOptions.debugPlaylog)}).`);
 			url += `?playId=${loadedPlaylogPlayId}&mode=replay`;
 			console.log(`if access ${url}, you can show this play.`);
 		}
@@ -207,6 +207,7 @@ async function cli(cliConfigParam: CliConfigServe) {
 // TODOこのファイルを改名してcli.tsにする
 export async function run(argv: any): Promise<void> {
 	const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8")).version;
+	const commander = new Command();
 	commander
 		.version(ver)
 		.description("Development server for Akashic Engine to debug multiple-player games")
@@ -226,7 +227,8 @@ export async function run(argv: any): Promise<void> {
 		.option("--preserve-disconnected", "Disable auto closing for disconnected windows.")
 		.parse(argv);
 
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), async (error, configuration) => {
+	const options = commander.opts();
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), async (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -234,19 +236,19 @@ export async function run(argv: any): Promise<void> {
 
 		const conf = configuration.commandOptions.serve || {};
 		const cliConfigParam: CliConfigServe = {
-			port: commander.port ?? conf.port,
-			hostname: commander.hostname ?? conf.hostname,
-			verbose: commander.verbose ?? conf.verbose,
-			autoStart: commander.autoStart ?? conf.autoStart,
-			targetService: commander.targetService ?? conf.targetService,
-			debugPlaylog: commander.debugPlaylog ?? conf.debugPlaylog,
-			debugUntrusted: commander.debugUntrusted ?? conf.debugUntrusted,
-			debugProxyAudio: commander.proxyAudio ?? conf.debugProxyAudio,
-			allowExternal: commander.allowExternal ?? conf.allowExternal,
+			port: options.port ?? conf.port,
+			hostname: options.hostname ?? conf.hostname,
+			verbose: options.verbose ?? conf.verbose,
+			autoStart: options.autoStart ?? conf.autoStart,
+			targetService: options.targetService ?? conf.targetService,
+			debugPlaylog: options.debugPlaylog ?? conf.debugPlaylog,
+			debugUntrusted: options.debugUntrusted ?? conf.debugUntrusted,
+			debugProxyAudio: options.proxyAudio ?? conf.debugProxyAudio,
+			allowExternal: options.allowExternal ?? conf.allowExternal,
 			targetDirs: commander.args.length > 0 ? commander.args : (conf.targetDirs ?? [process.cwd()]),
-			openBrowser: commander.openBrowser ?? conf.openBrowser,
-			preserveDisconnected: commander.preserveDisconnected ?? conf.preserveDisconnected
+			openBrowser: options.openBrowser ?? conf.openBrowser,
+			preserveDisconnected: options.preserveDisconnected ?? conf.preserveDisconnected
 		};
-		await cli(cliConfigParam);
+		await cli(cliConfigParam, options);
 	});
 }

--- a/packages/akashic-cli-stat/src/cli.ts
+++ b/packages/akashic-cli-stat/src/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { Logger, ConsoleLogger, ConfigurationFile, CliConfigurationFile, CliConfigStat } from "@akashic/akashic-cli-commons";
 import * as stat from "./stat";
 
@@ -26,6 +26,7 @@ function errorExit(logger: Logger, message: string): void {
 
 const version = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
 	.description("Show statistics information")
 	.version(version)
@@ -50,7 +51,8 @@ function cli(param: CliConfigStat): void {
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	const options = commander.opts();
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -59,10 +61,10 @@ export function run(argv: string[]): void {
 		const conf = configuration.commandOptions.stat || {};
 		cli({
 			args: commander.args ?? conf.args,
-			cwd: commander.cwd ?? conf.cwd,
-			quiet: commander.quiet ?? conf.quiet,
-			limit: commander.limit ?? conf.limit,
-			raw: commander.raw ?? conf.raw
+			cwd: options.cwd ?? conf.cwd,
+			quiet: options.quiet ?? conf.quiet,
+			limit: options.limit ?? conf.limit,
+			raw: options.raw ?? conf.raw
 		});
 	});
 }

--- a/packages/akashic-cli-uninstall/src/cli.ts
+++ b/packages/akashic-cli-uninstall/src/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigUninstall } from "@akashic/akashic-cli-commons";
 import { promiseUninstall } from "./uninstall";
 
@@ -17,6 +17,7 @@ function cli(param: CliConfigUninstall): void {
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
 	.version(ver);
 
@@ -30,7 +31,8 @@ commander
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	const options = commander.opts();
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -39,10 +41,10 @@ export function run(argv: string[]): void {
 		const conf = configuration.commandOptions.uninstall || {};
 		cli({
 			args: commander.args ?? conf.args,
-			cwd: commander.cwd ?? conf.cwd,
-			unlink: commander.unlink ?? conf.unlink,
-			quiet: commander.quiet ?? conf.quiet,
-			plugin: commander.plugin ?? conf.plugin
+			cwd: options.cwd ?? conf.cwd,
+			unlink: options.unlink ?? conf.unlink,
+			quiet: options.quiet ?? conf.quiet,
+			plugin: options.plugin ?? conf.plugin
 		});
 	});
 }

--- a/packages/akashic-cli-update/src/cli.ts
+++ b/packages/akashic-cli-update/src/cli.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger, CliConfigurationFile, CliConfigUpdate } from "@akashic/akashic-cli-commons";
 import { promiseUpdate } from "./update";
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
 	.usage("[options] <moduleName...>")
 	.description("Update installed npm modules")
@@ -25,7 +26,8 @@ commander
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
-	CliConfigurationFile.read(path.join(commander["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
+	const options = commander.opts();
+	CliConfigurationFile.read(path.join(options["cwd"] || process.cwd(), "akashic.config.js"), (error, configuration) => {
 		if (error) {
 			console.error(error);
 			process.exit(1);
@@ -33,8 +35,8 @@ export function run(argv: string[]): void {
 
 		const conf = configuration.commandOptions.update || {};
 		cli({
-			cwd: commander.cwd ?? conf.cwd,
-			quiet: commander.quiet ?? conf.quiet,
+			cwd: options.cwd ?? conf.cwd,
+			quiet: options.quiet ?? conf.quiet,
 			args: commander.args ?? conf.args
 		});
 	});

--- a/packages/akashic-cli/src/ui.ts
+++ b/packages/akashic-cli/src/ui.ts
@@ -5,7 +5,6 @@ var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json
 
 const commander = new Command();
 commander
-	.storeOptionsAsProperties()
 	.version(ver)
 	.command("init", "Initialize game.json and make asset directories")
 	.command("scan", "Update asset and globalScripts properties of game.json")
@@ -20,9 +19,3 @@ commander
 	.command("stat", "Show statistics information")
 	.command("serve", "Start a server that hosts a game to test multiplaying")
 	.parse(process.argv);
-
-const optionNames = commander.commands.map((cmd) => cmd.name());
-if (!optionNames.includes(commander.args[0])) {
-	console.log("Unknown command : " + process.argv[2]);
-	commander.help();
-}

--- a/packages/akashic-cli/src/ui.ts
+++ b/packages/akashic-cli/src/ui.ts
@@ -1,9 +1,11 @@
-import * as commander from "commander";
+import { Command } from "commander";
 import * as fs from "fs";
 import * as path from "path";
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
+const commander = new Command();
 commander
+	.storeOptionsAsProperties()
 	.version(ver)
 	.command("init", "Initialize game.json and make asset directories")
 	.command("scan", "Update asset and globalScripts properties of game.json")
@@ -19,7 +21,8 @@ commander
 	.command("serve", "Start a server that hosts a game to test multiplaying")
 	.parse(process.argv);
 
-if (!commander.runningCommand) {
+const optionNames = commander.commands.map((cmd) => cmd.name());
+if (!optionNames.includes(commander.args[0])) {
 	console.log("Unknown command : " + process.argv[2]);
 	commander.help();
 }


### PR DESCRIPTION
### 概要

renovate のPR #650 の commander.js アップデートによるエラーを修正します。

- commander.js が v7 から使用方法が変更となった
  - Command のインスタンス化
  - オプションの取得方法変更   

**#650 へマージします**