### PR TITLE
Extend serve --target-service option

### DIFF
--- a/packages/akashic-cli-commons/src/ServiceType.ts
+++ b/packages/akashic-cli-commons/src/ServiceType.ts
@@ -1,8 +1,20 @@
 /*
  * 対象のサービス
  * nicolive: ニコニコ生放送
+ * nicolive:multi: ニコニコ生放送
+ * nicolive:multi_admission: ニコニコ生放送募集
  * atsumaru: ゲームアツマール
+ * atsumaru:single: ゲームアツマール:シングル
+ * astumaru:multi:ゲームアツマール: マルチ
  * none: サービスなし
  */
-export const SERVICE_TYPES = ["nicolive", "atsumaru", "none"] as const;
+export const SERVICE_TYPES = [
+	"nicolive",
+	"nicolive:multi",
+	"nicolive:multi_admission",
+	"atsumaru",
+	"atsumaru:single",
+	"atsumaru:multi",
+	"none"
+] as const;
 export type ServiceType = typeof SERVICE_TYPES[number];

--- a/packages/akashic-cli-serve/src/client/common/createSessionParameter.ts
+++ b/packages/akashic-cli-serve/src/client/common/createSessionParameter.ts
@@ -14,8 +14,9 @@ export function createSessionParameter(service: ServiceType): playlog.Event {
 		}
 	];
 
-	if (service !== "none") {
-		ret[playlog.MessageEventIndex.Data].parameters.service = service;
+	if (service !== "none" && service !== "atsumaru:single") {
+		const targetService = /^nicolive.*/.test(service) ? "nicolive" : "atsumaru";
+		ret[playlog.MessageEventIndex.Data].parameters.service = targetService;
 	}
 
 	return ret;

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -72,7 +72,7 @@ export class Operator {
 				play = await this._createServerLoop(loc);
 			}
 		}
-		if (store.targetService === "atsumaru") {
+		if (store.targetService === "atsumaru:single") {
 			(window as any).RPGAtsumaru = new RPGAtsumaruApi({
 				// 元のAPIが0～1の実数を返す仕様になっているので、それに合わせた
 				getVolumeCallback: () => this.store.devtoolUiStore.volume / 100
@@ -99,7 +99,7 @@ export class Operator {
 
 		let isJoin = false;
 		let argument = undefined;
-		if (store.targetService === "nicolive") {
+		if (/^nicolive.*/.test(store.targetService) || store.targetService === "atsumaru:multi") {
 			if (previousPlay) {
 				isJoin = previousPlay.joinedPlayerTable.has(store.player.id);
 			} else {
@@ -167,7 +167,7 @@ export class Operator {
 			this.store.profilerStore.pushProfilerValueResult("frame", value.frameTime);
 			this.store.profilerStore.pushProfilerValueResult("rendering", value.renderingTime);
 		});
-		if (store.targetService !== "atsumaru") {
+		if (store.targetService !== "atsumaru:single") {
 			this.store.devtoolUiStore.initTotalTimeLimit(play.content.preferredSessionParameters.totalTimeLimit);
 			this.devtool.setupNiconicoDevtoolValueWatcher();
 		}
@@ -203,9 +203,8 @@ export class Operator {
 			// TODO: `autoSendEvents` は非推奨。互換性のためこのパスを残しているが、`autoSendEvents` の削除時にこのパスも削除する。
 			console.warn("[deprecated] `autoSendEvents` in sandbox.config.js is deprecated. Please use `autoSendEventName`.");
 			events[autoSendEvents].forEach((pev: any) => play.amflow.enqueueEvent(pev));
-		} else if (!autoSendEventName && this.store.targetService === "nicolive") {
-			// TODO: 現状は "nicolive" で固定。 "atsumaru" を使う方法は要検討
-			play.amflow.enqueueEvent(createSessionParameter("nicolive")); // セッションパラメータを送る
+		} else if (!autoSendEventName && (/^nicolive.*/.test(this.store.targetService) || this.store.targetService === "atsumaru:multi")) {
+			play.amflow.enqueueEvent(createSessionParameter(this.store.targetService)); // セッションパラメータを送る
 		}
 
 		if (this.store.devtoolUiStore.isAutoSendEvent) {

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -70,14 +70,14 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				onMouseLeaveEntityItem: operator.devtool.clearHighlightedEntity
 			}}
 			atsumaruDevtoolProps={{
-				disabled: targetService !== "atsumaru",
+				disabled: targetService !== "atsumaru:single",
 				volume: devtoolUiStore.volume,
 				isSeekingVolume: devtoolUiStore.isSeekingVolume,
 				changeVolume: operator.devtool.volumeChangeTo,
 				dicideVolume: operator.devtool.volumeSeekTo
 			}}
 			niconicoDevtoolProps={{
-				disabled: targetService === "atsumaru",
+				disabled: targetService === "atsumaru:single",
 				isAutoSendEvent: devtoolUiStore.isAutoSendEvent,
 				emulatingShinichibaMode: devtoolUiStore.emulatingShinichibaMode,
 				totalTimeLimitInputValue: devtoolUiStore.totalTimeLimitInputValue,

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -69,7 +69,7 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 
 	private _makePlayerControlProps = (): PlayerControlPropsData => {
 		const { localInstance, operator, targetService } = this.props;
-		const joinEnabled = targetService !== "nicolive";
+		const joinEnabled = !/^nicolive.*/.test(targetService) && targetService !== "atsumaru:multi";
 		return {
 			selfId: localInstance.player.id,
 			isJoined: localInstance.isJoined,

--- a/packages/akashic-cli-serve/src/client/view/molecule/AtsumaruDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/AtsumaruDevtool.tsx
@@ -17,7 +17,7 @@ export class AtsumaruDevtool extends React.Component<AtsumaruDevtoolProps, {}> {
 		return <div>
 			{
 				// TODO: ここのデザイン部分をユーザーフレンドリーなものに修正する
-				props.disabled && <p><b>このタブは現在無効になっています。有効にするためには起動オプションに --target-service atsumaru を指定する必要があります。</b></p>
+				props.disabled && <p><b>このタブは現在無効になっています。有効にするためには起動オプションに --target-service atsumaru:single を指定する必要があります。</b></p>
 			}
 			volume:
 			<ToolProgressBar

--- a/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtool.tsx
@@ -39,7 +39,7 @@ export class NiconicoDevtool extends React.Component<NiconicoDevtoolProps, {}> {
 
 		return <div className={styles["niconico-devtool"]}>
 			<div className={this.props.disabled ? "" : styles["hidden"]}>
-				<b>起動オプションの --target-service atsumaru が指定されている場合、このタブは無効になります。</b>
+				<b>起動オプションの --target-service atsumaru:single が指定されている場合、このタブは無効になります。</b>
 			</div>
 
 			<FlexScrollY>

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -91,14 +91,30 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	}
 
 	if (cliConfigParam.targetService) {
-		if (!cliConfigParam.autoStart && cliConfigParam.targetService === "nicolive") {
-			getSystemLogger().error("--no-auto-start and --target-service nicolive can not be set at the same time.");
+		if (!cliConfigParam.autoStart &&
+			(/^nicolive.*/.test(cliConfigParam.targetService) || cliConfigParam.targetService === "atsumaru:multi")
+		) {
+			getSystemLogger().error("--no-auto-start and --target-service nicolive or atsumaru:multi can not be set at the same time.");
 			process.exit(1);
 		}
 
 		if (!SERVICE_TYPES.includes(cliConfigParam.targetService )) {
-			getSystemLogger().error("Invalid --target-service option argument: " + cliConfigParam.targetService);
+			const serviceName: string = cliConfigParam.targetService;
+			if (serviceName === "nicolive:ranking" || serviceName === "nicolive:single") {
+				// モードとしてあるがサポートしてないものは未実装のエラーとする
+				getSystemLogger().error("Unimplemented --target-service option argument: " + cliConfigParam.targetService);
+			} else {
+				getSystemLogger().error("Invalid --target-service option argument: " + cliConfigParam.targetService);
+			}
 			process.exit(1);
+		}
+
+		if (cliConfigParam.targetService === "atsumaru") {
+			cliConfigParam.targetService = "atsumaru:single"; // "atsumaru" は "atsumaru:single" のエイリアスとする
+		}
+
+		if (cliConfigParam.targetService === "nicolive") {
+			cliConfigParam.targetService = "nicolive:multi"; // "nicolive"  は "nicolive:multi" のエイリアスとする
 		}
 		serverGlobalConfig.targetService = cliConfigParam.targetService;
 	}


### PR DESCRIPTION
## 概要

`SERVICE_TYPES` に `nicolive:multi`, `nicolive:multi_admission`,  `atsumaru:single`, `atsumaru:multi` を追加し、serve の `--target-service` オプションを拡張します。
既存の `nicolive` は `nicolive:multi`,  `atsumaru` は `atsumaru:single` のエイリアスとします。

オプションの値が `atsumaru:multi`, `nicolive:multi`, `nicolive:multi_admission` の場合は、下記の動作を行います。
-  最初のユーザが自動的に join し、join/leave ボタンを disable (既存の nicolive の値と同動作)
- セッションパラメータに `“service”: “nicolive” | “atsumaru”` を追加
- window.RPGAtsumaru は生成しない

`atsumaru:single` の場合は既存の `atsumaru` と同動作となります。