### PR TITLE
fix e2e test on npm@7

### DIFF
--- a/test/e2e.js
+++ b/test/e2e.js
@@ -126,8 +126,9 @@ try{
 	execSync(`${akashicCliPath} uninstall @akashic-extension/akashic-label`);
 	packageJson = JSON.parse(fs.readFileSync(`${targetDir}/game/package.json`).toString());
 	gameJson = JSON.parse(fs.readFileSync(`${targetDir}/game/game.json`).toString());
-	// TODO npm7だとpackageJson["dependencies"]がundefinedとなるためエラーになる。そのためpackage.json中にdependenciesキーがあるかどうかだけ確認するテストに変える必要がある。
-	assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
+	if (packageJson["dependencies"]) {
+		assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
+	}
 	assertNotContains(Object.keys(gameJson), "moduleMainScripts");
 	assertNotContains(gameJson["globalScripts"], "node_modules/@akashic-extension/akashic-label/lib/index.js");
 


### PR DESCRIPTION
npm@7 で「 npm rm して dependencies が空になった時、 dependencies プロパティそのものがなくなるようになった」ためにテストがエラーになっていました。なくなること自体は期待動作と言えるので、単に許容するようにします。

自明につきセルフマージします。
