### PR TITLE
add --minify-json for Export zip 

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -7,6 +7,8 @@ export interface CliConfigExportZip {
 	force?: boolean;
 	strip?: boolean;
 	minify?: boolean;
+	minifyJs?: boolean;
+	minifyJson?: boolean;
 	bundle?: boolean;
 	babel?: boolean;
 	hashFilename?: number | boolean;

--- a/packages/akashic-cli-commons/src/GameConfiguration.ts
+++ b/packages/akashic-cli-commons/src/GameConfiguration.ts
@@ -79,6 +79,8 @@ export interface ExportZipInfo {
 		force?: boolean;
 		strip?: boolean;
 		minify?: boolean;
+		minifyJs?: boolean;
+		minifyJson?: boolean;
 		bundle?: boolean;
 		babel?: boolean;
 		hashFilename?: number | boolean;

--- a/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
+++ b/packages/akashic-cli-export/src/zip/GameConfigurationUtil.ts
@@ -109,3 +109,7 @@ export function extractScriptAssetFilePaths(gamejson: cmn.GameConfiguration): st
 export function isScriptJsFile(filePath: string): boolean {
 	return /^(script|assets)\/.+(\.js$)/.test(filePath);
 }
+
+export function isTextJsonFile(filePath: string): boolean {
+	return /^(text|assets)\/.+(\.json$)/.test(filePath);
+}

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -63,7 +63,7 @@ commander
 	.option("-o, --output <fileName>", "Name of output file (default: game.zip)")
 	.option("-f, --force", "Overwrites existing files")
 	.option("-S, --no-strip", "output fileset without strip")
-	.option("-M, --minify", "(DEPRECATED) Minify JavaScript files")
+	.option("-M, --minify", "(DEPRECATED: use --minify-js) Minify JavaScript files")
 	.option("-H, --hash-filename [length]", "Rename asset files with their hash values")
 	.option("-b, --bundle", "Bundle script assets into a single file")
 	.option("--no-es5-downpile", "No convert JavaScript into es5")

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -19,6 +19,8 @@ export function cli(param: CliConfigExportZip): void {
 			bundle: param.bundle,
 			babel: (param.babel != null) ? param.babel : true,
 			minify: param.minify,
+			minifyJs: param.minifyJs,
+			minifyJson: param.minifyJson,
 			strip: (param.strip != null) ? param.strip : true,
 			source: param.cwd,
 			dest: param.output,
@@ -34,6 +36,8 @@ export function cli(param: CliConfigExportZip): void {
 					force: param.force,
 					strip: param.strip,
 					minify: param.minify,
+					minifyJs: param.minifyJs,
+					minifyJson: param.minifyJson,
 					bundle: param.bundle,
 					babel: param.babel,
 					hashFilename: param.hashFilename,
@@ -59,12 +63,14 @@ commander
 	.option("-o, --output <fileName>", "Name of output file (default: game.zip)")
 	.option("-f, --force", "Overwrites existing files")
 	.option("-S, --no-strip", "output fileset without strip")
-	.option("-M, --minify", "Minify JavaScript files")
+	.option("-M, --minify", "(DEPRECATED) Minify JavaScript files")
 	.option("-H, --hash-filename [length]", "Rename asset files with their hash values")
 	.option("-b, --bundle", "Bundle script assets into a single file")
 	.option("--no-es5-downpile", "No convert JavaScript into es5")
 	.option("--no-omit-empty-js", "(DEPRECATED) Changes nothing. Provided for backward compatibility")
 	.option("--no-omit-unbundled-js", "Preserve unbundled .js files (not required from root). Works with --bundle only")
+	.option("--minify-js", "Minify JavaScript files")
+	.option("--minify-json", "Minify JSON files")
 	.option("--target-service <service>", `Specify the target service of the exported content:${availableServices}`);
 
 export function run(argv: string[]): void {
@@ -92,6 +98,8 @@ export function run(argv: string[]): void {
 			force: options.force ?? conf.force,
 			strip: options.strip ?? conf.strip,
 			minify: options.minify ?? conf.minify,
+			minifyJs: options.minifyJs ?? conf.minifyJs,
+			minifyJson: options.minifyJson ?? conf.minifyJson,
 			hashFilename: options.hashFilename ?? conf.hashFilename,
 			bundle: options.bundle ?? conf.bundle,
 			babel: options.es5Downpile ?? conf.babel,

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -218,7 +218,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			return cmn.ConfigurationFile.write(gamejson, path.resolve(param.dest, "game.json"), param.logger);
 		})
 		.then(() => {
-			if (!param.minify || !param.minifyJs)
+			if (!param.minify && !param.minifyJs)
 				return;
 			const scriptAssetPaths = gcu.extractScriptAssetFilePaths(gamejson).map(p => path.resolve(param.dest, p));
 			scriptAssetPaths.forEach(p => {

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -10,6 +10,8 @@ export interface ExportZipParameterObject {
 	bundle?: boolean;
 	babel?: boolean;
 	minify?: boolean;
+	minifyJs?: boolean;
+	minifyJson?: boolean;
 	strip?: boolean;
 	source?: string;
 	dest?: string;
@@ -28,6 +30,8 @@ function _createExportInfo(param: ExportZipParameterObject): cmn.ExportZipInfo {
 			force: !!param.force,
 			strip: !!param.strip,
 			minify: !!param.minify,
+			minifyJs: !!param.minifyJs,
+			minifyJson: !!param.minifyJson,
 			bundle: !!param.bundle,
 			babel: !!param.babel,
 			targetService: param.targetService || "none"
@@ -40,6 +44,8 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		bundle: !!param.bundle,
 		babel: !!param.babel,
 		minify: !!param.minify,
+		minifyJs: !!param.minifyJs,
+		minifyJson: !!param.minifyJson,
 		strip: !!param.strip,
 		source: param.source || process.cwd(),
 		dest: param.dest || "./game.zip",
@@ -83,6 +89,8 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 				bundle: param.bundle,
 				babel: param.babel,
 				minify: param.minify,
+				minifyJs: param.minifyJs,
+				minifyJson: param.minifyJson,
 				strip: param.strip,
 				source: param.source,
 				dest: destDir,


### PR DESCRIPTION
## このpull requestが解決する内容

### 概要

`akashic export zip` コマンドに `--minify-json` オプションを追加します。このオプションが有効な場合、 export 結果に含まれる JSON ファイルのインデント等が圧縮して出力されます。
また、ミニファイオプション体系を整理します。 `--minify` を非推奨にし（廃止時期未定の移行措置として残します）、同じ機能を提供する `--minify-js` オプションを追加します。

## 破壊的な変更を含んでいるか?

- なし
- 