### PR TITLE
Fix error by the update of the commander@v8

### DIFF
--- a/packages/akashic-cli-extra/src/config/cli.ts
+++ b/packages/akashic-cli-extra/src/config/cli.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as commander from "commander";
+import { Command } from "commander";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons";
 import * as config from "./config";
 
@@ -12,7 +12,7 @@ import * as config from "./config";
 export function run(argv: string[]): void {
 
 	const packageJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8"));
-
+	const commander = new Command();
 	commander
 		.description("List and edit configurations")
 		.version(packageJson.version)


### PR DESCRIPTION
## 概要

renovate のPR #781 の commander@8.0.0 への アップデートによるエラーを修正します。

commander が v7 から使用方法が変更となりインスタンス化が必要となったためエラーとなった。
`akashic-cli-extra/config/cli` だけインスタンス化していなかったので修正。(commander は 5 から 8へ更新)

**#781 へマージします** 
