### PR TITLE
chore(serve): introduce ToolCheckbox

### DIFF
--- a/packages/akashic-cli-serve/src/client/view/atom/ToolCheckbox.css
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolCheckbox.css
@@ -1,0 +1,13 @@
+.switch-option {
+	display: inline-flex;
+	flex-flow: row nowrap;
+	align-items: center;
+	margin: 0 9px;
+	font-size: 0.9rem;
+	user-select: none;
+	-webkit-user-select: none;
+}
+
+.switch-option > input[type=checkbox] {
+	margin-right: 5px;
+}

--- a/packages/akashic-cli-serve/src/client/view/atom/ToolCheckbox.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/ToolCheckbox.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { observer } from "mobx-react";
+import * as styles from "./ToolCheckbox.css";
+
+export interface ToolCheckboxProps {
+	checked: boolean;
+	label?: string;
+	onChange: (checked: boolean) => void;
+}
+
+export const ToolCheckbox = observer(function ToolCheckbox(props: ToolCheckboxProps) {
+	const { checked, label, onChange } = props;
+	const handleChange = React.useCallback(() => onChange(!checked), [checked, onChange]);
+	return (
+		<label className={styles["switch-option"]}>
+			<input type="checkbox" checked={checked} onChange={handleChange} />
+			{ label }
+		</label>
+	);
+});

--- a/packages/akashic-cli-serve/src/client/view/molecule/EntityTreeOptionBar.css
+++ b/packages/akashic-cli-serve/src/client/view/molecule/EntityTreeOptionBar.css
@@ -7,17 +7,6 @@
 	border-bottom: 1px solid var(--color-base-grid);
 }
 
-.switch-option {
-	margin: 0 9px;
-	font-size: 0.8rem;
-	user-select: none;
-	-webkit-user-select: none;
-}
-
-.switch-option > input[type=checkbox] {
-	margin-right: 5px;
-}
-
 .sep {
 	align-self: center;
 	display: block;

--- a/packages/akashic-cli-serve/src/client/view/molecule/EntityTreeOptionBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/EntityTreeOptionBar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { observer } from "mobx-react";
 import { ToolIconButton } from "../atom/ToolIconButton";
+import { ToolCheckbox } from "../atom/ToolCheckbox";
 import * as styles from "./EntityTreeOptionBar.css";
 
 export interface EntityTreeOptionBarProps {
@@ -13,47 +14,48 @@ export interface EntityTreeOptionBarProps {
 	onClickUpdateEntityTrees: () => void;
 }
 
-@observer
-export class EntityTreeOptionBar extends React.Component<EntityTreeOptionBarProps, {}> {
-	render(): React.ReactNode {
-		const { isSelectingEntity, showsHidden, onClickSelectEntity, onClickUpdateEntityTrees } = this.props;
-		return <div className={styles["entity-tree-option-bar"]}>
-			<ToolIconButton
-				className="external-ref_button_select-entity-from-screen"
-				icon="input"
-				title="ゲーム画面からエンティティを選択"
-				pushed={isSelectingEntity}
-				size={17}
-				onClick={onClickSelectEntity}
-			/>
-			<div className={styles["sep"]} />
-			<ToolIconButton
-				className="external-ref_button_refresh-entity-tree"
-				icon="refresh"
-				title="エンティティツリーを更新"
-				size={20}
-				onClick={this.props.onClickUpdateEntityTrees}
-			>
-				Update
-			</ToolIconButton>
-			<label className={styles["switch-option"]}>
-				<input type="checkbox" checked={this.props.showsHidden} onChange={this._onInputChange} />
-				Show hidden
-			</label>
-			<ToolIconButton
-				className="external-ref_button_dump-to-console"
-				icon="web_asset"
-				title="選択エンティティをコンソールにダンプ"
-				size={20}
-				disabled={this.props.selectedEntityId == null}
-				onClick={this.props.onClickDump}
-			>
-				console.log()
-			</ToolIconButton>
-		</div>;
-	}
-
-	private _onInputChange = (): void => {
-		this.props.onChangeShowsHidden(!this.props.showsHidden);
-	}
-}
+export const EntityTreeOptionBar = observer(function EntityTreeOptionBar(props: EntityTreeOptionBarProps) {
+	const {
+		isSelectingEntity,
+		selectedEntityId,
+		showsHidden,
+		onClickDump,
+		onChangeShowsHidden,
+		onClickSelectEntity,
+		onClickUpdateEntityTrees
+	} = props;
+	return <div className={styles["entity-tree-option-bar"]}>
+		<ToolIconButton
+			className="external-ref_button_select-entity-from-screen"
+			icon="input"
+			title="ゲーム画面からエンティティを選択"
+			pushed={isSelectingEntity}
+			size={17}
+			onClick={onClickSelectEntity}
+		/>
+		<div className={styles["sep"]} />
+		<ToolIconButton
+			className="external-ref_button_refresh-entity-tree"
+			icon="refresh"
+			title="エンティティツリーを更新"
+			size={20}
+			onClick={onClickUpdateEntityTrees}
+		>
+			Update
+		</ToolIconButton>
+		<ToolCheckbox
+			checked={showsHidden}
+			label="Show hidden"
+			onChange={onChangeShowsHidden} />
+		<ToolIconButton
+			className="external-ref_button_dump-to-console"
+			icon="web_asset"
+			title="選択エンティティをコンソールにダンプ"
+			size={20}
+			disabled={selectedEntityId == null}
+			onClick={onClickDump}
+		>
+			console.log()
+		</ToolIconButton>
+	</div>;
+});


### PR DESCRIPTION
掲題どおり。 "Entity" devtool のチェックボックスを他でも使えるよう切り出します。(コンポーネント自体は単純なものの、付随する CSS のスタイルをコピーして回りたくないので)

この部分です:

![スクリーンショット 2021-10-21 20 47 35](https://user-images.githubusercontent.com/16988148/138272071-3d585055-2a02-482b-bbf0-c5329e993100.png)

