### PR TITLE
change reference method of akashic-cli-commons in init, scan, serve

### DIFF
--- a/packages/akashic-cli-init/spec/BasicParametersSpec.js
+++ b/packages/akashic-cli-init/spec/BasicParametersSpec.js
@@ -1,15 +1,15 @@
-var mockPrompt = require("./support/mockPrompt");
-var bp = require("../lib/BasicParameters");
-var mockfs = require("mock-fs");
 var fs = require("fs-extra");
+var mockfs = require("mock-fs");
 var os = require("os");
 var path = require("path");
-var commons = require("@akashic/akashic-cli-commons");
+var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger;
+var bp = require("../lib/BasicParameters");
+var mockPrompt = require("./support/mockPrompt");
 
 describe("BasicParameters", function () {
 	describe("updateConfigurationFile()", function () {
 		var confPath = fs.mkdtempSync(path.join(os.tmpdir(), ".akashicrc"));
-		var quietLogger = new commons.ConsoleLogger({quiet: true});
+		var quietLogger = new ConsoleLogger({quiet: true});
 
 		beforeEach(() => {
 			mockfs({});

--- a/packages/akashic-cli-init/spec/InitParameterObjectSpec.js
+++ b/packages/akashic-cli-init/spec/InitParameterObjectSpec.js
@@ -1,14 +1,14 @@
-var MockConfigFile = require("./support/mockConfigFile");
-var target = require("../lib/InitParameterObject");
-var commons = require("@akashic/akashic-cli-commons");
 var os = require("os");
 var path = require("path");
+var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger;
+var target = require("../lib/InitParameterObject");
+var MockConfigFile = require("./support/mockConfigFile");
 
 describe("InitParameterObject.ts", () => {
 	describe("completeInitParameterObject()", () => {
 		it("complete InitParameterObject", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				configFile: new MockConfigFile({
 					"init.repository": "dummyRepositoryUrl",
 					"init.localTemplateDirectory": "dummyTemplateDirectory",
@@ -28,7 +28,7 @@ describe("InitParameterObject.ts", () => {
 
 		it("using default values", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				configFile: new MockConfigFile({})
 			};
 			target.completeInitParameterObject(param)

--- a/packages/akashic-cli-init/spec/copyTemplateSpec.js
+++ b/packages/akashic-cli-init/spec/copyTemplateSpec.js
@@ -1,8 +1,8 @@
-var ct = require("../lib/copyTemplate");
-var mockfs = require("mock-fs");
-var commons = require("@akashic/akashic-cli-commons");
 var fs = require("fs-extra");
+var mockfs = require("mock-fs");
 var path = require("path");
+var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger;
+var ct = require("../lib/copyTemplate");
 
 describe("copyTemplate.ts", () => {
 	describe("copyTemplate()", () => {
@@ -48,7 +48,7 @@ describe("copyTemplate.ts", () => {
 
 		it("copy simple template", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "simple",
 				cwd: "home"
@@ -65,7 +65,7 @@ describe("copyTemplate.ts", () => {
 
 		it("copy manual template", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "manual",
 				cwd: "home"
@@ -80,7 +80,7 @@ describe("copyTemplate.ts", () => {
 
 		it("can not copy when file exists", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "simple",
 				cwd: ".akashic-templates/copyTo"
@@ -95,7 +95,7 @@ describe("copyTemplate.ts", () => {
 
 		it("can not copy when file exists (specify files)", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "simple",
 				cwd: ".akashic-templates/copyTo"
@@ -110,7 +110,7 @@ describe("copyTemplate.ts", () => {
 
 		it("can copy files with force-option even if file exists", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "simple",
 				cwd: ".akashic-templates/copyTo",
@@ -127,7 +127,7 @@ describe("copyTemplate.ts", () => {
 
 		it("can copy files with force-option even if file exists (specify files)", done => {
 			var param = {
-				logger: new commons.ConsoleLogger({quiet: true}),
+				logger: new ConsoleLogger({quiet: true}),
 				_realTemplateDirectory: ".akashic-templates",
 				type: "simple",
 				cwd: ".akashic-templates/copyTo",

--- a/packages/akashic-cli-init/spec/downloadTemplateSpec.js
+++ b/packages/akashic-cli-init/spec/downloadTemplateSpec.js
@@ -1,10 +1,9 @@
-var dt = require("../lib/downloadTemplate");
-var lt = require("../lib/listTemplates");
-var commons = require("@akashic/akashic-cli-commons");
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
-var MockConfigFile = require("./support/mockConfigFile");
+var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger;
+var dt = require("../lib/downloadTemplate");
+var lt = require("../lib/listTemplates");
 
 describe("downloadTemplate.ts", () => {
 
@@ -40,7 +39,7 @@ describe("downloadTemplate.ts", () => {
 				})
 			}).then((dir) => {
 				var param = {
-					logger: new commons.ConsoleLogger({quiet: true}),
+					logger: new ConsoleLogger({quiet: true}),
 					_realTemplateDirectory: dir,
 					repository: "http://127.0.0.1:18080/templates/",
 					templateListJsonPath: "template-list.json",
@@ -74,7 +73,7 @@ describe("downloadTemplate.ts", () => {
 			})
 			.then((dir) =>{
 				param = {
-					logger: new commons.ConsoleLogger({ quiet: true }),
+					logger: new ConsoleLogger({ quiet: true }),
 					_realTemplateDirectory: dir,
 					repository: "http://127.0.0.1:18080/templates/",
 					templateListJsonPath: "template-list.json",

--- a/packages/akashic-cli-init/src/BasicParameters.ts
+++ b/packages/akashic-cli-init/src/BasicParameters.ts
@@ -1,5 +1,7 @@
 import * as Prompt from "prompt";
-import * as commons from "@akashic/akashic-cli-commons";
+import { ConfigurationFile } from "@akashic/akashic-cli-commons/lib/ConfigurationFile";
+import { GameConfiguration } from "@akashic/akashic-cli-commons/lib/GameConfiguration";
+import { Logger } from "@akashic/akashic-cli-commons/lib/Logger";
 
 /**
  * game.jsonの初期値として与えるパラメータ。
@@ -87,7 +89,7 @@ function validateBasicParameters(params: any, props: any): string {
 /**
  * game.json に BasicParameters の内容をセットする。
  */
-function setBasicParameters(conf: commons.GameConfiguration, basicParams: BasicParameters): void {
+function setBasicParameters(conf: GameConfiguration, basicParams: BasicParameters): void {
 	conf.width = basicParams.width;
 	conf.height = basicParams.height;
 	conf.fps = basicParams.fps;
@@ -96,8 +98,8 @@ function setBasicParameters(conf: commons.GameConfiguration, basicParams: BasicP
 /**
  * 指定した game.json の基本パラメータを更新する
  */
-export function updateConfigurationFile(confPath: string, logger: commons.Logger, skipAsk: boolean): Promise<void> {
-	return commons.ConfigurationFile.read(confPath, logger)
+export function updateConfigurationFile(confPath: string, logger: Logger, skipAsk: boolean): Promise<void> {
+	return ConfigurationFile.read(confPath, logger)
 		.then(conf =>
 			promptGetBasicParameters({
 				width: conf.width,
@@ -106,7 +108,7 @@ export function updateConfigurationFile(confPath: string, logger: commons.Logger
 			}, skipAsk)
 				.then(basicParams => {
 					setBasicParameters(conf, basicParams);
-					return commons.ConfigurationFile.write(conf, confPath, logger);
+					return ConfigurationFile.write(conf, confPath, logger);
 				})
 		);
 }

--- a/packages/akashic-cli-init/src/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/InitParameterObject.ts
@@ -1,4 +1,5 @@
-import * as commons from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { Logger } from "@akashic/akashic-cli-commons/lib/Logger";
 import * as config from "@akashic/akashic-cli-config";
 import * as os from "os";
 import * as path from "path";
@@ -8,7 +9,7 @@ export interface InitParameterObject {
 	 * コマンドの出力を受け取るロガー。
 	 * 省略された場合、akashic-cli-commons の `new ConsoleLogger()` 。
 	 */
-	logger?: commons.Logger;
+	logger?: Logger;
 
 	/**
 	 * 利用する設定ファイル
@@ -73,7 +74,7 @@ const templateConfigValidator: config.StringMap = {
  * 未代入のパラメータを補完する
  */
 export function completeInitParameterObject(param: InitParameterObject): Promise<void> {
-	param.logger = param.logger || new commons.ConsoleLogger();
+	param.logger = param.logger || new ConsoleLogger();
 	param.configFile = param.configFile || new config.AkashicConfigFile(templateConfigValidator);
 	param.cwd = param.cwd || process.cwd();
 	param.templateListJsonPath = param.templateListJsonPath || "template-list.json";

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -1,7 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Command } from "commander";
-import { ConsoleLogger, CliConfigurationFile, CliConfigInit } from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { CliConfigurationFile } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigurationFile";
+import { CliConfigInit } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigInit";
 import { promiseInit } from "./init";
 import { listTemplates } from "./listTemplates";
 

--- a/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/ConfigurationSpec.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import * as fs from "fs";
-import * as cmn from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { hashFilepath } from "@akashic/akashic-cli-commons/lib/Renamer";
 import * as cnf from "../../lib/Configuration";
 import { MockPromisedNpm } from "./helpers/MockPromisedNpm";
 
@@ -124,7 +125,7 @@ describe("Utilities for Configuration", function () {
 });
 
 describe("Configuration", function () {
-	var nullLogger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
+	var nullLogger = new ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 	var DUMMY_1x1_PNG_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy1x1.png"));
 	var DUMMY_OGG_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy.ogg"));
 	var DUMMY_AAC_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy.aac"));
@@ -591,7 +592,7 @@ describe("Configuration", function () {
 			}
 		});
 		var loggedCount = 0;
-		var logger = new cmn.ConsoleLogger({ quiet: false, debugLogMethod: () => ++loggedCount });
+		var logger = new ConsoleLogger({ quiet: false, debugLogMethod: () => ++loggedCount });
 		var conf = new cnf.Configuration({ content: <any>{}, logger: logger, basepath: process.cwd() });
 		conf.scanAssetsAudio(["audio"]).then(() => {
 			// アセット追加のログが1つ + duration差のwarnが1つ + AAC利用のwarnが1つ
@@ -1763,7 +1764,7 @@ describe("Configuration", function () {
 		mockfs(mockFsContent);
 
 		var warnLogs: string[] = [];
-		class Logger extends cmn.ConsoleLogger {
+		class Logger extends ConsoleLogger {
 			warn(message: any) {
 				warnLogs.push(message);
 			}
@@ -1813,7 +1814,7 @@ describe("Configuration", function () {
 		mockfs(mockFsContent);
 
 		var warnLogs: string[] = [];
-		class Logger extends cmn.ConsoleLogger {
+		class Logger extends ConsoleLogger {
 			warn(message: any) {
 				warnLogs.push(message);
 			}
@@ -2177,7 +2178,7 @@ describe("Configuration", function () {
 
 
 		const genhashPath = (filePath: string) => {
-			const hashPath = cmn.Renamer.hashFilepath(filePath, 6);
+			const hashPath = hashFilepath(filePath, 6);
 			return "asset:" + path.basename(hashPath, path.extname(filePath));
 		};
 
@@ -2253,7 +2254,7 @@ describe("Configuration", function () {
 		});
 
 		const genhashPath = (filePath: string) => {
-			const hashPath = cmn.Renamer.hashFilepath(filePath, 6);
+			const hashPath = hashFilepath(filePath, 6);
 			return "asset:" + path.basename(hashPath, path.extname(filePath));
 		};
 		await conf.scanAssetsDir();

--- a/packages/akashic-cli-scan/spec/src/LibConfigurationSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/LibConfigurationSpec.ts
@@ -1,8 +1,8 @@
-import * as cmn from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
 import { LibConfiguration } from "../../lib/LibConfiguration";
 
 describe("LibConfiguration", () => {
-	const nullLogger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
+	const nullLogger = new ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 
 	it("add/remove/clear", () => {
 		const conf = new LibConfiguration({

--- a/packages/akashic-cli-scan/spec/src/helpers/MockPromisedNpm.ts
+++ b/packages/akashic-cli-scan/spec/src/helpers/MockPromisedNpm.ts
@@ -1,12 +1,12 @@
-import * as cmn from "@akashic/akashic-cli-commons";
+import { PromisedNpm, PromisedNpmParameterObject } from "@akashic/akashic-cli-commons/lib/PromisedNpm";
 
-export interface MockPromisedNpmParameterObject extends cmn.PromisedNpmParameterObject {
+export interface MockPromisedNpmParameterObject extends PromisedNpmParameterObject {
 	expectDependencies: {[key: string]: any};
 	expectDevDependencies?: {[key: string]: any};
 }
 
 // テスト実行に必要な最低限のNPMメソッドをモック化します。
-export class MockPromisedNpm extends cmn.PromisedNpm {
+export class MockPromisedNpm extends PromisedNpm {
 	expectDependencies: {[key: string]: any};
 	expectDevDependencies: {[key: string]: any};
 	constructor(param: MockPromisedNpmParameterObject) {

--- a/packages/akashic-cli-scan/spec/src/scanSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/scanSpec.ts
@@ -1,12 +1,13 @@
 import * as path from "path";
 import * as fs from "fs";
-import * as cmn from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { PromisedNpm } from "@akashic/akashic-cli-commons/lib/PromisedNpm";
 import * as mockfs from "mock-fs";
 import { promiseScanAsset, scanAsset, scanNodeModules } from "../../lib/scan";
 import { MockPromisedNpm } from "./helpers/MockPromisedNpm";
 
 describe("scan", function () {
-	var nullLogger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
+	var nullLogger = new ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 	var DUMMY_OGG_DATA2 = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy2.ogg"));
 	const DUMMY_1x1_PNG_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy1x1.png"));
 
@@ -201,7 +202,7 @@ describe("scan", function () {
 			};
 			mockfs(mockFsContent);
 
-			var nullNpm: cmn.PromisedNpm = new MockPromisedNpm({
+			var nullNpm: PromisedNpm = new MockPromisedNpm({
 				expectDependencies: { "dummy": {}, "dummy2": {} }
 			});
 			scanNodeModules({ cwd: "./", logger: nullLogger, debugNpm: nullNpm }, (err: any) => {

--- a/packages/akashic-cli-scan/spec/src/scanUtilsSpec.ts
+++ b/packages/akashic-cli-scan/spec/src/scanUtilsSpec.ts
@@ -1,11 +1,11 @@
 import * as path from "path";
 import * as fs from "fs";
-import * as cmn from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
 import * as mockfs from "mock-fs";
 import { scanAudioAssets, scanImageAssets, scanScriptAssets, scanTextAssets } from "../../lib/scanUtils";
 
 describe("scanUtils", () => {
-	const nullLogger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
+	const nullLogger = new ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 	const DUMMY_MP4_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy.mp4"));
 	const DUMMY_AAC_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy.aac"));
 	const DUMMY_OGG_DATA = fs.readFileSync(path.resolve(__dirname, "../fixtures/dummy.ogg"));
@@ -143,7 +143,7 @@ describe("scanUtils", () => {
 
 	it("scanAudioAssets()", async () => {
 		const warnLogs: string[] = [];
-		class Logger extends cmn.ConsoleLogger {
+		class Logger extends ConsoleLogger {
 			warn(message: string) {
 				warnLogs.push(message);
 			}

--- a/packages/akashic-cli-scan/src/LibConfiguration.ts
+++ b/packages/akashic-cli-scan/src/LibConfiguration.ts
@@ -1,24 +1,27 @@
-import * as cmn from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { AssetConfiguration } from "@akashic/akashic-cli-commons/lib/GameConfiguration";
+import * as cmnlibconf from "@akashic/akashic-cli-commons/lib/LibConfiguration";
+import { Logger } from "@akashic/akashic-cli-commons/lib/Logger";
 import { scanAudioAssets, scanImageAssets } from "./scanUtils";
 
 export interface LibConfigurationParameterObject {
-	content: cmn.LibConfiguration;
+	content: cmnlibconf.LibConfiguration;
 	basepath: string;
-	logger?: cmn.Logger;
+	logger?: Logger;
 }
 
 export class LibConfiguration {
-	_content: cmn.LibConfiguration;
+	_content: cmnlibconf.LibConfiguration;
 	_basepath: string;
-	_logger: cmn.Logger;
+	_logger: Logger;
 
 	constructor(param: LibConfigurationParameterObject) {
 		this._content = param.content;
 		this._basepath = param.basepath;
-		this._logger = param.logger || new cmn.ConsoleLogger();
+		this._logger = param.logger || new ConsoleLogger();
 	}
 
-	getContent(): cmn.LibConfiguration {
+	getContent(): cmnlibconf.LibConfiguration {
 		return this._content;
 	}
 
@@ -80,7 +83,7 @@ export class LibConfiguration {
 		return this;
 	}
 
-	addAsset(asset: cmn.AssetConfiguration): this {
+	addAsset(asset: AssetConfiguration): this {
 		if (!this._content.assetList) {
 			this._content.assetList = [];
 		}

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -1,7 +1,9 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Command } from "commander";
-import { ConsoleLogger, CliConfigurationFile, CliConfigScanAsset, CliConfigScanGlobalScripts } from "@akashic/akashic-cli-commons";
+import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
+import { CliConfigurationFile } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigurationFile";
+import { CliConfigScanAsset, CliConfigScanGlobalScripts } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigScan";
 import { promiseScanAsset, promiseScanNodeModules, watchAsset, ScanAssetParameterObject } from "./scan";
 
 var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;

--- a/packages/akashic-cli-scan/src/getAudioDuration.ts
+++ b/packages/akashic-cli-scan/src/getAudioDuration.ts
@@ -3,9 +3,9 @@ import * as path from "path";
 import * as aacDuration from "aac-duration";
 import * as musicMetaData from "music-metadata";
 import { mp4Inspector } from "thumbcoil";
-import * as cmn from "@akashic/akashic-cli-commons";
+import { Logger } from "@akashic/akashic-cli-commons/lib/Logger";
 
-export function getAudioDuration(filepath: string, logger?: cmn.Logger): Promise<number> {
+export function getAudioDuration(filepath: string, logger?: Logger): Promise<number> {
 	var ext = path.extname(filepath);
 	switch (ext) {
 	case ".aac":

--- a/packages/akashic-cli-scan/src/scanUtils.ts
+++ b/packages/akashic-cli-scan/src/scanUtils.ts
@@ -1,5 +1,7 @@
 import * as path from "path";
-import * as cmn from "@akashic/akashic-cli-commons";
+import { AssetConfiguration } from "@akashic/akashic-cli-commons/lib/GameConfiguration";
+import { Logger } from "@akashic/akashic-cli-commons/lib/Logger";
+import { invertMap, makeUnixPath } from "@akashic/akashic-cli-commons/lib/Util";
 import * as readdirRecursive from "fs-readdir-recursive";
 import { imageSize } from "image-size";
 import { getAudioDuration } from "./getAudioDuration";
@@ -39,15 +41,15 @@ export type AudioDurationInfoMap = { [path: string]: AudioDurationInfo };
 export async function scanScriptAssets(
 	baseDir: string,
 	dir: string,
-	_logger?: cmn.Logger,
+	_logger?: Logger,
 	filter: AssetFilter = scriptAssetFilter
-): Promise<cmn.AssetConfiguration[]> {
+): Promise<AssetConfiguration[]> {
 	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
 	return relativeFilePaths
 		.map(relativeFilePath => {
 			return {
 				type: "script",
-				path: cmn.Util.makeUnixPath(path.join(dir, relativeFilePath)),
+				path: makeUnixPath(path.join(dir, relativeFilePath)),
 				global: true
 			};
 		})
@@ -57,15 +59,15 @@ export async function scanScriptAssets(
 export async function scanTextAssets(
 	baseDir: string,
 	dir: string,
-	_logger?: cmn.Logger,
+	_logger?: Logger,
 	filter: AssetFilter = textAssetFilter
-): Promise<cmn.AssetConfiguration[]> {
+): Promise<AssetConfiguration[]> {
 	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
 	return relativeFilePaths
 		.map(relativeFilePath => {
 			return {
 				type: "text",
-				path: cmn.Util.makeUnixPath(path.join(dir, relativeFilePath))
+				path: makeUnixPath(path.join(dir, relativeFilePath))
 			};
 		})
 		.filter(asset => asset != null);
@@ -74,9 +76,9 @@ export async function scanTextAssets(
 export async function scanImageAssets(
 	baseDir: string,
 	dir: string,
-	logger?: cmn.Logger,
+	logger?: Logger,
 	filter: AssetFilter = imageAssetFilter
-): Promise<cmn.AssetConfiguration[]> {
+): Promise<AssetConfiguration[]> {
 	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
 	return relativeFilePaths
 		.map(relativeFilePath => {
@@ -88,7 +90,7 @@ export async function scanImageAssets(
 			}
 			return {
 				type: "image",
-				path: cmn.Util.makeUnixPath(path.join(dir, relativeFilePath)),
+				path: makeUnixPath(path.join(dir, relativeFilePath)),
 				width: size.width,
 				height: size.height
 			};
@@ -99,9 +101,9 @@ export async function scanImageAssets(
 export async function scanAudioAssets(
 	baseDir: string,
 	dir: string,
-	logger?: cmn.Logger,
+	logger?: Logger,
 	filter: AssetFilter = audioAssetFilter
-): Promise<cmn.AssetConfiguration[]> {
+): Promise<AssetConfiguration[]> {
 	const relativeFilePaths: string[] = readdirRecursive(path.join(baseDir, dir)).filter(filter);
 
 	const durationInfos: AudioDurationInfo[] = [];
@@ -115,11 +117,11 @@ export async function scanAudioAssets(
 			basename,
 			ext: ext,
 			duration: Math.ceil(duration * 1000),
-			path: cmn.Util.makeUnixPath(nonExtRelativeFilePath)
+			path: makeUnixPath(nonExtRelativeFilePath)
 		});
 	}
 
-	const durationRevMap = cmn.Util.invertMap(durationInfos as any, "path");
+	const durationRevMap = invertMap(durationInfos as any, "path");
 	for (const nonExtFilePath in durationRevMap) {
 		// お節介機能: 拡張子が違うだけの音声ファイル間で、500ms以上長さが違ったら警告しておく。
 		// (別のファイルがまぎれているかもしれない) お節介なので数値に深い意味はない。
@@ -139,7 +141,7 @@ export async function scanAudioAssets(
 		}
 	}
 
-	const audioAssets: cmn.AssetConfiguration[] = [];
+	const audioAssets: AssetConfiguration[] = [];
 	for (const filePath in durationMap) {
 		if (!durationMap.hasOwnProperty(filePath)) continue;
 		audioAssets.push({

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -1,6 +1,6 @@
 import {observable, action} from "mobx";
 import * as queryString from "query-string";
-import {ServiceType} from "@akashic/akashic-cli-commons";
+import {ServiceType} from "@akashic/akashic-cli-commons/lib/ServiceType";
 import {Player} from "../../common/types/Player";
 import {AppOptions} from "../../common/types/AppOptions";
 import {ClientContentLocator} from "../common/ClientContentLocator";

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react";
-import { ServiceType } from "@akashic/akashic-cli-commons";
+import { ServiceType } from "@akashic/akashic-cli-commons/lib/ServiceType";
 import { SandboxConfig } from "../../../common/types/SandboxConfig";
 import { PlayEntity } from "../../store/PlayEntity";
 import { DevtoolUiStore } from "../../store/DevtoolUiStore";

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react";
-import { ServiceType } from "@akashic/akashic-cli-commons";
+import { ServiceType } from "@akashic/akashic-cli-commons/lib/ServiceType";
 import { PlayEntity } from "../../store/PlayEntity";
 import { LocalInstanceEntity } from "../../store/LocalInstanceEntity";
 import { ToolBarUiStore } from "../../store/ToolBarUiStore";

--- a/packages/akashic-cli-serve/src/client/view/organism/ToolBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/organism/ToolBar.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { observer } from "mobx-react";
-import { ServiceType } from "@akashic/akashic-cli-commons";
+import { ServiceType } from "@akashic/akashic-cli-commons/lib/ServiceType";
 import { ToolIconButton } from "../atom/ToolIconButton";
 import { ToolLabel } from "../atom/ToolLabel";
 import { PlayControl, PlayControlPropsData } from "../molecule/PlayControl";

--- a/packages/akashic-cli-serve/src/common/types/AppOptions.ts
+++ b/packages/akashic-cli-serve/src/common/types/AppOptions.ts
@@ -1,4 +1,4 @@
-import { ServiceType } from "@akashic/akashic-cli-commons";
+import { ServiceType } from "@akashic/akashic-cli-commons/lib/ServiceType";
 
 export interface AppOptions {
 	autoStart: boolean;

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -1,4 +1,4 @@
-import { ServiceType } from "@akashic/akashic-cli-commons";
+import { ServiceType } from "@akashic/akashic-cli-commons/lib/ServiceType";
 
 export interface ServerGlobalConfig {
 	hostname: string;

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -17,7 +17,9 @@ import { serverGlobalConfig } from "./common/ServerGlobalConfig";
 import { createContentsRouter } from "./route/ContentsRoute";
 import { createHealthCheckRouter } from "./route/HealthCheckRoute";
 import { ServerContentLocator } from "./common/ServerContentLocator";
-import {  CliConfigurationFile, CliConfigServe, SERVICE_TYPES } from "@akashic/akashic-cli-commons";
+import { CliConfigurationFile } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigurationFile";
+import { CliConfigServe } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigServe";
+import { SERVICE_TYPES } from "@akashic/akashic-cli-commons/lib/ServiceType";
 import { PlayerIdStore } from "./domain/PlayerIdStore";
 import { ModTargetFlags, watchContent } from "./domain/GameConfigs";
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -126,7 +126,7 @@ try{
 	execSync(`${akashicCliPath} uninstall @akashic-extension/akashic-label`);
 	packageJson = JSON.parse(fs.readFileSync(`${targetDir}/game/package.json`).toString());
 	gameJson = JSON.parse(fs.readFileSync(`${targetDir}/game/game.json`).toString());
-	// TODO Node15だとここでエラーになるのでpackage.json中にdependenciesキーがあるかどうかだけ確認するテストに変える
+	// TODO npm7だとpackageJson["dependencies"]がundefinedとなるためエラーになる。そのためpackage.json中にdependenciesキーがあるかどうかだけ確認するテストに変える必要がある。
 	assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
 	assertNotContains(Object.keys(gameJson), "moduleMainScripts");
 	assertNotContains(gameJson["globalScripts"], "node_modules/@akashic-extension/akashic-label/lib/index.js");

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -126,6 +126,7 @@ try{
 	execSync(`${akashicCliPath} uninstall @akashic-extension/akashic-label`);
 	packageJson = JSON.parse(fs.readFileSync(`${targetDir}/game/package.json`).toString());
 	gameJson = JSON.parse(fs.readFileSync(`${targetDir}/game/game.json`).toString());
+	// TODO Node15だとここでエラーになるのでpackage.json中にdependenciesキーがあるかどうかだけ確認するテストに変える
 	assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
 	assertNotContains(Object.keys(gameJson), "moduleMainScripts");
 	assertNotContains(gameJson["globalScripts"], "node_modules/@akashic-extension/akashic-label/lib/index.js");


### PR DESCRIPTION
### 概要
* akashic-cliコマンド起動速度を上げるために以下のパッケージでakashic-cli-commonsで利用するものだけをロードする対応を行いました。
  * akashic-cli-init
  * akashic-cli-scan
  * akashic-cli-serve
 
### やったこと
* 対象のパッケージで akashic-cli-commonsのオブジェクトやメソッドを直接参照するように変更
  * 例：ConsoleLoggerであれば`var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger`といった感じで取得 