### PR TITLE
fix(serve): fix crash on --debug-untrusted

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
@@ -1,5 +1,6 @@
 import { Trigger } from "@akashic/trigger";
 import { EDumpItem } from "../common/types/EDumpItem";
+import { ProfilerValue } from "../common/types/Profiler";
 
 function getMatrixFromRoot(e: ae.ELike | null, camera: ae.CameraLike | null): ae.MatrixLike | null {
 	if (!e || !e.getMatrix)
@@ -120,5 +121,17 @@ export class ServeGameContent {
 		const game = this._game;
 		const pointSource = game.scene().findPointSourceByPoint({ x, y }, true, game.focusingCamera);
 		return (pointSource && pointSource.target) ? pointSource.target.id : null;
+	}
+
+	setProfilerValueTrigger(cb: (value: ProfilerValue) => void): void {
+		const gameDriver = this.agvGameContent.getGameDriver();
+		if (!gameDriver) {
+			this.agvGameContent.addContentLoadListener(() => this.setProfilerValueTrigger(cb));
+			return;
+		}
+
+		// 全体的に内部プロパティなので、存在しない場合に備えて ?. をつけておく。
+		// 特に _gameLoop は実際に存在しない場合がある (--debug-untrusted) 。
+		gameDriver._gameLoop?._clock?._profiler?._calculateProfilerValueTrigger?.add(cb);
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/LocalInstanceEntity.ts
@@ -222,15 +222,8 @@ export class LocalInstanceEntity implements GameInstanceEntity {
 		return t;
 	}
 
-	@action
 	setProfilerValueTrigger(cb: (value: ProfilerValue) => void): void {
-		const gameDriver = this._serveGameContent.agvGameContent.getGameDriver();
-		if (gameDriver) {
-			// TODO gameDriver の中身を触る処理なので ServeGameContent に移すべき
-			gameDriver._gameLoop._clock._profiler._calculateProfilerValueTrigger.add(cb);
-		} else {
-			this._serveGameContent.agvGameContent.addContentLoadListener(() => this.setProfilerValueTrigger(cb));
-		}
+		this._serveGameContent.setProfilerValueTrigger(cb);
 	}
 
 	followPlayAudioStateChange(): void {


### PR DESCRIPTION
掲題どおり。

- プロファイラ関連で、存在しない場合があるプロパティを考慮できていなかったので `?.` に変えます。
- ついでに TODO を消化して、プロファイラ関連の処理を `ServeGameContent` に移します。