### PR TITLE
fix(serve): akashic-cli-serve で「今までのプレイ情報を保存」を押した時ゲーム進行が止まる不具合の修正

### DIFF
--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -5,13 +5,12 @@
   "requires": true,
   "dependencies": {
     "@akashic/akashic-cli-commons": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.7.0.tgz",
-      "integrity": "sha512-T+4oq4hlpU5jg/wGTsiJ1JifnaApsFqEjusbDEX1cB7zo5S8tOr6f+5qtYIWVOTJ8dUK19wLKWph/M21qDzfSA==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.10.0.tgz",
+      "integrity": "sha512-alnO6B/6S7IbEUn7s9e5PaOPGU/4zFk8+PHNF+Zxwl64loWfAmSmYqq0kclZf2DpiMBBVhMSdLfvv75aLQxYpg==",
       "requires": {
         "browserify": "17.0.0",
-        "eslint": "7.17.0",
-        "fs-extra": "9.0.1",
+        "fs-extra": "9.1.0",
         "fs-readdir-recursive": "1.1.0",
         "js-sha256": "^0.9.0"
       },
@@ -71,6 +70,111 @@
             "xtend": "^4.0.0"
           }
         },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
+    "@akashic/akashic-cli-scan": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-scan/-/akashic-cli-scan-0.8.0.tgz",
+      "integrity": "sha512-s08BAkC7prL50oiEEvMzZ7JOD5xGB7uoijSPNf+W06r1f3w+a1E6MkbMBvmyoacOrMmYI9jETCASt73vnOiu0Q==",
+      "requires": {
+        "@akashic/akashic-cli-commons": "0.7.0",
+        "aac-duration": "0.0.1",
+        "chokidar": "^3.4.3",
+        "commander": "^5.0.0",
+        "fs-readdir-recursive": "1.1.0",
+        "image-size": "~0.9.0",
+        "music-metadata": "7.6.2",
+        "thumbcoil": "~1.2.0"
+      },
+      "dependencies": {
+        "@akashic/akashic-cli-commons": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.7.0.tgz",
+          "integrity": "sha512-T+4oq4hlpU5jg/wGTsiJ1JifnaApsFqEjusbDEX1cB7zo5S8tOr6f+5qtYIWVOTJ8dUK19wLKWph/M21qDzfSA==",
+          "requires": {
+            "browserify": "17.0.0",
+            "eslint": "7.17.0",
+            "fs-extra": "9.0.1",
+            "fs-readdir-recursive": "1.1.0",
+            "js-sha256": "^0.9.0"
+          }
+        },
+        "browserify": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
+          "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+          "requires": {
+            "JSONStream": "^1.0.3",
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^2.0.0",
+            "browserify-zlib": "~0.2.0",
+            "buffer": "~5.2.1",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "^1.6.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.1",
+            "domain-browser": "^1.2.0",
+            "duplexer2": "~0.1.2",
+            "events": "^3.0.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "^1.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.2.1",
+            "labeled-stream-splicer": "^2.0.0",
+            "mkdirp-classic": "^0.5.2",
+            "module-deps": "^6.2.3",
+            "os-browserify": "~0.3.0",
+            "parents": "^1.0.1",
+            "path-browserify": "^1.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum-object": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^3.0.0",
+            "stream-http": "^3.0.0",
+            "string_decoder": "^1.1.1",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "0.0.1",
+            "url": "~0.11.0",
+            "util": "~0.12.0",
+            "vm-browserify": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
         "eslint": {
           "version": "7.17.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
@@ -114,28 +218,6 @@
             "text-table": "^0.2.0",
             "v8-compile-cache": "^2.0.3"
           }
-        }
-      }
-    },
-    "@akashic/akashic-cli-scan": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-scan/-/akashic-cli-scan-0.8.0.tgz",
-      "integrity": "sha512-s08BAkC7prL50oiEEvMzZ7JOD5xGB7uoijSPNf+W06r1f3w+a1E6MkbMBvmyoacOrMmYI9jETCASt73vnOiu0Q==",
-      "requires": {
-        "@akashic/akashic-cli-commons": "0.7.0",
-        "aac-duration": "0.0.1",
-        "chokidar": "^3.4.3",
-        "commander": "^5.0.0",
-        "fs-readdir-recursive": "1.1.0",
-        "image-size": "~0.9.0",
-        "music-metadata": "7.6.2",
-        "thumbcoil": "~1.2.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
         }
       }
     },

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -85,22 +85,16 @@ export class PlayOperator {
 	};
 
 	downloadPlaylog = (): void => {
-		location.href = `/api/plays/${this.store.currentPlay.playId}/playlog`;
+		this.downloadFile(`/api/plays/${this.store.currentPlay.playId}/playlog`);
 	};
 
 	downloadSnapshot = (frame: number): void => {
 		this.store.currentPlay?.amflow.getStartPoint({ frame }, (err: Error | null, startPoint: StartPoint) => {
 			if (err) throw err;
 
-			const a = document.createElement("a");
-			document.body.appendChild(a);
 			const blob = new Blob([ JSON.stringify(startPoint) ], { "type" : "application/octet-stream" });
 			const url = window.URL.createObjectURL(blob);
-			a.href = url;
-			a.download = `snapshot_${frame}.json`;
-			a.click();
-			window.URL.revokeObjectURL(url);
-			document.body.removeChild(a);
+			this.downloadFile(url, `snapshot_${frame}.json`);
 		});
 	};
 
@@ -114,5 +108,17 @@ export class PlayOperator {
 
 	unmuteAll = (): void => {
 		this.store.currentPlay.unmuteAll();
+	};
+
+	// 指定したURLからファイルをダウンロードする
+	// download属性が無いとコンテンツが止まって可能性があるので、空文字をファイル名のデフォルト値にしている
+	private downloadFile = (url: string, fileName: string = "") => {
+		const a = document.createElement("a");
+		document.body.appendChild(a);
+		a.href = url;
+		a.download = fileName;
+		a.click();
+		window.URL.revokeObjectURL(url);
+		document.body.removeChild(a);
 	};
 }

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -85,7 +85,8 @@ export class PlayOperator {
 	};
 
 	downloadPlaylog = (): void => {
-		this.downloadFile(`/api/plays/${this.store.currentPlay.playId}/playlog`);
+		const playId = this.store.currentPlay.playId;
+		this.downloadFile(`/api/plays/${playId}/playlog`, `playlog_${playId}.json`);
 	};
 
 	downloadSnapshot = (frame: number): void => {
@@ -95,6 +96,7 @@ export class PlayOperator {
 			const blob = new Blob([ JSON.stringify(startPoint) ], { "type" : "application/octet-stream" });
 			const url = window.URL.createObjectURL(blob);
 			this.downloadFile(url, `snapshot_${frame}.json`);
+			window.URL.revokeObjectURL(url);
 		});
 	};
 
@@ -111,14 +113,12 @@ export class PlayOperator {
 	};
 
 	// 指定したURLからファイルをダウンロードする
-	// download属性が無いとコンテンツが止まって可能性があるので、空文字をファイル名のデフォルト値にしている
-	private downloadFile = (url: string, fileName: string = ""): void => {
+	private downloadFile = (url: string, fileName: string): void => {
 		const a = document.createElement("a");
 		document.body.appendChild(a);
 		a.href = url;
 		a.download = fileName;
 		a.click();
-		window.URL.revokeObjectURL(url);
 		document.body.removeChild(a);
 	};
 }

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -112,7 +112,7 @@ export class PlayOperator {
 
 	// 指定したURLからファイルをダウンロードする
 	// download属性が無いとコンテンツが止まって可能性があるので、空文字をファイル名のデフォルト値にしている
-	private downloadFile = (url: string, fileName: string = "") => {
+	private downloadFile = (url: string, fileName: string = ""): void => {
 		const a = document.createElement("a");
 		document.body.appendChild(a);
 		a.href = url;


### PR DESCRIPTION
### 概要
* 「今までのプレイ情報を保存」を押した時、`location.href`をプレイログ取得APIに向けることでプレイログファイルをダウンロードしていたがその時download属性無いことでserve上のコンテンツやjavascriptが停止してしまっていたので、プレイログファイル時もdownload属性を付けるように修正しました

### やったこと
* スクリーンショットをダウンロードする処理をファイルをダウンロードする処理として関数化して、プレイログファイルのダウンロードでも利用するようにした