### PR TITLE
fix(export): remove obsolete warning messages

### DIFF
--- a/packages/akashic-cli-export/spec/fixtures/sample_game_v3/game.json
+++ b/packages/akashic-cli-export/spec/fixtures/sample_game_v3/game.json
@@ -12,6 +12,9 @@
 	},
 	"renderers": ["canvas"],
 	"environment": {
-		"sandbox-runtime": "3"
+		"sandbox-runtime": "3",
+		"nicolive": {
+			"supportedModes": ["single"]
+		}
 	}
 }

--- a/packages/akashic-cli-export/spec/fixtures/sample_game_with_akashic_runtime/game.json
+++ b/packages/akashic-cli-export/spec/fixtures/sample_game_with_akashic_runtime/game.json
@@ -15,7 +15,7 @@
 		"akashic-runtime": {
 			"version": "~1.0.9-beta"
 		},
-		"niconico": {
+		"nicolive": {
 			"supportedModes": ["single", "ranking"]
 		}
 	}

--- a/packages/akashic-cli-export/spec/src/html/exportAtsumaruSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/exportAtsumaruSpec.ts
@@ -73,10 +73,8 @@ describe("exportAtsumaru", function () {
 					expect(dest).toBe(outputDirPath);
 					const gameJson = require(path.join(outputDirPath, "game.json"));
 					expect(gameJson.environment.external.send).toBe("0");
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~1\.1\.\d+$/);
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~1\.1\.\d+(-.*)?$/);
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe(undefined);
-					expect(gameJson.environment.niconico.supportedModes.length).toBe(1);
-					expect(gameJson.environment.niconico.supportedModes).toContain("single");
 				})
 				.then(done, done.fail);
 		});
@@ -92,17 +90,15 @@ describe("exportAtsumaru", function () {
 					expect(dest).toBe(outputDirPath);
 					const gameJson = require(path.join(outputDirPath, "game.json"));
 					expect(gameJson.environment.external.send).toBe("0");
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~2\.1\.\d+$/);
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~2\.1\.\d+(-.*)?$/);
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
-					expect(gameJson.environment.niconico.supportedModes.length).toBe(1);
-					expect(gameJson.environment.niconico.supportedModes).toContain("single");
 				})
 				.then(function() {
 					fsx.removeSync(outputDirPath);
 				})
 				.then(done, done.fail);
 		});
-		it("add information about environment to game.json (v3)", function (done: DoneFn) {
+		it("add information about environment to game.json (v3), keep environment.nicolive", function (done: DoneFn) {
 			const targetDirPath = path.join(__dirname, "..", "..", "fixtures", "sample_game_v3");
 			const outputDirPath = path.join(targetDirPath, "output");
 			Promise.resolve()
@@ -114,10 +110,10 @@ describe("exportAtsumaru", function () {
 					expect(dest).toBe(outputDirPath);
 					const gameJson = require(path.join(outputDirPath, "game.json"));
 					expect(gameJson.environment.external.send).toBe("0");
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+.*$/);
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+(-.*)?$/);
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
-					expect(gameJson.environment.niconico.supportedModes.length).toBe(1);
-					expect(gameJson.environment.niconico.supportedModes).toContain("single");
+					expect(gameJson.environment.nicolive.supportedModes.length).toBe(1);
+					expect(gameJson.environment.nicolive.supportedModes).toContain("single");
 				})
 				.then(function() {
 					fsx.removeSync(outputDirPath);
@@ -138,9 +134,9 @@ describe("exportAtsumaru", function () {
 					expect(gameJson.environment.external.send).toBe("0");
 					expect(gameJson.environment["akashic-runtime"].version).toBe("~1.0.9-beta");
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe(undefined);
-					expect(gameJson.environment.niconico.supportedModes.length).toBe(2);
-					expect(gameJson.environment.niconico.supportedModes).toContain("single");
-					expect(gameJson.environment.niconico.supportedModes).toContain("ranking");
+					expect(gameJson.environment.nicolive.supportedModes.length).toBe(2);
+					expect(gameJson.environment.nicolive.supportedModes).toContain("single");
+					expect(gameJson.environment.nicolive.supportedModes).toContain("ranking");
 				})
 				.then(function() {
 					fsx.removeSync(outputDirPath);

--- a/packages/akashic-cli-export/src/html/exportAtsumaru.ts
+++ b/packages/akashic-cli-export/src/html/exportAtsumaru.ts
@@ -39,16 +39,6 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 			if (!gameJson.environment) {
 				gameJson.environment = {};
 			}
-			if (!gameJson.environment.niconico || !gameJson.environment.niconico.supportedModes) {
-				// モード指定がなければ、常に指定可能なモードであるsingleモードを追加する。
-				completedParam.logger.warn(
-					"'environment.niconico.supportedModes', a required property for '--atsumaru' mode," +
-					"is not given in game.json. Assumed to be [\"single\"]."
-				);
-				gameJson.environment.niconico = {
-					"supportedModes": ["single"]
-				};
-			}
 			if (!gameJson.environment.external) {
 				gameJson.environment.external = {};
 			}
@@ -68,14 +58,6 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 					if (!gameJson.renderers || gameJson.renderers.indexOf("webgl") === -1) {
 						gameJson.environment["akashic-runtime"].flavor = "-canvas";
 					}
-				}
-				if (/\d+\.\d+\.\d+-\w+/.test(gameJson.environment["akashic-runtime"].version)) {
-					const runtimeVersion = gameJson.environment["akashic-runtime"].version.slice(1);
-					const engineVersion = gameJson.environment["sandbox-runtime"] || "1";
-					completedParam.logger.warn(
-						`UNSTABLE: Akashic Engine v${engineVersion} (akashic-runtime@${runtimeVersion})`
-						+ " is in beta. The game exported MAY NOT WORK PROPERLY."
-					);
 				}
 				return gameJson;
 			});


### PR DESCRIPTION
掲題どおり。以下を削除します。

- a) akashic-runtime-version-table から取得した envionment["akashic-runtime"] の値が、 `1.2.3` のような 3 桁の数字でない時に、 beta として警告する処理
- b) envionment.niconico がない時に、警告して `{ supportedModes: ["single"] }` を補う処理

(a) は v3 がベータ版だった頃に、間違って `3.0.0-beta.12` などが使われるケースを想定したものでした。しかし先ごろのエンジン内部のバージョン表記法の変更の影響で、誤ってベータ版でないものにまでこのメッセージが出るようになりました。削除します。(将来のベータ版をどう扱うかは未検討ですが、別の形式を使うことにします)

(b) は、 [ニコ生ゲーム関連の仕様 の モード の節](https://akashic-games.github.io/guide/shin-ichiba/shin-ichiba-spec#supported-modes) に記載のとおり `environment.niconico` から `environment.nicolive` に変更になったものです。実装が追従できていませんでした。 `environment.atsumaru` がサポートされた今、機械的に `atsumaru`, `nicolive` のどちらかまたは両方を補うことはできなくなっています。警告・補完処理ともに削除します。
