### PR TITLE
feat(serve): move profiler toggle button to toolbar

### DIFF
--- a/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
@@ -97,6 +97,6 @@ export class UiOperator {
 	};
 
 	setShowsProfiler = (show: boolean): void => {
-		this.store.devtoolUiStore.setShowsProfiler(show);
+		this.store.toolBarUiStore.setShowsProfiler(show);
 	};
 }

--- a/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
@@ -16,7 +16,6 @@ export class DevtoolUiStore {
 	@observable usePreferredTotalTimeLimit: boolean;
 	@observable stopsGameOnTimeout: boolean;
 	@observable totalTimeLimitInputValue: number;
-	@observable showsProfiler: boolean;
 
 	// storage に保存しないもの
 	@observable isSelectingEntity: boolean;
@@ -49,7 +48,6 @@ export class DevtoolUiStore {
 		this.usePreferredTotalTimeLimit = storage.data.usePreferredTotalTimeLimit;
 		this.stopsGameOnTimeout = storage.data.stopsGameOnTimeout;
 		this.totalTimeLimitInputValue = storage.data.totalTimeLimitInputValue;
-		this.showsProfiler = storage.data.showsProfiler;
 	}
 
 	@action
@@ -171,11 +169,5 @@ export class DevtoolUiStore {
 	initTotalTimeLimit(_preferredTotalTimeLimit: number): void {
 		this.preferredTotalTimeLimit = _preferredTotalTimeLimit;
 		this.totalTimeLimit = this.usePreferredTotalTimeLimit ? _preferredTotalTimeLimit : this.totalTimeLimitInputValue;
-	}
-
-	@action
-	setShowsProfiler(show: boolean): void {
-		this.showsProfiler = show;
-		storage.put({ showsProfiler: show });
 	}
 }

--- a/packages/akashic-cli-serve/src/client/store/ToolBarUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/ToolBarUiStore.ts
@@ -11,6 +11,7 @@ export class ToolBarUiStore {
 	@observable showsDisplayOptionPopover: boolean;
 	@observable showsBackgroundImage: boolean;
 	@observable showsGrid: boolean;
+	@observable showsProfiler: boolean;
 	@observable showsDesignGuideline: boolean;
 
 	constructor() {
@@ -22,6 +23,7 @@ export class ToolBarUiStore {
 		this.showsDisplayOptionPopover = false;
 		this.showsBackgroundImage = storage.data.showsBackgroundImage;
 		this.showsGrid = storage.data.showsGrid;
+		this.showsProfiler = storage.data.showsProfiler;
 		this.showsDesignGuideline = storage.data.showsDesignGuideline;
 	}
 
@@ -72,6 +74,12 @@ export class ToolBarUiStore {
 	setShowGrid(show: boolean): void {
 		this.showsGrid = show;
 		storage.put({ showsGrid: show });
+	}
+
+	@action
+	setShowsProfiler(show: boolean): void {
+		this.showsProfiler = show;
+		storage.put({ showsProfiler: show });
 	}
 
 	@action

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -96,9 +96,7 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				onTotalTimeLimitInputValueChanged: operator.devtool.setTotalTimeLimitInputValue
 			}}
 			miscDevtoolProps={{
-				showsProfiler: devtoolUiStore.showsProfiler,
-				downloadPlaylog: operator.play.downloadPlaylog,
-				setShowsProfiler: operator.ui.setShowsProfiler
+				downloadPlaylog: operator.play.downloadPlaylog
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: play.startPointHeaders,

--- a/packages/akashic-cli-serve/src/client/view/container/GameScreenContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/GameScreenContainer.tsx
@@ -68,7 +68,7 @@ export class GameScreenContainer extends React.Component<GameScreenContainerProp
 	}
 
 	private _makeProfilerCanvasProps = (): ProfilerCanvasProps | undefined => {
-		return this.props.devtoolUiStore.showsProfiler ? {
+		return this.props.toolBarUiStore.showsProfiler ? {
 			profilerDataArray: this.props.profilerStore.profilerDataArray,
 			profilerStyleSetting: this.props.profilerStore.profilerStyleSetting,
 			profilerWidth: this.props.profilerStore.profilerWidth,

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -99,10 +99,12 @@ export class ToolBarContainer extends React.Component<ToolBarContainerProps, {}>
 			showsDisplayOptionPopover: toolBarUiStore.showsDisplayOptionPopover,
 			showsBackgroundImage: toolBarUiStore.showsBackgroundImage,
 			showsGrid: toolBarUiStore.showsGrid,
+			showsProfiler: toolBarUiStore.showsProfiler,
 			showsDesignGuideline: toolBarUiStore.showsDesignGuideline,
 			onClickDisplayOptionPopover: operator.ui.setShowDisplayOptionPopover,
 			onChangeShowBackgroundImage: operator.ui.setShowBackgroundImage,
 			onChangeShowGrid: operator.ui.setShowGrid,
+			onChangeShowProfiler: operator.ui.setShowsProfiler,
 			onChangeShowDesignGuideline: operator.ui.setShowDesignGuideline
 		};
 	}

--- a/packages/akashic-cli-serve/src/client/view/molecule/DisplayOptionControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/DisplayOptionControl.tsx
@@ -8,10 +8,12 @@ export interface DisplayOptionControlPropsData {
 	showsDisplayOptionPopover: boolean;
 	showsBackgroundImage: boolean;
 	showsGrid: boolean;
+	showsProfiler: boolean;
 	showsDesignGuideline: boolean;
 	onClickDisplayOptionPopover: (show: boolean) => void;
 	onChangeShowBackgroundImage: (show: boolean) => void;
 	onChangeShowGrid: (show: boolean) => void;
+	onChangeShowProfiler: (show: boolean) => void;
 	onChangeShowDesignGuideline: (show: boolean) => void;
 }
 
@@ -24,10 +26,12 @@ export const DisplayOptionControl = observer(function (props: DisplayOptionContr
 		showsDisplayOptionPopover,
 		showsBackgroundImage,
 		showsGrid,
+		showsProfiler,
 		showsDesignGuideline,
 		onClickDisplayOptionPopover,
 		onChangeShowBackgroundImage,
 		onChangeShowGrid,
+		onChangeShowProfiler,
 		onChangeShowDesignGuideline
 	} = props.makeProps();
 	const ref = React.useRef();
@@ -66,6 +70,17 @@ export const DisplayOptionControl = observer(function (props: DisplayOptionContr
 						onChange={() => onChangeShowGrid(!showsGrid)}
 					/>
 					Show grid
+				</label>
+			</div>
+			<div className={styles["label"]}>
+				<label>
+					<input
+						className={styles["checkbox"] + " external-ref_checkbox_shows-profiler"}
+						type="checkbox"
+						checked={showsProfiler}
+						onChange={() => onChangeShowProfiler(!showsProfiler)}
+					/>
+					Show profiler
 				</label>
 			</div>
 			<div className={styles["label"]}>

--- a/packages/akashic-cli-serve/src/client/view/molecule/MiscDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/MiscDevtool.tsx
@@ -3,9 +3,7 @@ import { observer } from "mobx-react";
 import { ToolLabelButton } from "../atom/ToolLabelButton";
 
 export interface MiscDevtoolProps {
-	showsProfiler: boolean;
 	downloadPlaylog: () => void;
-	setShowsProfiler: (show: boolean) => void;
 }
 
 @observer
@@ -20,18 +18,6 @@ export class MiscDevtool extends React.Component<MiscDevtoolProps, {}> {
 			>
 				今までのリプレイ情報を保存
 			</ToolLabelButton>
-			<div>
-				<input
-					className="external-ref_checkbox_show-profiler"
-					type="checkbox"
-					checked={this.props.showsProfiler}
-					onChange={this._onShowProfilerCheckboxChange} />
-				プロファイラー情報の表示
-			</div>
 		</div>;
-	}
-
-	private _onShowProfilerCheckboxChange = (): void => {
-		this.props.setShowsProfiler(!this.props.showsProfiler);
 	}
 }

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -195,9 +195,7 @@ const TestWithBehaviour = observer(() => (
 		}}
 		niconicoDevtoolProps={nicoProps}
 		miscDevtoolProps={{
-			showsProfiler: false,
-			downloadPlaylog: action("download-playlog"),
-			setShowsProfiler: action("show-profiler")
+			downloadPlaylog: action("download-playlog")
 		}}
 		snapshotDevtoolProps={{
 			startPointHeaders: [
@@ -310,9 +308,7 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				showsProfiler: false,
-				downloadPlaylog: action("download-playlog"),
-				setShowsProfiler: action("show-profiler")
+				downloadPlaylog: action("download-playlog")
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: [],
@@ -411,9 +407,7 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				showsProfiler: false,
-				downloadPlaylog: action("download-playlog"),
-				setShowsProfiler: action("show-profiler")
+				downloadPlaylog: action("download-playlog")
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: [],
@@ -516,9 +510,7 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				showsProfiler: false,
-				downloadPlaylog: action("download-playlog"),
-				setShowsProfiler: action("show-profiler")
+				downloadPlaylog: action("download-playlog")
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: [],
@@ -575,9 +567,7 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				showsProfiler: false,
-				downloadPlaylog: action("download-playlog"),
-				setShowsProfiler: action("show-profiler")
+				downloadPlaylog: action("download-playlog")
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: [],
@@ -634,9 +624,7 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				showsProfiler: false,
-				downloadPlaylog: action("download-playlog"),
-				setShowsProfiler: action("show-profiler")
+				downloadPlaylog: action("download-playlog")
 			}}
 			snapshotDevtoolProps={{
 				startPointHeaders: [],

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
@@ -19,6 +19,7 @@ const store = observable({
 	showsDisplayOptionPopover: false,
 	showsBackgroundImage: false,
 	showsGrid: false,
+	showsProfiler: false,
 	isActivePausing: false,
 	audioStateSummary: "all-player-unmuted" as PlayAudioStateSummary,
 	showsDesignGuideline: false
@@ -71,10 +72,12 @@ const TestWithBehaviour = observer(() => (
 				showsDisplayOptionPopover: store.showsDisplayOptionPopover,
 				showsBackgroundImage: store.showsBackgroundImage,
 				showsGrid: store.showsGrid,
+				showsProfiler: store.showsProfiler,
 				showsDesignGuideline: store.showsDesignGuideline,
 				onClickDisplayOptionPopover: (show => store.showsDisplayOptionPopover = show),
 				onChangeShowBackgroundImage: (show => store.showsBackgroundImage = show),
 				onChangeShowGrid: (show => store.showsGrid = show),
+				onChangeShowProfiler: (show => store.showsProfiler = show),
 				onChangeShowDesignGuideline: (show => store.showsDesignGuideline = show)
 			})}
 			showsAppearance={store.showsAppearance}
@@ -126,10 +129,12 @@ storiesOf("o-ToolBar", module)
 				showsDisplayOptionPopover: true,
 				showsBackgroundImage: false,
 				showsGrid: true,
+				showsProfiler: true,
 				showsDesignGuideline: false,
 				onClickDisplayOptionPopover: action("display-option"),
 				onChangeShowBackgroundImage: action("bgimage"),
 				onChangeShowGrid: action("grid"),
+				onChangeShowProfiler: action("profiler"),
 				onChangeShowDesignGuideline: action("design-guideline")
 			})}
 			showsAppearance={false}


### PR DESCRIPTION
リプレイ情報を扱う "Playback" devtool の新設に先立ち、 "Misc" devtool から「プロファイラー情報の表示」をツールバーの "Display Options" に移動します。

"Misc" は、分類不能で CSS も特に作り込んでいない機能をとりあえず置くための場所です。現状「プロファイラー情報の表示」と「今までのリプレイ情報を保存」しか機能がなく、後者を "Playback" に移動するので、この際 "Misc" ごと削除するためにより適当な場所に移動します。
