### PR TITLE
handle symlink when scan globalScripts

### DIFF
--- a/packages/akashic-cli-commons/spec/NodeModulesSpec.js
+++ b/packages/akashic-cli-commons/spec/NodeModulesSpec.js
@@ -31,7 +31,17 @@ describe("NodeModules", function () {
 			"dummy2": {
 				"index.js": "require('./sub')",
 				"sub.js": "",
-			}
+			},
+			"dummy3": mockfs.symlink({ path: "../dummy3-original" })
+		},
+		"dummy3-original": {
+			"index.js": "require('./sub')",
+			"sub.js": "",
+			"package.json": JSON.stringify({
+				name: "dummy3",
+				version: "0.0.0",
+				main: "index.js"
+			})
 		}
 	};
 
@@ -45,7 +55,7 @@ describe("NodeModules", function () {
 		it("list the script files and all package.json", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules.listModuleFiles(".", ["dummy@1", "dummy2"]))
+				.then(() => NodeModules.listModuleFiles(".", ["dummy@1", "dummy2", "dummy3"]))
 				.then((pkgjsonPaths) => {
 					expect(pkgjsonPaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/foo.js",
@@ -54,7 +64,10 @@ describe("NodeModules", function () {
 						"node_modules/dummy/node_modules/dummyChild/package.json",
 						"node_modules/dummy/package.json",
 						"node_modules/dummy2/index.js",
-						"node_modules/dummy2/sub.js"
+						"node_modules/dummy2/sub.js",
+						"node_modules/dummy3/package.json",
+						"node_modules/dummy3/index.js",
+						"node_modules/dummy3/sub.js"
 					].sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0)));
 				})
 				.then(() => NodeModules.listModuleFiles(".", "dummy2"))
@@ -73,12 +86,13 @@ describe("NodeModules", function () {
 		it("list the files named package.json", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2"]))
+				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2", "dummy3"]))
 				.then((filePaths) => NodeModules.listPackageJsonsFromScriptsPath(".", filePaths))
 				.then((pkgJsonPaths) => {
 					expect(pkgJsonPaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/package.json",
-						"node_modules/dummy/node_modules/dummyChild/package.json"
+						"node_modules/dummy/node_modules/dummyChild/package.json",
+						"node_modules/dummy3/package.json"
 					].sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0)))
 				})
 				.then(() => NodeModules.listScriptFiles(".", "dummy2"))
@@ -95,14 +109,16 @@ describe("NodeModules", function () {
 		it("list the scripts in node_modules/ up", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2"]))
+				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2", "dummy3"]))
 				.then((filePaths) => {
 					expect(filePaths.sort((a, b) => ((a > b) ? 1 : (a < b) ? -1 : 0))).toEqual([
 						"node_modules/dummy/foo.js",
 						"node_modules/dummy/main.js",
 						"node_modules/dummy/node_modules/dummyChild/main.js",
 						"node_modules/dummy2/index.js",
-						"node_modules/dummy2/sub.js"
+						"node_modules/dummy2/sub.js",
+						"node_modules/dummy3/index.js",
+						"node_modules/dummy3/sub.js",
 					]);
 				})
 				.then(() => NodeModules.listScriptFiles(".", "dummy"))
@@ -122,13 +138,14 @@ describe("NodeModules", function () {
 		it("list the files named package.json", function (done) {
 			mockfs(mockFsContent);
 			Promise.resolve()
-				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2"]))
+				.then(() => NodeModules.listScriptFiles(".", ["dummy", "dummy2", "dummy3"]))
 				.then((filePaths) => NodeModules.listPackageJsonsFromScriptsPath(".", filePaths))
 				.then((packageJsonFiles) => NodeModules.listModuleMainScripts(packageJsonFiles))
 				.then((moduleMainScripts) => {
 					expect(moduleMainScripts).toEqual({
 						"dummy": "node_modules/dummy/main.js",
-						"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js"
+						"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js",
+						"dummy3": "node_modules/dummy3/index.js"
 					});
 				})
 				.then(done)

--- a/packages/akashic-cli-commons/src/NodeModules.ts
+++ b/packages/akashic-cli-commons/src/NodeModules.ts
@@ -99,7 +99,6 @@ export module NodeModules {
 				if (filePath === dummyRootName || (!checkAllModules && !(/^(?:\.\/)?node_modules/.test(filePath)))) {
 					return;
 				}
-
 				if (/^\.\.\//.test(filePath)) {
 					const rawFilePath = Util.makeUnixPath(row.file);
 					if (ignoreModulePaths.find((modulePath) => rawFilePath.includes(modulePath))) {

--- a/packages/akashic-cli-commons/src/NodeModules.ts
+++ b/packages/akashic-cli-commons/src/NodeModules.ts
@@ -87,6 +87,7 @@ export module NodeModules {
 		var b = browserify({
 			entries: new StringStream(rootRequirer, dummyRootPath),
 			basedir: basepath,
+			preserveSymlinks: true, // npm link で node_modules 以下に置かれたモジュールを symlink パスのまま扱う
 			builtins: true  // builtins (コアモジュール) はサポートしていないが、b.on("dep", ...) で検出するためにtrueにする
 		});
 		b.external("g");
@@ -98,6 +99,7 @@ export module NodeModules {
 				if (filePath === dummyRootName || (!checkAllModules && !(/^(?:\.\/)?node_modules/.test(filePath)))) {
 					return;
 				}
+
 				if (/^\.\.\//.test(filePath)) {
 					const rawFilePath = Util.makeUnixPath(row.file);
 					if (ignoreModulePaths.find((modulePath) => rawFilePath.includes(modulePath))) {


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要
`akashic scan globalScripts` の対象にシンボリックリンクが含まれている場合に、 そのモジュールがスキャン対象から漏れていた挙動を修正します。
（ex: npm link でインストールしたモジュールをコンテンツから利用するケースなど）

## 破壊的な変更を含んでいるか?

- なし