### PR TITLE
Support https serve

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -15,6 +15,6 @@ export interface CliConfigServe {
 	preserveDisconnected?: boolean;
 	watch?: boolean;
 	experimentalOpen?: number;
-	certificate?: string;
-	privatekey?: string;
+	sslCert?: string;
+	sslKey?: string;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -15,4 +15,6 @@ export interface CliConfigServe {
 	preserveDisconnected?: boolean;
 	watch?: boolean;
 	experimentalOpen?: number;
+	certificate?: string;
+	privatekey?: string;
 }

--- a/packages/akashic-cli-serve/src/client/api/socketInstance.ts
+++ b/packages/akashic-cli-serve/src/client/api/socketInstance.ts
@@ -3,7 +3,8 @@ import parser from "../../common/MsgpackParser";
 
 declare var io: typeof ioc.io;
 
-const socket = io("ws://" + window.location.host, {
+const wsProtocol = window.location.protocol.includes("https") ? "wss" : "ws";
+const socket = io(`${wsProtocol}://${window.location.host}`, {
 	// デフォルトはInfinityだが、過去に同じホスト・ポートで起動されたサーバに
 	// 接続していたクライアントが生きている(i.e. ブラウザのタブが開いたまま)時、
 	// つなぎなおして来てしまうのでやむなく1にしている。(0だとInfinity扱いされる)

--- a/packages/akashic-cli-serve/src/server/common/ServerContentLocator.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerContentLocator.ts
@@ -3,7 +3,7 @@ import { serverGlobalConfig } from "./ServerGlobalConfig";
 
 export class ServerContentLocator extends ContentLocator {
 	asAbsoluteUrl(): string {
-		const host = this.host || `http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`;
+		const host = this.host || `${serverGlobalConfig.protocol}://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}`;
 		return host + this.asRootRelativeUrl();
 	}
 }

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -13,6 +13,7 @@ export interface ServerGlobalConfig {
 	allowExternal: boolean;
 	preserveDisconnected: boolean;
 	experimentalOpen: number;
+	protocol: string;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -30,5 +31,6 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	targetService: "none",
 	allowExternal: false,
 	preserveDisconnected: false,
-	experimentalOpen: null
+	experimentalOpen: null,
+	protocol: "http"
 };

--- a/packages/akashic-cli-serve/src/server/controller/ContentController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ContentController.ts
@@ -60,7 +60,7 @@ export const createHandlerToGetEngineConfig = (dirPaths: string[], isRaw: boolea
 			}
 			const hostname = serverGlobalConfig.useGivenHostname ? serverGlobalConfig.hostname : urlInfo[0];
 			const port = serverGlobalConfig.useGivenPort ? serverGlobalConfig.port : parseInt(urlInfo[1], 10);
-			const baseUrl = `http://${hostname}:${port}`;
+			const baseUrl = `${serverGlobalConfig.protocol}://${hostname}:${port}`;
 			const engineConfigJson = EngineConfig.getEngineConfig({ baseUrl, contentId, baseDir: dirPaths[contentId], isRaw });
 			// akashic-gameview側でレスポンスがengineConfigJsonの形式なっていることを前提にしているので、resoponseSuccessは使わない
 			res.status(200).json(engineConfigJson);

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -97,7 +97,8 @@ export class RunnerStore {
 	}
 
 	private createAllowedUrls(contentId: string, externalAssets: (string | RegExp)[] | null): (string | RegExp)[] | null {
-		let allowedUrls: (string | RegExp)[] = [`http://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/contents/${contentId}/`];
+		let allowedUrls: (string | RegExp)[] =
+			[`${serverGlobalConfig.protocol}://${serverGlobalConfig.hostname}:${serverGlobalConfig.port}/contents/${contentId}/`];
 		if (serverGlobalConfig.allowExternal) {
 			// null は全てのアクセスを許可するため、nullが指定された場合は他の値を参照せず null を返す
 			if (externalAssets === null) return null;

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -160,24 +160,24 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 
 	const app = express();
 	let httpServer;
-	if (cliConfigParam.certificate || cliConfigParam.privatekey) {
-		if (cliConfigParam.certificate && !cliConfigParam.privatekey) {
-			getSystemLogger().error("Please specify the --privatekey option.");
+	if (cliConfigParam.sslCert || cliConfigParam.sslKey) {
+		if (cliConfigParam.sslCert && !cliConfigParam.sslKey) {
+			getSystemLogger().error("Please specify the --ssl-key option.");
 			process.exit(1);
 		}
-		if (!cliConfigParam.certificate && cliConfigParam.privatekey) {
-			getSystemLogger().error("Please specify the --certificate option.");
+		if (!cliConfigParam.sslCert && cliConfigParam.sslKey) {
+			getSystemLogger().error("Please specify the --ssl-cert option.");
 			process.exit(1);
 		}
 
-		const keyPath = path.join(process.cwd(), cliConfigParam.privatekey);
-		const certPath = path.join(process.cwd(), cliConfigParam.certificate);
+		const keyPath = path.join(process.cwd(), cliConfigParam.sslKey);
+		const certPath = path.join(process.cwd(), cliConfigParam.sslCert);
 		if (!fs.existsSync(keyPath)) {
-			getSystemLogger().error(`--privatekey option parameter ${cliConfigParam.privatekey} not found.`);
+			getSystemLogger().error(`--ssl-key option parameter ${cliConfigParam.sslKey} not found.`);
 			process.exit(1);
 		}
 		if (!fs.existsSync(certPath)) {
-			getSystemLogger().error(`--certificate option parameter ${cliConfigParam.certificate} not found.`);
+			getSystemLogger().error(`--ssl-cert option parameter ${cliConfigParam.sslCert} not found.`);
 			process.exit(1);
 		}
 
@@ -357,8 +357,8 @@ export async function run(argv: any): Promise<void> {
 		.option("--preserve-disconnected", "Disable auto closing for disconnected windows.")
 		.option("--experimental-open <num>",
 			"EXPERIMENTAL: Open <num> browser windows at startup. The upper limit of <num> is 10.") // TODO: open-browser と統合
-		.option("--certificate <certificatePath>", "Specify the certificate and privatekey and start with https")
-		.option("--privatekey <privatekeyPath>", "Specify the privatekey and certificate and start with https")
+		.option("--ssl-cert <certificatePath>", "Specify path to an SSL/TLS certificate to use HTTPS")
+		.option("--ssl-key <privatekeyPath>", "Specify path to an SSL/TLS privatekey to use HTTPS")
 		.parse(argv);
 
 	const options = commander.opts();
@@ -384,8 +384,8 @@ export async function run(argv: any): Promise<void> {
 			preserveDisconnected: options.preserveDisconnected ?? conf.preserveDisconnected,
 			watch: options.watch ?? conf.watch,
 			experimentalOpen: options.experimentalOpen ?? conf.experimentalOpen,
-			certificate: options.certificate ?? conf.certificate,
-			privatekey: options.privatekey ?? conf.privatekey
+			sslCert: options.sslCert ?? conf.sslCert,
+			sslKey: options.sslKey ?? conf.sslKey
 		};
 		await cli(cliConfigParam, options);
 	});

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -170,8 +170,8 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 			process.exit(1);
 		}
 
-		const keyPath = path.join(process.cwd(), cliConfigParam.sslKey);
-		const certPath = path.join(process.cwd(), cliConfigParam.sslCert);
+		const keyPath = path.resolve(process.cwd(), cliConfigParam.sslKey);
+		const certPath = path.resolve(process.cwd(), cliConfigParam.sslCert);
 		if (!fs.existsSync(keyPath)) {
 			getSystemLogger().error(`--ssl-key option parameter ${cliConfigParam.sslKey} not found.`);
 			process.exit(1);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -357,8 +357,8 @@ export async function run(argv: any): Promise<void> {
 		.option("--preserve-disconnected", "Disable auto closing for disconnected windows.")
 		.option("--experimental-open <num>",
 			"EXPERIMENTAL: Open <num> browser windows at startup. The upper limit of <num> is 10.") // TODO: open-browser と統合
-		.option("--certificate <certificatePath>", "Specify the certificate and start with https")
-		.option("--privatekey <privatekeyPath>", "Specify the privatekey and start with https")
+		.option("--certificate <certificatePath>", "Specify the certificate and privatekey and start with https")
+		.option("--privatekey <privatekeyPath>", "Specify the privatekey and certificate and start with https")
 		.parse(argv);
 
 	const options = commander.opts();


### PR DESCRIPTION
## 概要

Serve で http での起動を対応します。
https 起動に必要な`--ssl-cert`, `--ssl-key` オプションを追加。


(動作確認は自己証明書で行っているため、自己証明書によるブラウザや node などの問題は解決して動作確認しています。)