### PR TITLE
Add confirm of access to unofficial URL in akashic-init

### DIFF
--- a/packages/akashic-cli-init/spec/cloneTemplateSpec.js
+++ b/packages/akashic-cli-init/spec/cloneTemplateSpec.js
@@ -1,6 +1,7 @@
 var ConsoleLogger = require("@akashic/akashic-cli-commons/lib/ConsoleLogger").ConsoleLogger;
 var ct = require("../lib/init/cloneTemplate");
 var init = require("../lib/init/init");
+var Prompt =  require("prompt");
 
 jest.mock("child_process");
 const mockExec = require("child_process").exec;
@@ -8,9 +9,16 @@ mockExec.mockImplementation((_command, _opts, callback) => {
 	callback();
 });
 
+let mockPromptGet = jest.spyOn(Prompt, "get").mockImplementation((_schema, func) => {
+	func(undefined, { confirm: "y" });
+});
+
 describe("cloneTemplate.js", () => {
 	beforeEach(() => {
 		mockExec.mockClear();
+	});
+	afterAll(() => {
+		mockPromptGet.mockRestore();
 	});
 
 	it("can execute a command to clone repository from github.com via promiseInit()", async () => {

--- a/packages/akashic-cli-init/spec/cloneTemplateSpec.js
+++ b/packages/akashic-cli-init/spec/cloneTemplateSpec.js
@@ -9,13 +9,15 @@ mockExec.mockImplementation((_command, _opts, callback) => {
 	callback();
 });
 
-let mockPromptGet = jest.spyOn(Prompt, "get").mockImplementation((_schema, func) => {
-	func(undefined, { confirm: "y" });
-});
-
 describe("cloneTemplate.js", () => {
+	let mockPromptGet = null;
 	beforeEach(() => {
 		mockExec.mockClear();
+	});
+	beforeAll(async () => {
+		mockPromptGet = jest.spyOn(Prompt, "get").mockImplementation((_schema, func) => {
+			func(undefined, { confirm: "y" });
+		});
 	});
 	afterAll(() => {
 		mockPromptGet.mockRestore();

--- a/packages/akashic-cli-init/spec/listTemplatesSpec.js
+++ b/packages/akashic-cli-init/spec/listTemplatesSpec.js
@@ -3,16 +3,22 @@ var path = require("path");
 var express = require("express");
 var getPort = require("get-port");
 var listTemplates = require("../lib/list/listTemplates").listTemplates;
+var Prompt = require("prompt");
 
 describe("list.ts", () => {
 	let templateServer = null;
 	let repositoryUrl = "";
+	let mockPromptGet = null;
 	beforeAll(async () => {
 		const port = await getPort();
 		const app = express();
 		app.use(express.static(path.resolve(__dirname, "support", "fixture")));
 		templateServer = app.listen(port);
 		repositoryUrl = `http://127.0.0.1:${port}/remote/`;
+
+		mockPromptGet = jest.spyOn(Prompt, "get").mockImplementation((_schema, func) => {
+			func(undefined, { confirm: "y" });
+		});
 	});
 	afterAll(() => {
 		if (templateServer) {
@@ -20,6 +26,7 @@ describe("list.ts", () => {
 			templateServer = null;
 			repositoryUrl = "";
 		}
+		mockPromptGet.mockRestore();
 	});
 
 	describe("listTemplates()", () => {

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -15,9 +15,7 @@ async function cli(param: CliConfigInit): Promise<void> {
 		if (/(^(github|ghe):)|(\.git$)/.test(param.repository)) {
 			logger.warn("Misused -r, --repository options. Use -t option for Github repository");
 		}
-		// if (param.repository !== defaultTemplateRepository) {
-		if (param.repository === DEFAULT_TEMPLATE_REPOSITORY) {
-			// 非公式な URL の場合、アクセス許可をユーザ確認させる
+		if (param.repository !== DEFAULT_TEMPLATE_REPOSITORY) {
 			const ret = await confirmAccessToUrl(param.repository);
 			if (!ret) process.exit(1);
 		}
@@ -27,9 +25,7 @@ async function cli(param: CliConfigInit): Promise<void> {
 		const m = param.type.match(/(.+):(.+)\/(.+)/) ?? [];
 		if (m[1] === "github") {
 			const owner = m[2];
-			// if (owner !== "akashic-games") {
-			if (owner === "akashic-games") {
-				// 非公式な URL の場合、アクセス許可をユーザ確認させる
+			if (owner !== "akashic-games") {
 				const ret = await confirmAccessToUrl(param.type);
 				if (!ret) process.exit(1);
 			}

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -4,38 +4,11 @@ import { CliConfigInit } from "@akashic/akashic-cli-commons/lib/CliConfig/CliCon
 import { CliConfigurationFile } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigurationFile";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
 import { Command } from "commander";
-import * as Prompt from "prompt";
-import { DEFAULT_TEMPLATE_REPOSITORY } from "./common/InitCommonOptions";
 import { promiseInit } from "./init/init";
 import { listTemplates } from "./list/listTemplates";
 
 async function cli(param: CliConfigInit): Promise<void> {
 	const logger = new ConsoleLogger({ quiet: param.quiet });
-	if (param.repository) {
-		if (/(^(github|ghe):)|(\.git$)/.test(param.repository)) {
-			logger.warn("Misused -r, --repository options. Use -t option for Github repository");
-		}
-		if (param.repository !== DEFAULT_TEMPLATE_REPOSITORY) {
-			const ret = await confirmAccessToUrl(param.repository);
-			if (!ret) process.exit(1);
-		}
-	}
-
-	if (param.type) {
-		const m = param.type.match(/(.+):(.+)\/(.+)/) ?? [];
-		if (m[1] === "github") {
-			const owner = m[2];
-			if (owner !== "akashic-games") {
-				const ret = await confirmAccessToUrl(param.type);
-				if (!ret) process.exit(1);
-			}
-		}
-
-		if (m[1] === "ghe") {
-			// TODO: 許可した URL を.akashicrc に保存する時に実装する
-		}
-	}
-
 	try {
 		if (param.list) {
 			await listTemplates({
@@ -96,31 +69,6 @@ export function run(argv: string[]): void {
 			list: options.list ?? conf.list,
 			yes: options.yes ?? conf.yes,
 			force: options.force ?? conf.force
-		});
-	});
-}
-
-function confirmAccessToUrl(url: string): Promise<boolean> {
-	return new Promise<boolean>((resolve: (result: boolean) => void, reject: (err: any) => void) => {
-		const schema = {
-			properties: {
-				confirm: {
-					pattern: /^(yes|no|y|n)$/gi,
-					description: `Allow access to this URL(${url})? y/n`,
-					required: true,
-					default: "y"
-				}
-			}
-		};
-		Prompt.start();
-		Prompt.get(schema, (err: any, result: any) => {
-			const value = result.confirm.toLowerCase();
-			const ret = value === "y" || value === "yes";
-			if (err) {
-				reject(err);
-			} else {
-				resolve(ret);
-			}
 		});
 	});
 }

--- a/packages/akashic-cli-init/src/common/InitCommonOptions.ts
+++ b/packages/akashic-cli-init/src/common/InitCommonOptions.ts
@@ -102,7 +102,7 @@ export function confirmAccessToUrl(url: string): Promise<boolean> {
 						+ "The template obtained here may cause arbitrary command execution"
 						+ "(not by this command but by using the template).\n"
 						+ "You should not use this URL unless you trust its owners and contents.\n"
-						+ "Do you trust the owners and contents of this URL? (y/n)",
+						+ "Do you trust the owners and contents of this URL? (y/N)",
 					required: true,
 					default: "n"
 				}

--- a/packages/akashic-cli-init/src/common/InitCommonOptions.ts
+++ b/packages/akashic-cli-init/src/common/InitCommonOptions.ts
@@ -48,7 +48,7 @@ const initConfigValidator: config.StringMap = {
 	"init.ghe.protocol": ""
 };
 
-const defaultTemplateRepository = "https://akashic-contents.github.io/templates/";
+export const DEFAULT_TEMPLATE_REPOSITORY = "https://akashic-contents.github.io/templates/";
 
 /**
  * 未代入のパラメータを補完する。
@@ -60,7 +60,7 @@ export async function completeInitCommonOptions(opts: InitCommonOptions): Promis
 	const templateListJsonPath = opts.templateListJsonPath || "template-list.json";
 
 	await configFile.load();
-	const repository = opts.repository ?? (await configFile.getItem("init.repository")) ?? defaultTemplateRepository;
+	const repository = opts.repository ?? (await configFile.getItem("init.repository")) ?? DEFAULT_TEMPLATE_REPOSITORY;
 	const localTemplateDirectory =
 		opts.localTemplateDirectory ??
 		await configFile.getItem("init.localTemplateDirectory") ??

--- a/packages/akashic-cli-init/src/init/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/init/InitParameterObject.ts
@@ -1,5 +1,5 @@
 import { InitCommonOptions, completeInitCommonOptions, confirmAccessToUrl } from "../common/InitCommonOptions";
-import { createGitUri, parseUriPartsFromType } from "./cloneTemplate";
+import { createGitUri, parseCloneTargetInfo } from "./cloneTemplate";
 
 export type GitProtocol = "https" | "ssh";
 
@@ -84,7 +84,7 @@ export async function completeInitParameterObject(param: InitParameterObject): P
 	if (!isGitProtocol(gheProtocol))
 		throw new Error(`invalid option gheProtocol: ${gheProtocol}`);
 
-	const { gitType, owner, repo } = parseUriPartsFromType(type);
+	const { gitType, owner, repo } = parseCloneTargetInfo(type);
 	if (gitType === "github" && owner !== "akashic-games" ) {
 		const url = createGitUri(githubHost, githubProtocol, owner,  repo);
 		const ret = await confirmAccessToUrl(url);

--- a/packages/akashic-cli-init/src/init/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/init/InitParameterObject.ts
@@ -1,4 +1,5 @@
-import { InitCommonOptions, completeInitCommonOptions } from "../common/InitCommonOptions";
+import { InitCommonOptions, completeInitCommonOptions, confirmAccessToUrl } from "../common/InitCommonOptions";
+import { createGitUri, parseUriPartsFromType } from "./cloneTemplate";
 
 export type GitProtocol = "https" | "ssh";
 
@@ -82,6 +83,22 @@ export async function completeInitParameterObject(param: InitParameterObject): P
 		throw new Error(`invalid option githubProtocol: ${githubProtocol}`);
 	if (!isGitProtocol(gheProtocol))
 		throw new Error(`invalid option gheProtocol: ${gheProtocol}`);
+
+	const { gitType, owner, repo } = parseUriPartsFromType(type);
+	if (gitType === "github" && owner === "akashic-games" ) {
+		const url = createGitUri(githubHost, githubProtocol, owner,  repo);
+		const ret = await confirmAccessToUrl(url);
+		if (!ret) process.exit(1);
+
+	} else if (gitType === "ghe") {
+		if (!gheHost) {
+			throw new Error(
+				`Type '${param.type}' requires GHE host configuraton. ` +
+				"Run akashic config set init.ghe.host <url>"
+			);
+		}
+		// TODO: 許可した URL を.akashicrc に保存する時に実装
+	}
 
 	return {
 		logger,

--- a/packages/akashic-cli-init/src/init/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/init/InitParameterObject.ts
@@ -86,7 +86,7 @@ export async function completeInitParameterObject(param: InitParameterObject): P
 
 	const { gitType, owner, repo } = parseCloneTargetInfo(type);
 	if (gitType === "github" && owner !== "akashic-games" ) {
-		const url = createGitUri(githubHost, githubProtocol, owner,  repo);
+		const url = createGitUri(githubHost, githubProtocol, owner, repo);
 		const ret = await confirmAccessToUrl(url);
 		if (!ret) process.exit(1);
 

--- a/packages/akashic-cli-init/src/init/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/init/InitParameterObject.ts
@@ -85,7 +85,7 @@ export async function completeInitParameterObject(param: InitParameterObject): P
 		throw new Error(`invalid option gheProtocol: ${gheProtocol}`);
 
 	const { gitType, owner, repo } = parseUriPartsFromType(type);
-	if (gitType === "github" && owner === "akashic-games" ) {
+	if (gitType === "github" && owner !== "akashic-games" ) {
 		const url = createGitUri(githubHost, githubProtocol, owner,  repo);
 		const ret = await confirmAccessToUrl(url);
 		if (!ret) process.exit(1);

--- a/packages/akashic-cli-init/src/init/cloneTemplate.ts
+++ b/packages/akashic-cli-init/src/init/cloneTemplate.ts
@@ -13,7 +13,7 @@ interface GitCloneParameterObject {
 	shallow?: boolean;
 }
 
-export interface GitUriPartsParameterObjecct {
+export interface CloneTargetInfo {
 	gitType: string;
 	owner: string;
 	repo: string;
@@ -107,7 +107,7 @@ async function rmPromise(path: string, opts: fs.RmOptions = {}): Promise<void> {
  * type オプションの値をパースします
  * @param type -t オプションの値
  */
-export function parseUriPartsFromType(type: string): GitUriPartsParameterObjecct {
+export function parseCloneTargetInfo(type: string): CloneTargetInfo {
 	const m = type.match(/(.+):(.+)\/(.+)/) ?? [];
 	const gitType = m[1] || null;
 	const owner = m[2] || null;

--- a/packages/akashic-cli-init/src/init/cloneTemplate.ts
+++ b/packages/akashic-cli-init/src/init/cloneTemplate.ts
@@ -54,19 +54,6 @@ function completeParameter(opts: GitCloneParameterObject): Required<GitClonePara
 	};
 }
 
-export function parseUriPartsFromType(type: string): GitUriPartsParameterObjecct {
-	const m = type.match(/(.+):(.+)\/(.+)/) ?? [];
-	const gitType = m[1] || null;
-	const owner = m[2] || null;
-	const repo = m[3] || null;
-	return {
-		gitType,
-		owner,
-		repo
-	};
-}
-
-
 export function createGitUri(host: string, protocol: GitProtocol, owner: string, repo: string): string {
 	if (protocol === "https") {
 		return `${protocol}://${host}/${owner}/${repo}.git`;
@@ -114,4 +101,20 @@ async function rmPromise(path: string, opts: fs.RmOptions = {}): Promise<void> {
 			}
 		});
 	});
+}
+
+/**
+ * type オプションの値をパースします
+ * @param type -t オプションの値
+ */
+export function parseUriPartsFromType(type: string): GitUriPartsParameterObjecct {
+	const m = type.match(/(.+):(.+)\/(.+)/) ?? [];
+	const gitType = m[1] || null;
+	const owner = m[2] || null;
+	const repo = m[3] || null;
+	return {
+		gitType,
+		owner,
+		repo
+	};
 }

--- a/packages/akashic-cli-init/src/init/cloneTemplate.ts
+++ b/packages/akashic-cli-init/src/init/cloneTemplate.ts
@@ -13,6 +13,12 @@ interface GitCloneParameterObject {
 	shallow?: boolean;
 }
 
+export interface GitUriPartsParameterObjecct {
+	gitType: string;
+	owner: string;
+	repo: string;
+}
+
 /**
  * GitHub または GitHub Enterprise から リポジトリを clone する。
  */
@@ -48,7 +54,20 @@ function completeParameter(opts: GitCloneParameterObject): Required<GitClonePara
 	};
 }
 
-function createGitUri(host: string, protocol: GitProtocol, owner: string, repo: string): string {
+export function parseUriPartsFromType(type: string): GitUriPartsParameterObjecct {
+	const m = type.match(/(.+):(.+)\/(.+)/) ?? [];
+	const gitType = m[1] || null;
+	const owner = m[2] || null;
+	const repo = m[3] || null;
+	return {
+		gitType,
+		owner,
+		repo
+	};
+}
+
+
+export function createGitUri(host: string, protocol: GitProtocol, owner: string, repo: string): string {
 	if (protocol === "https") {
 		return `${protocol}://${host}/${owner}/${repo}.git`;
 	} else if (protocol === "ssh") {

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -9,13 +9,13 @@ import {
 	fetchTemplate
 } from "../common/TemplateMetadata";
 import { updateConfigurationFile } from "./BasicParameters";
-import { cloneTemplate, parseUriPartsFromType } from "./cloneTemplate";
+import { cloneTemplate, parseCloneTargetInfo } from "./cloneTemplate";
 import { InitParameterObject, completeInitParameterObject } from "./InitParameterObject";
 import { TemplateConfig, completeTemplateConfig, NormalizedTemplateConfig } from "./TemplateConfig";
 
 export async function promiseInit(p: InitParameterObject): Promise<void> {
 	const param = await completeInitParameterObject(p);
-	const { gitType, owner, repo } = parseUriPartsFromType(param.type);
+	const { gitType, owner, repo } = parseCloneTargetInfo(param.type);
 
 	if (gitType === "github") {
 		await cloneTemplate(

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -9,17 +9,15 @@ import {
 	fetchTemplate
 } from "../common/TemplateMetadata";
 import { updateConfigurationFile } from "./BasicParameters";
-import { cloneTemplate } from "./cloneTemplate";
+import { cloneTemplate, parseUriPartsFromType } from "./cloneTemplate";
 import { InitParameterObject, completeInitParameterObject } from "./InitParameterObject";
 import { TemplateConfig, completeTemplateConfig, NormalizedTemplateConfig } from "./TemplateConfig";
 
 export async function promiseInit(p: InitParameterObject): Promise<void> {
 	const param = await completeInitParameterObject(p);
-	const m = param.type.match(/(.+):(.+)\/(.+)/) ?? [];
+	const { gitType, owner, repo } = parseUriPartsFromType(param.type);
 
-	if (m[1] === "github") {
-		const owner = m[2];
-		const repo = m[3];
+	if (gitType === "github") {
 		await cloneTemplate(
 			param.githubHost,
 			param.githubProtocol,
@@ -31,15 +29,7 @@ export async function promiseInit(p: InitParameterObject): Promise<void> {
 			param
 		);
 
-	} else if (m[1] === "ghe") {
-		if (!param.gheHost) {
-			throw new Error(
-				`Type '${param.type}' requires GHE host configuraton. ` +
-				"Run akashic config set init.ghe.host <url>"
-			);
-		}
-		const owner = m[2];
-		const repo = m[3];
+	} else if (gitType === "ghe") {
 		await cloneTemplate(
 			param.gheHost,
 			param.gheProtocol,


### PR DESCRIPTION
## 概要

akashic-init で オプション `-t` の値が `github:xxx`, `ghe:xxx` や `-r` の値に非公式な URL が指定された場合、その URL へのアクセスを許可するかプロンプトにてユーザ確認するようにします。

#916 へマージします