### PR TITLE
Add experimentalOpen to CliConfigServe

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -14,4 +14,5 @@ export interface CliConfigServe {
 	openBrowser?: boolean;
 	preserveDisconnected?: boolean;
 	watch?: boolean;
+	experimentalOpen?: number;
 }


### PR DESCRIPTION
## 概要

serve の `--experimental-open` オプション追加に伴い、commns の CliConfigServe.ts に `experimentalOpen` を追加。

**関連PR**
https://github.com/akashic-games/akashic-cli/pull/724