### PR TITLE
fix(export): fix wrong bin name 'akashic-cli-zip' to 'akashic-cli-export-zip'

### DIFF
--- a/packages/akashic-cli-export/package.json
+++ b/packages/akashic-cli-export/package.json
@@ -32,7 +32,7 @@
   "bin": {
     "akashic-cli-export": "./bin/run",
     "akashic-cli-export-html": "./bin/akashic-cli-export-html",
-    "akashic-cli-zip": "./bin/akashic-cli-export-zip"
+    "akashic-cli-export-zip": "./bin/akashic-cli-export-zip"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
掲題どおり。

bin で提供するコマンドが間違っていました。自明につきセルフマージします。

