### PR TITLE
rename instances id format

### DIFF
--- a/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/InstancesDevtool.tsx
@@ -41,9 +41,9 @@ export class InstancesDevtool extends React.Component<InstancesDevtoolProps, {}>
 					</thead>
 					<tbody>
 						{
-							this.props.instances.map(i => (
+							this.props.instances.map((i, index) => (
 								// TODO playerId をkeyにすると複数サーバインスタンスができない
-								<tr key={i.playerId} >
+								<tr key={ `${index}-${i.playerId}` } >
 									<td>{ i.type }</td>
 									<td>{ (i.playerId != null) ? i.playerId : "(null)" }</td>
 									<td>{ (i.name != null) ? i.name : "(null)" }</td>


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

`serve` コマンドの Instances UI 要素の id が重複してエラーが発生する問題を解消します。
現象はクエリパラメータ `playId=pid1` など同じ playId を含む URL のブラウザウインドウを複数同時に立ち上げることで再現します。


## 破壊的な変更を含んでいるか?

- なし