### PR TITLE
feat(serve): add isForceResetOnSeek option (without UI)

### DIFF
--- a/packages/akashic-cli-serve/src/client/common/queryParameters.ts
+++ b/packages/akashic-cli-serve/src/client/common/queryParameters.ts
@@ -104,6 +104,11 @@ export interface ServeQueryParameters {
 	activeDevtool: string | null;
 
 	/**
+	 * シークバーでのシーク時に強制的に最も近いスナップショット(スタートポイント)から開始するか。
+	 */
+	isForceResetOnSeek: boolean | null;
+
+	/**
 	 * Events ツールでイベントリストを表示するか。
 	 */
 	showsEventList: boolean | null;
@@ -251,6 +256,7 @@ export function makeServeQueryParameters(query: RawParsedQuery): ServeQueryParam
 		showsDevtools: asBool(query.showsDevtools),
 		devtoolsHeight: asNumber(query.devtoolsHeight),
 		activeDevtool: asString(query.activeDevtool),
+		isForceResetOnSeek: asBool(query.isForceResetOnSeek),
 		showsEventList: asBool(query.showsEventList),
 		eventListWidth: asNumber(query.eventListWidth),
 		eventEditContent: asString(query.eventEditContent),

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -80,10 +80,10 @@ export class Operator {
 
 		if (query.mode === "replay") {
 			if (query.replayResetAge != null) {
-				await this.localInstance.resetByNearestStartPointOf({ frame: query.replayResetAge }, false);
+				await this.localInstance.resetByAge(query.replayResetAge);
 			}
 			if (query.replayTargetTime != null) {
-				this.localInstance.seekTo(query.replayTargetTime);
+				this.store.currentLocalInstance.setTargetTime(query.replayTargetTime);
 			}
 		}
 

--- a/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/DevtoolUiStore.ts
@@ -5,8 +5,10 @@ import { storage } from "./storage";
 export class DevtoolUiStore {
 	static DEFAULT_TOTAL_TIME_LIMIT = 85;
 
+	// storage に保存するもの
 	@observable height: number;
 	@observable activeDevtool: string;
+	@observable isForceResetOnSeek: boolean;
 	@observable showsEventList: boolean;
 	@observable eventListWidth: number;
 	@observable eventEditContent: string;
@@ -33,6 +35,7 @@ export class DevtoolUiStore {
 	constructor() {
 		this.height = storage.data.devtoolsHeight;
 		this.activeDevtool = storage.data.activeDevtool;
+		this.isForceResetOnSeek = storage.data.isForceResetOnSeek;
 		this.showsEventList = storage.data.showsEventList;
 		this.eventListWidth = storage.data.eventListWidth;
 		this.eventEditContent = storage.data.eventEditContent;
@@ -60,6 +63,12 @@ export class DevtoolUiStore {
 	setActiveDevtool(type: string): void {
 		this.activeDevtool = type;
 		storage.put({ activeDevtool: type });
+	}
+
+	@action
+	toggleForceResetOnSeek(reset: boolean): void {
+		this.isForceResetOnSeek = reset;
+		storage.put({ isForceResetOnSeek: reset });
 	}
 
 	@action

--- a/packages/akashic-cli-serve/src/client/store/storage.ts
+++ b/packages/akashic-cli-serve/src/client/store/storage.ts
@@ -8,6 +8,7 @@ export interface StorageData {
 	showsDevtools: boolean;
 	devtoolsHeight: number;
 	activeDevtool: string;
+	isForceResetOnSeek: boolean;
 	showsEventList: boolean;
 	eventListWidth: number;
 	eventEditContent: string;
@@ -58,6 +59,7 @@ export class Storage {
 			showsDevtools: choose(query.showsDevtools, s.showsDevtools, false),
 			devtoolsHeight: choose(query.devtoolsHeight, s.devtoolsHeight, 200),
 			activeDevtool: choose(query.activeDevtool, s.activeDevtool, "Instances"),
+			isForceResetOnSeek: choose(query.isForceResetOnSeek, s.isForceResetOnSeek, false),
 			showsEventList: choose(query.showsEventList, s.showsEventList, true),
 			eventListWidth: choose(query.eventListWidth, s.eventListWidth, 150),
 			eventEditContent: choose(query.eventEditContent, s.eventEditContent, ""),


### PR DESCRIPTION
文書未公開の機能・スナップショットのデバッグに備えて、シークバー操作時に必ずリセット (移動先に最も近いスナップショットでゲーム状態を初期化) するオプション `isForceResetOnSeek` を追加します。

### 確認方法

1. スナップショットを保存するコンテンツを serve で起動する
2. クエリパラメータ `?isForceResetOnSeek=1` をつけてウィンドウを開く
   - 現状このオプションを操作する UI はありません (別途実装します)
3. スナップショットを保存するフレームをまたぐ形でシークバーを未来に進める
4. リセットされればこのオプションが有効になっています。
   - #889 によって、リセット時刻はプログレスバー上のゲージの色が変わることで示されます
