### PR TITLE
chore(export): restore removed bin name for compatiblity

### DIFF
--- a/packages/akashic-cli-export/package.json
+++ b/packages/akashic-cli-export/package.json
@@ -32,7 +32,8 @@
   "bin": {
     "akashic-cli-export": "./bin/run",
     "akashic-cli-export-html": "./bin/akashic-cli-export-html",
-    "akashic-cli-export-zip": "./bin/akashic-cli-export-zip"
+    "akashic-cli-export-zip": "./bin/akashic-cli-export-zip",
+    "akashic-cli-zip": "./bin/akashic-cli-export-zip"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
#815 で `akashic-cli-zip` という間違った名前を修正してしまいましたが、考え直して後方互換性を持たせます。(実害がまず考えられないこともあり)　古い名前は major 更新時に破棄します。

自明につきセルフマージします。
