### PR TITLE
Support compress if zip extension with -o option of export-html

### DIFF
--- a/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
@@ -105,7 +105,8 @@ describe("exportHTML", function () {
 				minify: false,
 				magnify: false,
 				unbundleText: false,
-				lint: false
+				lint: false,
+				compress: true
 			};
 			return exp.promiseExportHTML(param);
 		})

--- a/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
@@ -91,4 +91,29 @@ describe("exportHTML", function () {
 		})
 		.then(done, done.fail);
 	});
+
+	it("output option has zip extension", function (done) {
+		Promise.resolve()
+		.then(function () {
+			const param: exp.ExportHTMLParameterObject = {
+				logger: undefined,
+				cwd: path.join(__dirname, "..", "..", "fixtures", "sample_game"),
+				source: ".",
+				output: "../output.zip",
+				force: true,
+				strip: true,
+				minify: false,
+				magnify: false,
+				unbundleText: false,
+				lint: false
+			};
+			return exp.promiseExportHTML(param);
+		})
+		.then((dest) => {
+			expect(dest).toBe(path.join(__dirname, "..", "..", "fixtures", "output.zip"));
+			fsx.removeSync(dest);
+		})
+		.then(done, done.fail);
+	});
+
 });

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -28,6 +28,7 @@ function cli(param: CliConfigExportHtml): void {
 		autoSendEventName: param.autoSendEventName || param.autoSendEvents,
 		needsUntaintedImageAsset: param.atsumaru,
 		omitUnbundledJs: param.atsumaru && param.omitUnbundledJs,
+		atsumaru: param.atsumaru,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version: ver, // export実行時のバージョン

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -28,7 +28,7 @@ function cli(param: CliConfigExportHtml): void {
 		autoSendEventName: param.autoSendEventName || param.autoSendEvents,
 		needsUntaintedImageAsset: param.atsumaru,
 		omitUnbundledJs: param.atsumaru && param.omitUnbundledJs,
-		atsumaru: param.atsumaru,
+		compress: param.output && !param.atsumaru ? path.extname(param.output) === ".zip" : false,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version: ver, // export実行時のバージョン

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -111,14 +111,13 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 		}
 	})
 	.then(() => {
-		// output が zip 拡張子の場合は zip 化
 		if (outputZip) {
-			const dirName = `export-html-temp-${new Date().getTime().toString(16)}`;
-			fs.renameSync(param.output, dirName);
-			// TODO: zip 化処理の共通化
+			const targetDir = `export-html-temp-${new Date().getTime().toString(16)}`;
+			fs.renameSync(param.output, targetDir);
+
 			return new Promise<void>((resolve, reject) => {
-				const files = readdir(dirName).map(p => ({
-					src: path.resolve(dirName, p),
+				const files = readdir(targetDir).map(p => ({
+					src: path.resolve(targetDir, p),
 					entryName: p
 				}));
 				const ostream = fs.createWriteStream(param.output);
@@ -129,7 +128,7 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 				files.forEach((f) => archive.file(f.src, { name: f.entryName }));
 				archive.finalize();
 			}).finally(() => {
-				fsx.removeSync(dirName);
+				fsx.removeSync(targetDir);
 			});
 		}
 	})

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -133,9 +133,6 @@ export function promiseExportHTML(p: ExportHTMLParameterObject): Promise<string>
 		})
 		.then(() => {
 			return param.compress ? output : param.output;
-		})
-		.catch((error) => {
-			throw error;
 		});
 }
 


### PR DESCRIPTION
## 概要

export-html の output オプションの指定が `.zip` 拡張子の場合は、zip ファイルとして出力します。