### PR TITLE
Fix isEmptyScriptJs() in export-zip

### DIFF
--- a/packages/akashic-cli-export/spec/src/zip/GameConfigurationUtilSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/GameConfigurationUtilSpec.ts
@@ -355,6 +355,9 @@ describe("GameConfigurationUtil", () => {
 
 			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:!0});var a=\"a\";");
 			expect(ret).toBeFalsy();
+
+			ret = gcu.isEmptyScriptJs("Object.defineProperty(exports, \"__esModule\", {value:true});");
+			expect(ret).toBeTruthy();
 		});
 	});
 });

--- a/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
+++ b/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
@@ -113,8 +113,12 @@ export function isScriptJsFile(filePath: string): boolean {
 export function isEmptyScriptJs(str: string): boolean {
 	if (!str || str.length === 0) return true;
 
-	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
 	// TypeScirpt 2.2.0以下かminifyされた場合は、"use strict";だけの出力となる
-	const regex = /^"use strict";[\r\n\s]*(Object.defineProperty\(exports,\s*("__esModule",)\s*?({\s*?value\s*:\s*?[true|!0]+\s*})\);)*$/;
+	if (/^"use strict";$/.test(str.trim())) return true;
+
+	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
+	// interface 以外に変数や関数等の記述がある場合、build 後は `Object.definePropert()` の後の行に記述されるため、
+	// `Object.definePropert()` が末尾で一致する場合は空と同様とする
+	const regex = /(Object.defineProperty\(exports,\s*("__esModule",)\s*?({\s*?value\s*:\s*?[true|!0]+\s*})\);)$/;
 	return regex.test(str.trim());
 }

--- a/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
+++ b/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
@@ -115,6 +115,6 @@ export function isEmptyScriptJs(str: string): boolean {
 
 	// TypeScirpt 2.2.0以下かminifyされた場合は、"use strict";だけの出力となる
 	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
-	const regex = /^("use strict";)?[\r\n\s]*(Object.defineProperty\(exports,\s*"__esModule",\s*?({\s*?value\s*:\s*?(true|!0)+\s*})\);)*$/;
+	const regex = /^("use strict";)?[\r\n\s]*(Object.defineProperty\(exports,\s*"__esModule",\s*?{\s*?value\s*:\s*?(true|!0)\s*}\);)?$/;
 	return regex.test(str.trim());
 }

--- a/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
+++ b/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
@@ -114,11 +114,7 @@ export function isEmptyScriptJs(str: string): boolean {
 	if (!str || str.length === 0) return true;
 
 	// TypeScirpt 2.2.0以下かminifyされた場合は、"use strict";だけの出力となる
-	if (/^"use strict";$/.test(str.trim())) return true;
-
 	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
-	// interface 以外に変数や関数等の記述がある場合、build 後は `Object.definePropert()` の後の行に記述されるため、
-	// `Object.definePropert()` が末尾で一致する場合は空と同様とする
-	const regex = /(Object.defineProperty\(exports,\s*("__esModule",)\s*?({\s*?value\s*:\s*?[true|!0]+\s*})\);)$/;
+	const regex = /^("use strict";)?[\r\n\s]*(Object.defineProperty\(exports,\s*"__esModule",\s*?({\s*?value\s*:\s*?(true|!0)+\s*})\);)*$/;
 	return regex.test(str.trim());
 }


### PR DESCRIPTION
## 概要

export-zip の空のJS除去の判定ロジックの修正。
  - 正規表現でチェックしていた、`"use strict";` が出力されないケースがあるため、`isEmptyScriptJs()` を修正
