### PR TITLE
fix(export): deprecate and always enable --no-omit-empty-js

### DIFF
--- a/packages/akashic-cli-export/spec/src/zip/GameConfigurationUtilSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/GameConfigurationUtilSpec.ts
@@ -321,45 +321,4 @@ describe("GameConfigurationUtil", () => {
 			expect(ret).toBeFalsy();
 		});
 	});
-
-	describe("isEmptyScriptJs", () => {
-		it("when argument is empty true is returned", () => {
-			const ret = gcu.isEmptyScriptJs("");
-			expect(ret).toBeTruthy();
-		});
-		it("when argument isnt empty, false is returned", () => {
-			const ret = gcu.isEmptyScriptJs("aaaaaaaaaaa");
-			expect(ret).toBeFalsy();
-		});
-		it("For three or more lines", () => {
-			const ret = gcu.isEmptyScriptJs(
-				"\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });\nvar test = 123;"
-			);
-			expect(ret).toBeFalsy();
-		});
-		it("for two lines", () => {
-			let ret = gcu.isEmptyScriptJs("\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });");
-			expect(ret).toBeTruthy();
-
-			ret = gcu.isEmptyScriptJs("\"use strict\";\r\nObject.defineProperty(exports, \"__esModule\", { value: true });var hoge = 2;");
-			expect(ret).toBeFalsy();
-		});
-		it("for one line", () => {
-			let ret = gcu.isEmptyScriptJs("\"use strict\";");
-			expect(ret).toBeTruthy();
-			ret = gcu.isEmptyScriptJs("\"use strict\";var hoge=0;");
-			expect(ret).toBeFalsy();
-
-			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:!0});");
-			expect(ret).toBeTruthy();
-			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:true});");
-			expect(ret).toBeTruthy();
-
-			ret = gcu.isEmptyScriptJs("\"use strict\";Object.defineProperty(exports,\"__esModule\",{value:!0});var a=\"a\";");
-			expect(ret).toBeFalsy();
-
-			ret = gcu.isEmptyScriptJs("Object.defineProperty(exports, \"__esModule\", {value:true});");
-			expect(ret).toBeTruthy();
-		});
-	});
 });

--- a/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
@@ -150,7 +150,6 @@ describe("convert", () => {
 				source: path.resolve(__dirname, "..", "..", "fixtures", "simple_game_using_external"),
 				dest: destDir,
 				bundle: true,
-				omitEmptyJs: true,
 				omitUnbundledJs: false
 			};
 			convertGame(param)
@@ -169,7 +168,7 @@ describe("convert", () => {
 					expect(gameJson.assets.aez_bundle_main.path).toBe("script/aez_bundle_main.js");
 					expect(gameJson.assets.aez_bundle_main.type).toBe("script");
 					expect(gameJson.assets.aez_bundle_main.global).toBe(true);
-					expect(gameJson.assets.ignore2.global).toBeFalsy();
+					expect(gameJson.assets.ignore2.global).toBeTruthy(); // omitEmptyJs があった時は偽になりえたので念のため確認
 					done();
 				}, done.fail);
 		});
@@ -223,11 +222,10 @@ describe("convert", () => {
 				}, done.fail);
 		});
 
-		it("Include empty files when in no-omit-empty-js mode", (done) => {
+		it("includes empty .js (regression test for omitEmptyJs, a removed option)", (done) => {
 			const param = {
 				source: path.resolve(__dirname, "..", "..", "fixtures", "simple_game_using_external"),
-				dest: destDir,
-				omitEmptyJs: false
+				dest: destDir
 			};
 			convertGame(param)
 				.then(() => {

--- a/packages/akashic-cli-export/src/html/exportAtsumaru.ts
+++ b/packages/akashic-cli-export/src/html/exportAtsumaru.ts
@@ -29,7 +29,6 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 				strip: true,
 				force: true,
 				babel: true,
-				omitEmptyJs: true,
 				omitUnbundledJs: param.omitUnbundledJs,
 				targetService: "nicolive"
 			});

--- a/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
+++ b/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
@@ -109,12 +109,3 @@ export function extractScriptAssetFilePaths(gamejson: cmn.GameConfiguration): st
 export function isScriptJsFile(filePath: string): boolean {
 	return /^(script|assets)\/.+(\.js$)/.test(filePath);
 }
-
-export function isEmptyScriptJs(str: string): boolean {
-	if (!str || str.length === 0) return true;
-
-	// TypeScirpt 2.2.0以下かminifyされた場合は、"use strict";だけの出力となる
-	// jsファイルの中身が、Typescriptのinterfaceの記述のみの場合は空と同様とする
-	const regex = /^("use strict";)?[\r\n\s]*(Object.defineProperty\(exports,\s*"__esModule",\s*?{\s*?value\s*:\s*?(true|!0)\s*}\);)?$/;
-	return regex.test(str.trim());
-}

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -63,8 +63,8 @@ commander
 	.option("-H, --hash-filename [length]", "Rename asset files with their hash values")
 	.option("-b, --bundle", "Bundle script assets into a single file")
 	.option("--no-es5-downpile", "No convert JavaScript into es5")
-	.option("--no-omit-empty-js", "Disable omitting empty js from global assets")
-	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--bundle` option is specified.")
+	.option("--no-omit-empty-js", "(DEPRECATED) Changes nothing. Provided for backward compatibility")
+	.option("--no-omit-unbundled-js", "Preserve unbundled .js files (not required from root). Works with --bundle only")
 	.option("--target-service <service>", `Specify the target service of the exported content:${availableServices}`);
 
 export function run(argv: string[]): void {

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -9,6 +9,11 @@ const availableServices = SERVICE_TYPES.filter(v => v !== "atsumaru");
 
 export function cli(param: CliConfigExportZip): void {
 	var logger = new ConsoleLogger({ quiet: param.quiet });
+
+	if (param.omitEmptyJs != null) {
+		logger.info("deprecated: --no-omit-empty-js is now always enabled since output may be broken without this option.");
+	}
+
 	Promise.resolve()
 		.then(() => promiseExportZip({
 			bundle: param.bundle,
@@ -19,7 +24,6 @@ export function cli(param: CliConfigExportZip): void {
 			dest: param.output,
 			force: param.force,
 			hashLength: !param.hashFilename ? 0 : (param.hashFilename === true) ? 20 : Number(param.hashFilename),
-			omitEmptyJs: param.omitEmptyJs,
 			logger,
 			omitUnbundledJs: param.bundle && param.omitUnbundledJs,
 			targetService: param.targetService,
@@ -33,7 +37,6 @@ export function cli(param: CliConfigExportZip): void {
 					bundle: param.bundle,
 					babel: param.babel,
 					hashFilename: param.hashFilename,
-					omitEmptyJs: param.omitEmptyJs,
 					targetService: param.targetService || "none"
 				}
 			}

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -10,7 +10,7 @@ const availableServices = SERVICE_TYPES.filter(v => v !== "atsumaru");
 export function cli(param: CliConfigExportZip): void {
 	var logger = new ConsoleLogger({ quiet: param.quiet });
 
-	if (param.omitEmptyJs != null) {
+	if (!param.omitEmptyJs) {
 		logger.info("deprecated: --no-omit-empty-js is now always enabled since output may be broken without this option.");
 	}
 

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -16,7 +16,6 @@ export interface ExportZipParameterObject {
 	force?: boolean;
 	logger?: cmn.Logger;
 	hashLength?: number;
-	omitEmptyJs?: boolean;
 	exportInfo?: cmn.ExportZipInfo;
 	omitUnbundledJs?: boolean;
 	targetService?: cmn.ServiceType;
@@ -31,7 +30,6 @@ function _createExportInfo(param: ExportZipParameterObject): cmn.ExportZipInfo {
 			minify: !!param.minify,
 			bundle: !!param.bundle,
 			babel: !!param.babel,
-			omitEmptyJs: !!param.omitEmptyJs,
 			targetService: param.targetService || "none"
 		}
 	};
@@ -48,7 +46,6 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		force: !!param.force,
 		logger: param.logger || new cmn.ConsoleLogger(),
 		hashLength: param.hashLength,
-		omitEmptyJs: param.omitEmptyJs,
 		exportInfo: param.exportInfo || _createExportInfo(param),
 		omitUnbundledJs: param.omitUnbundledJs,
 		targetService: param.targetService || "none"
@@ -90,7 +87,6 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 				source: param.source,
 				dest: destDir,
 				hashLength: param.hashLength,
-				omitEmptyJs: param.omitEmptyJs,
 				logger: param.logger,
 				exportInfo: param.exportInfo,
 				omitUnbundledJs: param.omitUnbundledJs,


### PR DESCRIPTION
export zip の `omitEmptyJs` オプション、「空 .js のアセットを global: false にする最適化」を削除します。

この最適化は、 TypeScript が生成する無駄な .js ファイル (中身が実質的に空) の読み込みを避けるためのものでした。しかしある種の TS をコンパイルすると、空の .js ファイルであっても必要になることがわかりました。export zip コマンドの出力したゲームは壊れてしまうので、この最適化は誤りでした。削除します。

この最適化の抑止フラグ `--no-omit-empty-js` は意味がなくなります (指定しなくても自動的に有効になるのと同じなので)。deprecated としてメッセージを出すようにします。