### PR TITLE
disable play control buttons when replay mode

### DIFF
--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -42,7 +42,7 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 		return {
 			playbackRate: play.activePlaybackRate,
 			isActivePausing: play.isActivePausing,
-			isActiveStatusRunning: play.status === "running",
+			isActiveStatusRunning: play.status === "running", // NOTE: アクティブインスタンスの実行状態を PlayStatus から判定するのは現実装で一致しているだけであり、厳密には異なるケースがある
 			onClickReset: operator.restartWithNewPlay,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance,

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -42,6 +42,7 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 		return {
 			playbackRate: play.activePlaybackRate,
 			isActivePausing: play.isActivePausing,
+			isActiveStatusRunning: play.status === "running",
 			onClickReset: operator.restartWithNewPlay,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance,

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -42,7 +42,7 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 		return {
 			playbackRate: play.activePlaybackRate,
 			isActivePausing: play.isActivePausing,
-			isActiveStatusRunning: play.status === "running", // NOTE: アクティブインスタンスの実行状態を PlayStatus から判定するのは現実装で一致しているだけであり、厳密には異なるケースがある
+			isActiveExists: play.status === "running", // NOTE: アクティブインスタンスの存在を PlayStatus から判定するのは現実装で一致しているだけであり、厳密には異なるケースがある
 			onClickReset: operator.restartWithNewPlay,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance,

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -6,6 +6,7 @@ import { ToolControlGroup } from "../atom/ToolControlGroup";
 export interface PlayControlPropsData {
 	playbackRate: number;
 	isActivePausing: boolean;
+	isActiveStatusRunning: boolean;
 	onClickReset?: () => void;
 	onClickActivePause?: (toPause: boolean) => void;
 	onClickAddInstance?: () => void;
@@ -29,6 +30,7 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				className="external-ref_button_active-pause"
 				icon="pause_circle_filled"
+				disabled={!props.isActiveStatusRunning}
 				title={`アクティブインスタンスをポーズ${props.isActivePausing ? "解除" : ""}\r\r`
 				        + `ポーズ中は全インスタンスの進行が停止します。`}
 				pushed={props.isActivePausing}
@@ -37,12 +39,13 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				className="external-ref_button_active-step"
 				icon="skip_next"
-				disabled={!props.isActivePausing}
+				disabled={!props.isActivePausing || !props.isActiveStatusRunning}
 				title={`アクティブインスタンスのポーズ中、プレイを1フレーム進めます。`}
 				onClick={props.onClickStep} />
 			<ToolIconButton
 				className="external-ref_button_add-instance"
 				icon="group_add"
+				disabled={!props.isActiveStatusRunning}
 				title={"インスタンスを追加\r\r新しいタブ・ウィンドウでこのプレイに接続するインスタンスを追加します。"}
 				onClick={props.onClickAddInstance} />
 			{/* // 未実装

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -6,7 +6,7 @@ import { ToolControlGroup } from "../atom/ToolControlGroup";
 export interface PlayControlPropsData {
 	playbackRate: number;
 	isActivePausing: boolean;
-	isActiveStatusRunning: boolean;
+	isActiveExists: boolean;
 	onClickReset?: () => void;
 	onClickActivePause?: (toPause: boolean) => void;
 	onClickAddInstance?: () => void;
@@ -30,7 +30,7 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				className="external-ref_button_active-pause"
 				icon="pause_circle_filled"
-				disabled={!props.isActiveStatusRunning}
+				disabled={!props.isActiveExists}
 				title={`アクティブインスタンスをポーズ${props.isActivePausing ? "解除" : ""}\r\r`
 				        + `ポーズ中は全インスタンスの進行が停止します。`}
 				pushed={props.isActivePausing}
@@ -39,7 +39,7 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				className="external-ref_button_active-step"
 				icon="skip_next"
-				disabled={!props.isActivePausing || !props.isActiveStatusRunning}
+				disabled={!props.isActivePausing || !props.isActiveExists}
 				title={`アクティブインスタンスのポーズ中、プレイを1フレーム進めます。`}
 				onClick={props.onClickStep} />
 			<ToolIconButton

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -45,7 +45,6 @@ export class PlayControl extends React.Component<PlayControlProps, {}> {
 			<ToolIconButton
 				className="external-ref_button_add-instance"
 				icon="group_add"
-				disabled={!props.isActiveStatusRunning}
 				title={"インスタンスを追加\r\r新しいタブ・ウィンドウでこのプレイに接続するインスタンスを追加します。"}
 				onClick={props.onClickAddInstance} />
 			{/* // 未実装

--- a/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
@@ -8,6 +8,7 @@ storiesOf("m-PlayControl", module)
 		<PlayControl makeProps={() => ({
 			playbackRate: 1.5,
 			isActivePausing: false,
+			isActiveStatusRunning: true,
 			onClickReset: action("reset"),
 			onClickActivePause: action("active-pause"),
 			onClickAddInstance: action("add-instance"),
@@ -19,6 +20,7 @@ storiesOf("m-PlayControl", module)
 		<PlayControl makeProps={() => ({
 			playbackRate: 1.5,
 			isActivePausing: true,
+			isActiveStatusRunning: true,
 			onClickReset: action("reset"),
 			onClickActivePause: action("active-pause"),
 			onClickAddInstance: action("add-instance"),

--- a/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
@@ -8,7 +8,7 @@ storiesOf("m-PlayControl", module)
 		<PlayControl makeProps={() => ({
 			playbackRate: 1.5,
 			isActivePausing: false,
-			isActiveStatusRunning: true,
+			isActiveExists: true,
 			onClickReset: action("reset"),
 			onClickActivePause: action("active-pause"),
 			onClickAddInstance: action("add-instance"),
@@ -20,7 +20,7 @@ storiesOf("m-PlayControl", module)
 		<PlayControl makeProps={() => ({
 			playbackRate: 1.5,
 			isActivePausing: true,
-			isActiveStatusRunning: true,
+			isActiveExists: true,
 			onClickReset: action("reset"),
 			onClickActivePause: action("active-pause"),
 			onClickAddInstance: action("add-instance"),

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
@@ -31,7 +31,7 @@ const TestWithBehaviour = observer(() => (
 			makePlayControlProps={() => ({
 				playbackRate: 150,
 				isActivePausing: store.isActivePausing,
-				isActiveStatusRunning: true,
+				isActiveExists: true,
 				onClickReset: action("reset"),
 				onClickActivePause: (v => (store.isActivePausing = v)),
 				onClickAddInstance: action("add-instance"),
@@ -81,7 +81,7 @@ storiesOf("o-ToolBar", module)
 			makePlayControlProps={() => ({
 				playbackRate: 150,
 				isActivePausing: false,
-				isActiveStatusRunning: true,
+				isActiveExists: true,
 				onClickReset: action("reset"),
 				onClickActivePause: action("active-pause"),
 				onClickAddInstance: action("add-instance"),

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
@@ -31,6 +31,7 @@ const TestWithBehaviour = observer(() => (
 			makePlayControlProps={() => ({
 				playbackRate: 150,
 				isActivePausing: store.isActivePausing,
+				isActiveStatusRunning: true,
 				onClickReset: action("reset"),
 				onClickActivePause: (v => (store.isActivePausing = v)),
 				onClickAddInstance: action("add-instance"),
@@ -80,6 +81,7 @@ storiesOf("o-ToolBar", module)
 			makePlayControlProps={() => ({
 				playbackRate: 150,
 				isActivePausing: false,
+				isActiveStatusRunning: true,
 				onClickReset: action("reset"),
 				onClickActivePause: action("active-pause"),
 				onClickAddInstance: action("add-instance"),


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

`serve` コマンドを ` --debug-playlog` を渡してリプレイ実行した場合、アクティブインスタンスを操作するメニューボタンを無効化します。


## 破壊的な変更を含んでいるか?

- なし