### PR TITLE
feat(serve): extend ToolProgressBar

### DIFF
--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.css
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.css
@@ -18,25 +18,42 @@
 	-ms-user-select: none;
 }
 
-.bar {
+.bar, .subbar {
 	position: relative;
 	width: 0%;  /* style属性で上書き */
 	height: 100%;
 	background: #aaa;
 }
 
+.subbar {
+	position: absolute;
+	top: 0;
+	left: 0;
+	background: #ddd;
+}
+
 .circle {
 	position: absolute;
-	width: 10px;
-	height: 10px;
+	width: 8px;
+	height: 8px;
 	background: #999;
 	border-radius: 5px;
-	right: -5px;
-	top: -4px;
+	top: -3px;
+	left: -4px; /* style属性で上書き */
 }
 
 .circle:hover,
 .active .bar,
 .active .circle {
 	background: gray;
+}
+
+.marker {
+	position: absolute;
+	left: -4px; /* style属性で上書き */
+	width: 0;
+	height: 0;
+	border-left: 4px solid transparent;
+	border-right: 4px solid transparent;
+	border-bottom: 7px solid #aaf;
 }

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.css
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.css
@@ -1,11 +1,15 @@
 @import "../global.css";
 
+.container {
+	padding: 3px 0;
+	margin: 0 4px;
+}
+
 .tool-progress-bar {
 	position: relative;
-	width: 200px;  /* style属性で上書き */
 	height: 2px;
 	border-radius: 2px;
-	margin: 4px 8px;
+	margin: 4px 0;
 	border: 1px solid #888;
 
 	cursor: default;

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
@@ -3,13 +3,47 @@ import { observer } from "mobx-react";
 import * as styles from "./ToolProgressBar.css";
 
 export interface ToolProgressBarProps {
+	/**
+	 * 最大値。
+	 */
 	max: number;
+
+	/**
+	 * 現在値。
+	 */
 	value: number;
+
+	/**
+	 * 補助的に表示する値。
+	 * 指定した場合、 (ドラッグ可能であることを示すノブ部分を持たない) 色だけのゲージで描画される。
+	 */
 	subValue?: number;
+
+	/**
+	 * マーカーの値。
+	 * 指定した場合、プログレスバーの下部の当該の値にあたる箇所に三角形のマーカーが描画される。
+	 */
 	markerValue?: number;
+
+	/**
+	 * 幅 (px)。
+	 */
 	width?: number;
+
+	/**
+	 * アクティブな状態として描画するか。
+	 * ドラッグ操作などで `value` を変化させている間などに真であることを期待する値。
+	 */
 	active?: boolean;
+
+	/**
+	 * ノブを操作した時 (ドラッグなど) に通知されるハンドラ。
+	 */
 	onChange?: (val: number) => void;
+
+	/**
+	 * ノブの操作が完了 (ドロップなど) して、値が確定した時に通知されるハンドラ。
+	 */
 	onCommit?: (val: number) => void;
 }
 

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
@@ -73,7 +73,10 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 					{ (subRatio > ratio) && subBar }
 					<div className={styles["bar"]} style={{ width: `${ratio * 100}%` }} />
 					{ (subRatio <= ratio) && subBar }
-					{ (markerRatio != null) && <div className={styles["marker"]} style={{ left: `calc(${markerRatio * 100}% - 4px)` }} /> }
+					{
+						// 4px ずらすのは CSS に由来。.marker の定義を参照のこと。
+						(markerRatio != null) && <div className={styles["marker"]} style={{ left: `calc(${markerRatio * 100}% - 4px)` }} />
+					}
 					<div className={styles["circle"]} style={{ left: `calc(${ratio * 100}% - 4px)` }} onMouseDown={this._onMouseDown} />
 				</div>
 			</div>

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
@@ -9,7 +9,6 @@ export interface ToolProgressBarProps {
 	markerValue?: number;
 	width?: number;
 	active?: boolean;
-	showsKnob?: boolean;
 	onChange?: (val: number) => void;
 	onCommit?: (val: number) => void;
 }
@@ -29,7 +28,6 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 
 	render() {
 		const { width, max, value, subValue, markerValue, active } = this.props;
-		const showsKnob = this.props.showsKnob ?? true; // TODO: 移行措置。後でデフォルトを false にする
 		const ratio = clamp(value, 0, max) / max;
 		const subRatio = clamp((subValue ?? 0), 0, max) / max;
 		const markerRatio = (markerValue != null) ? clamp(markerValue, 0, max) / max : null;
@@ -42,7 +40,7 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 					<div className={styles["bar"]} style={{ width: `${ratio * 100}%` }} />
 					{ (subRatio <= ratio) && subBar }
 					{ (markerRatio != null) && <div className={styles["marker"]} style={{ left: `calc(${markerRatio * 100}% - 4px)` }} /> }
-					{ showsKnob && <div className={styles["circle"]} style={{ left: `calc(${ratio * 100}% - 4px)` }} onMouseDown={this._onMouseDown} /> }
+					<div className={styles["circle"]} style={{ left: `calc(${ratio * 100}% - 4px)` }} onMouseDown={this._onMouseDown} />
 				</div>
 			</div>
 		);

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolProgressBar.tsx
@@ -3,9 +3,9 @@ import { observer } from "mobx-react";
 import * as styles from "./ToolProgressBar.css";
 
 export interface ToolProgressBarProps {
-	width: number;
 	max: number;
 	value: number;
+	width?: number;
 	active?: boolean;
 	onChange?: (val: number) => void;
 	onCommit?: (val: number) => void;
@@ -24,13 +24,15 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 		const { width, max, value, active } = this.props;
 		const ratio = value / max;
 		const className = styles["tool-progress-bar"] + (active ? ` ${styles["active"]}` : "");
-		return <div className={className} style={{ width }}
-		            ref={this._onRef}
-		            onMouseDown={this._onMouseDownGauge}>
-			<div className={styles["bar"]} style={{ width: `${ratio * 100}%` }}>
-				<div className={styles["circle"]} onMouseDown={this._onMouseDown} />
+		return (
+			<div className={styles["container"]} style={{ width }} onMouseDown={this._onMouseDownGauge} >
+				<div className={className} ref={this._onRef}>
+					<div className={styles["bar"]} style={{ width: `${ratio * 100}%` }}>
+						<div className={styles["circle"]} onMouseDown={this._onMouseDown} />
+					</div>
+				</div>
 			</div>
-		</div>;
+		);
 	}
 
 	private _onRef = (e: HTMLDivElement): void => {
@@ -41,8 +43,9 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 		if (!this._ref || !this.props.onChange)
 			return;
 		this._onMouseDown(ev);
-		const offset = ev.nativeEvent.pageX - (window.pageXOffset + this._ref.getBoundingClientRect().left);
-		const v = this._valueFromOffset(offset);
+		const v = this._valueFromPageX(ev.nativeEvent.pageX);
+		if (isNaN(v))
+			return;
 		if (this.props.value !== v)
 			this.props.onChange(v);
 	}
@@ -57,10 +60,11 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 	private _onMouseMoveWindow = (ev: MouseEvent): void => {
 		ev.stopPropagation();
 		ev.preventDefault();
-		if (!this._ref || !this.props.onChange)
+		if (!this.props.onChange)
 			return;
-		const offset = ev.pageX - (window.pageXOffset + this._ref.getBoundingClientRect().left);
-		const v = this._valueFromOffset(offset);
+		const v = this._valueFromPageX(ev.pageX);
+		if (isNaN(v))
+			return;
 		if (this.props.value !== v)
 			this.props.onChange(v);
 	}
@@ -70,16 +74,21 @@ export class ToolProgressBar extends React.Component<ToolProgressBarProps, {}> {
 		ev.preventDefault();
 		window.removeEventListener("mousemove", this._onMouseMoveWindow);
 		window.removeEventListener("mouseup", this._onMouseUpWindow);
-		if (!this._ref || !this.props.onCommit)
+		if (!this.props.onCommit)
 			return;
-		const offset = ev.pageX - (window.pageXOffset + this._ref.getBoundingClientRect().left);
-		const v = this._valueFromOffset(offset);
-		// onChangeと異なり常に通知する。さもなくばonChangeの後にonCommitが来る保証がなくなってしまう
+		const v = this._valueFromPageX(ev.pageX);
+		if (isNaN(v))
+			return;
+		// onChangeと異なり、値が変化していなくても通知する。さもなくばonChangeの後にonCommitが来る保証がなくなってしまう
 		this.props.onCommit(v);
 	}
 
-	private _valueFromOffset(offset: number): number {
-		const { max, width } = this.props;
+	private _valueFromPageX(pageX: number): number {
+		if (!this._ref)
+			return NaN;
+		const max = this.props.max;
+		const { left, width } = this._ref.getBoundingClientRect();
+		const offset = pageX - (window.pageXOffset + left);
 		return Math.round(Math.min(1, Math.max(0, offset / width)) * max);
 	}
 }

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
@@ -8,14 +8,55 @@ import { ToolProgressBar } from "../atom/ToolProgressBar";
 const store = observable({
 	max: 100,
 	value: 10,
+	subValue: 4,
+	markerValue: 20,
 });
 
 const TestWithBehaviour = observer(() => (
 	<>
+		<div style={{ width: 300, display: "flex", flexFlow: "row nowrap", }}>
+			subValue
+			<div style={{ flex: "1 1 auto" }}>
+				<ToolProgressBar
+					max={store.max}
+					value={store.subValue}
+					showsKnob={true}
+					onChange={v => store.subValue = v}
+					onCommit={v => store.subValue = v}
+				/>
+			</div>
+		</div>
+		<div style={{ width: 300, display: "flex", flexFlow: "row nowrap", }}>
+			max
+			<div style={{ flex: "1 1 auto" }}>
+				<ToolProgressBar
+					max={200}
+					value={store.max}
+					showsKnob={true}
+					onChange={v => store.max = v}
+					onCommit={v => store.max = v}
+				/>
+			</div>
+		</div>
+		<div style={{ width: 300, display: "flex", flexFlow: "row nowrap", }}>
+			markerValue
+			<div style={{ flex: "1 1 auto" }}>
+				<ToolProgressBar
+					max={store.max}
+					value={store.markerValue}
+					showsKnob={true}
+					onChange={v => store.markerValue = v}
+					onCommit={v => store.markerValue = v}
+				/>
+			</div>
+		</div>
 		<div style={{ width: 300, padding: "0 14px", border: "1px solid red", resize: "horizontal", overflow: "auto" }}>
 			<ToolProgressBar
 				max={store.max}
 				value={store.value}
+				subValue={store.subValue}
+				markerValue={store.markerValue}
+				showsKnob={true}
 				onChange={v => store.value = v}
 				onCommit={v => store.value = v}
 			/>
@@ -26,19 +67,25 @@ const TestWithBehaviour = observer(() => (
 
 storiesOf("a-ToolProgressBar", module)
 	.add("basic", () => (
-		<ToolProgressBar width={200} max={100} value={64}
+		<ToolProgressBar width={200} max={100} value={64} showsKnob={true}
 		                 onChange={action("change")} onCommit={action("commit")} />
 	))
 	.add("active", () => (
-		<ToolProgressBar width={200} max={100} value={64} active />
+		<ToolProgressBar width={200} max={100} value={64} active showsKnob={true} />
 	))
 	.add("min", () => (
-		<ToolProgressBar width={200} max={10} value={0} />
+		<ToolProgressBar width={200} max={10} value={0} showsKnob={true} />
 	))
 	.add("max", () => (
-		<ToolProgressBar width={200} max={100} value={100} />
+		<ToolProgressBar width={200} max={100} value={100} showsKnob={true} />
 	))
 	.add("no-width", () => (
-		<ToolProgressBar max={100} value={50} />
+		<ToolProgressBar max={100} value={50} showsKnob={true} />
+	))
+	.add("no-knob", () => (
+		<ToolProgressBar width={200} max={100} value={30} showsKnob={false} />
+	))
+	.add("sub/marker", () => (
+		<ToolProgressBar width={200} max={100} value={30} subValue={50} markerValue={70} showsKnob={true} />
 	))
 	.add("with-behaviour", () => <TestWithBehaviour />);

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
@@ -1,7 +1,28 @@
 import * as React from "react";
+import { observable } from "mobx";
+import { observer } from "mobx-react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { ToolProgressBar } from "../atom/ToolProgressBar";
+
+const store = observable({
+	max: 100,
+	value: 10,
+});
+
+const TestWithBehaviour = observer(() => (
+	<>
+		<div style={{ width: 300, padding: "0 14px", border: "1px solid red", resize: "horizontal", overflow: "auto" }}>
+			<ToolProgressBar
+				max={store.max}
+				value={store.value}
+				onChange={v => store.value = v}
+				onCommit={v => store.value = v}
+			/>
+		</div>
+		{ store.value } / { store.max }
+	</>
+));
 
 storiesOf("a-ToolProgressBar", module)
 	.add("basic", () => (
@@ -16,4 +37,8 @@ storiesOf("a-ToolProgressBar", module)
 	))
 	.add("max", () => (
 		<ToolProgressBar width={200} max={100} value={100} />
-	));
+	))
+	.add("no-width", () => (
+		<ToolProgressBar max={100} value={50} />
+	))
+	.add("with-behaviour", () => <TestWithBehaviour />);

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolProgressBar.stories.tsx
@@ -20,7 +20,6 @@ const TestWithBehaviour = observer(() => (
 				<ToolProgressBar
 					max={store.max}
 					value={store.subValue}
-					showsKnob={true}
 					onChange={v => store.subValue = v}
 					onCommit={v => store.subValue = v}
 				/>
@@ -32,7 +31,6 @@ const TestWithBehaviour = observer(() => (
 				<ToolProgressBar
 					max={200}
 					value={store.max}
-					showsKnob={true}
 					onChange={v => store.max = v}
 					onCommit={v => store.max = v}
 				/>
@@ -44,7 +42,6 @@ const TestWithBehaviour = observer(() => (
 				<ToolProgressBar
 					max={store.max}
 					value={store.markerValue}
-					showsKnob={true}
 					onChange={v => store.markerValue = v}
 					onCommit={v => store.markerValue = v}
 				/>
@@ -56,7 +53,6 @@ const TestWithBehaviour = observer(() => (
 				value={store.value}
 				subValue={store.subValue}
 				markerValue={store.markerValue}
-				showsKnob={true}
 				onChange={v => store.value = v}
 				onCommit={v => store.value = v}
 			/>
@@ -67,25 +63,22 @@ const TestWithBehaviour = observer(() => (
 
 storiesOf("a-ToolProgressBar", module)
 	.add("basic", () => (
-		<ToolProgressBar width={200} max={100} value={64} showsKnob={true}
+		<ToolProgressBar width={200} max={100} value={64}
 		                 onChange={action("change")} onCommit={action("commit")} />
 	))
 	.add("active", () => (
-		<ToolProgressBar width={200} max={100} value={64} active showsKnob={true} />
+		<ToolProgressBar width={200} max={100} value={64} active />
 	))
 	.add("min", () => (
-		<ToolProgressBar width={200} max={10} value={0} showsKnob={true} />
+		<ToolProgressBar width={200} max={10} value={0} />
 	))
 	.add("max", () => (
-		<ToolProgressBar width={200} max={100} value={100} showsKnob={true} />
+		<ToolProgressBar width={200} max={100} value={100} />
 	))
 	.add("no-width", () => (
-		<ToolProgressBar max={100} value={50} showsKnob={true} />
-	))
-	.add("no-knob", () => (
-		<ToolProgressBar width={200} max={100} value={30} showsKnob={false} />
+		<ToolProgressBar max={100} value={50} />
 	))
 	.add("sub/marker", () => (
-		<ToolProgressBar width={200} max={100} value={30} subValue={50} markerValue={70} showsKnob={true} />
+		<ToolProgressBar width={200} max={100} value={30} subValue={50} markerValue={70} />
 	))
 	.add("with-behaviour", () => <TestWithBehaviour />);


### PR DESCRIPTION
"Playback" devtool の導入にあたり、プログレスバーに表示したいものが増えるので拡張します。

### props 追加

現状は「現在時刻」と「最後の時刻 (最新の時刻)」の二つしか値がなく、それぞれプログレスバー (`ToolProgressBar`) の  `value`, `max` に対応しています。これに次の二つを省略可能な props として加えます。

|prop|表示|想定用途|
|:---:|:---:|:---:|
|`subValue`|色違いのノブなしのゲージ|最後にゲームをリセットした時刻の表示|
|`markerValue`|ゲージ下の三角形のマーカー|選択中のスナップショットの時刻|

![スクリーンショット 2021-10-21 19 06 10](https://user-images.githubusercontent.com/16988148/138257832-cb885d15-4953-4cb0-9368-19b095ac884a.png)

途中まで色が薄くなっているのが `subValue` によるもの、 下の薄青の三角形が `makerValue` によるものです。

### その他調整

- `width` を optional に
   - (従来は px 単位での指定が必須でしたが、 "Playback" devtool では幅いっぱいで使用したいので)
- ゲージの当たり判定を拡張
   - 厳密にゲージ自体でない、近くの領域でもゲージを操作できるように (単純に使い心地が悪かったので)

いずれもこの段階ではソースコード中では利用していないので、Storybook (`npm run storybook`) で表示を目視確認しています。
