### PR TITLE
feat(init): introduce formatVersion to template.json and template-list.json

### DIFF
--- a/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
+++ b/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
@@ -47,13 +47,12 @@ describe("TemplateMetadata.ts", () => {
 		});
 
 		it("rejects unsupported formatVersion", done => {
-			fetchRemoteTemplatesMetadata(
-				new URL("template-list.unsupported.json", repositoryUrl)
-			).then(
+			const templateListJsonUri = new URL("template-list.unsupported.json", repositoryUrl);
+			fetchRemoteTemplatesMetadata(templateListJsonUri).then(
 				() => done.fail("unexpectedly succeed for unsuppoted formatVersion"),
 				(err) => {
 					expect(err?.message).toBe(
-						`Unsupported formatVersion: "42". ` +
+						`Unsupported formatVersion "42" found in ${templateListJsonUri.toString()}. ` +
 						`The only valid value for this version is "0". ` +
 						`Newer version of akashic-cli may support this formatVersion.`
 					);

--- a/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
+++ b/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
@@ -45,6 +45,22 @@ describe("TemplateMetadata.ts", () => {
 				done();
 			})
 		});
+
+		it("rejects unsupported formatVersion", done => {
+			fetchRemoteTemplatesMetadata(
+				new URL("template-list.unsupported.json", repositoryUrl)
+			).then(
+				() => done.fail("unexpectedly succeed for unsuppoted formatVersion"),
+				(err) => {
+					expect(err?.message).toBe(
+						`Unsupported formatVersion: "42". ` +
+						`The only valid value for this version is "0". ` +
+						`Newer version of akashic-cli may support this formatVersion.`
+					);
+					done();
+				}
+			)
+		});
 	});
 
 	describe("fetchTemplate()", () => {

--- a/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
+++ b/packages/akashic-cli-init/spec/TemplateMetadataSpec.js
@@ -51,7 +51,7 @@ describe("TemplateMetadata.ts", () => {
 			fetchRemoteTemplatesMetadata(templateListJsonUri).then(
 				() => done.fail("unexpectedly succeed for unsuppoted formatVersion"),
 				(err) => {
-					expect(err?.message).toBe(
+					expect(err.message).toBe(
 						`Unsupported formatVersion "42" found in ${templateListJsonUri.toString()}. ` +
 						`The only valid value for this version is "0". ` +
 						`Newer version of akashic-cli may support this formatVersion.`

--- a/packages/akashic-cli-init/spec/initSpec.js
+++ b/packages/akashic-cli-init/spec/initSpec.js
@@ -69,7 +69,7 @@ describe("init.ts", () => {
 				.then(
 					() => done.fail("unexpectedly succeed for unsuppoted formatVersion"),
 					(err) => {
-						expect(err?.message).toBe(
+						expect(err.message).toBe(
 							`Unsupported formatVersion: "101". ` +
 							`The only valid value for this version is "0". ` +
 							`Newer version of akashic-cli may support this formatVersion.`

--- a/packages/akashic-cli-init/spec/initSpec.js
+++ b/packages/akashic-cli-init/spec/initSpec.js
@@ -19,6 +19,7 @@ describe("init.ts", () => {
 					},
 					manual: {
 						"template.json": JSON.stringify({
+							formatVersion: "0",
 							files: [
 								{src: "a", dst: "a"},
 								{src: "b", dst: "y/z/e"}
@@ -59,6 +60,23 @@ describe("init.ts", () => {
 					expect(fs.statSync(path.join("home", "c")).isDirectory()).toBe(true);
 					expect(fs.statSync(path.join("home", "c", "d")).isFile()).toBe(true);
 				})
+				.then(done, done.fail);
+		});
+
+		it("reject unsupported formatVersion", done => {
+			var src = ".akashic-templates/never-refered";
+			completeTemplateConfig({ formatVersion: "101" }, src)
+				.then(
+					() => done.fail("unexpectedly succeed for unsuppoted formatVersion"),
+					(err) => {
+						expect(err?.message).toBe(
+							`Unsupported formatVersion: "101". ` +
+							`The only valid value for this version is "0". ` +
+							`Newer version of akashic-cli may support this formatVersion.`
+						);
+						done();
+					}
+				)
 				.then(done, done.fail);
 		});
 

--- a/packages/akashic-cli-init/spec/support/fixture/remote/template-list.unsupported.json
+++ b/packages/akashic-cli-init/spec/support/fixture/remote/template-list.unsupported.json
@@ -1,0 +1,7 @@
+{
+	"formatVersion": "42",
+	"templates": {
+		"javascript": "javascript.zip",
+		"typescript": "typescript.zip"
+	}
+}

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -63,7 +63,7 @@ export async function fetchRemoteTemplatesMetadata(templateListJsonUri: string):
 
 	if (formatVersion != null && formatVersion !== "0") {
 		throw new Error(
-			`Unsupported formatVersion: "${formatVersion}". ` +
+			`Unsupported formatVersion "${formatVersion}" found in ${templateListJsonUri}. ` +
 			"The only valid value for this version is \"0\". " +
 			"Newer version of akashic-cli may support this formatVersion."
 		);

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -7,6 +7,15 @@ import * as unzipper from "unzipper";
 
 // TODO: 適切な場所に移動
 interface TemplateList {
+	/**
+	 * このテンプレートリストのフォーマット。現在 "0" のみがサポートされている。
+	 * 省略された場合、 `"0"` 。
+	 */
+	formatVersion?: "0";
+
+	/**
+	 * テンプレート名と URL (またはパス) のテーブル。
+	 */
 	templates: {[type: string]: string};
 }
 
@@ -50,8 +59,18 @@ export async function collectLocalTemplatesMetadata(templateDirectory: string): 
 export async function fetchRemoteTemplatesMetadata(templateListJsonUri: string): Promise<RemoteTemplateMetadata[]> {
 	const res = await fetch(templateListJsonUri);
 	const templateListJson = (await res.json()) as TemplateList;
-	return Object.keys(templateListJson.templates).map(name => {
-		const rawUrl = templateListJson.templates[name];
+	const { formatVersion, templates } = templateListJson;
+
+	if (formatVersion != null && formatVersion !== "0") {
+		throw new Error(
+			`Unsupported formatVersion: "${formatVersion}". ` +
+			"The only valid value for this version is \"0\". " +
+			"Newer version of akashic-cli may support this formatVersion."
+		);
+	}
+
+	return Object.keys(templates).map(name => {
+		const rawUrl = templates[name];
 		return {
 			sourceType: "remote",
 			name,

--- a/packages/akashic-cli-init/src/init/TemplateConfig.ts
+++ b/packages/akashic-cli-init/src/init/TemplateConfig.ts
@@ -7,6 +7,12 @@ export interface TemplateFileEntry {
 
 export interface TemplateConfig {
 	/**
+	 * このテンプレートのフォーマット。現在 "0" のみがサポートされている。
+	 * 省略された場合、 `"0"` 。
+	 */
+	formatVersion?: "0";
+
+	/**
 	 * コピーするファイルの指定。
 	 * 省略された場合、直下の全て (ただし template.json を除く) がコピーされる。
 	 * 省略された場合、直下に game.json がなければならない。
@@ -36,7 +42,15 @@ type DeepRequired<T> = {
 export type NormalizedTemplateConfig = DeepRequired<TemplateConfig>;
 
 export async function completeTemplateConfig(templateConfig: TemplateConfig, baseDir: string): Promise<NormalizedTemplateConfig> {
-	const { files, gameJson, guideMessage } = templateConfig;
+	const { formatVersion, files, gameJson, guideMessage } = templateConfig;
+
+	if (formatVersion != null && formatVersion !== "0") {
+		throw new Error(
+			`Unsupported formatVersion: "${formatVersion}". ` +
+			"The only valid value for this version is \"0\". " +
+			"Newer version of akashic-cli may support this formatVersion."
+		);
+	}
 
 	let normalizedFiles: Required<TemplateFileEntry>[];
 	if (files) {
@@ -54,6 +68,7 @@ export async function completeTemplateConfig(templateConfig: TemplateConfig, bas
 	}
 
 	return {
+		formatVersion,
 		files: normalizedFiles,
 		gameJson: gameJson ?? "game.json",
 		guideMessage: guideMessage ?? null

--- a/packages/akashic-cli-init/template-spec.md
+++ b/packages/akashic-cli-init/template-spec.md
@@ -15,6 +15,7 @@
 
 ```
 {
+  "formatVersion": "0",
   "files": [
     {"src": "mainScene.js", "dst": "script/mainScene.js"},
     {"src": "game.json": "dst": "game.json"}
@@ -22,6 +23,9 @@
   "gameJson": "game.json"
 }
 ```
+
+`formatVersion` キーには `"0"` を指定するか、またはキーごと省略してください。
+これは将来の拡張のために予約されたキーです。
 
 `files` キーにはコピーするファイルを列挙します。
 上の例ではテンプレートディレクトリの `mainScene.js` をカレントディレクトリの
@@ -44,12 +48,16 @@
 
 ```
 {
+  "formatVersion": "0",
   "templates": {
     "javascript": "javascript.zip",
     "typescript": "typescript.zip"
   }
 }
 ```
+
+`formatVersion` キーには `"0"` を指定するか、またはキーごと省略してください。
+これは将来の拡張のために予約されたキーです。
 
 `templates` キーにテンプレート名と対応するzipファイルの対応関係を記述します。
 zipファイルはテンプレートを構成するファイルを圧縮したものです。


### PR DESCRIPTION
掲題どおり。

template.json と template-list.json はかなり以前からある機能ですが、 (`-r` オプションに不具合があり、コマンドラインから template-list.json の URL が指定不能だったなどの経緯から) 利用者がほぼ間違いなくゼロであったと確信できる機能です。

これらは #905 以降デフォルトで利用されるようになります。その  publish に先駆けて、将来の拡張に備えたバージョン識別子 `formatVersion` を予約します。

この値は `"0"` であるかまたは省略されなければなりません。省略できるため template.json, template-list.json の後方互換性は維持されます。この PR はむしろ "前方非互換" を正しく扱うために行います。すなわち、ここで「 `"0"` でない値ならエラーにする」処理を入れておくことで、将来の非互換な変更の際に、既存実装が正しくエラーを起こすことができるようになります。
