### PR TITLE
check operationPlugin script is root path or module name

### DIFF
--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/game.json
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/game.json
@@ -31,12 +31,28 @@
 		{
 			"code": 2,
 			"script": "./node_modules/@hoge/testmodule/lib/ModuleA.js"
+		},
+		{
+			"code": 3,
+			"script": "@hoge/testmodule2/"
+		},
+		{
+			"code": 4,
+			"script": "@hoge/testmodule3/lib/"
 		}
 	],
+	"moduleMainScripts": {
+		"@hoge/testmodule": "node_modules/@hoge/testmodule/lib/index.js",
+		"@hoge/testmodule2": "node_modules/@hoge/testmodule2/lib/index.js",
+		"@hoge/testmodule3": "node_modules/@hoge/testmodule3/lib/index.js"
+
+	},
 	"globalScripts": [
 		"node_modules/@hoge/testmodule/lib/ModuleA.js",
 		"node_modules/@hoge/testmodule/lib/ModuleB.js",
 		"node_modules/@hoge/testmodule/lib/ModuleC.js",
-		"node_modules/@hoge/testmodule/lib/index.js"
+		"node_modules/@hoge/testmodule/lib/index.js",
+		"node_modules/@hoge/testmodule2/lib/index.js",
+		"node_modules/@hoge/testmodule3/lib/index.js"
 	]
 }

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/game.json
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/game.json
@@ -45,7 +45,6 @@
 		"@hoge/testmodule": "node_modules/@hoge/testmodule/lib/index.js",
 		"@hoge/testmodule2": "node_modules/@hoge/testmodule2/lib/index.js",
 		"@hoge/testmodule3": "node_modules/@hoge/testmodule3/lib/index.js"
-
 	},
 	"globalScripts": [
 		"node_modules/@hoge/testmodule/lib/ModuleA.js",

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/lib/ModuleA.js
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/lib/ModuleA.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.moduleA = void 0;
+exports.moduleA = function () {
+    return true;
+};

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/lib/index.js
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/lib/index.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ModuleA = require("./ModuleA");

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/package.json
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@hoge/testmodule2",
+  "version": "0.1.0",
+  "main": "./lib/index.js"
+}

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/lib/ModuleA.js
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/lib/ModuleA.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.moduleA = void 0;
+exports.moduleA = function () {
+    return true;
+};

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/lib/index.js
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/lib/index.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ModuleA = require("./ModuleA");

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/package.json
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/node_modules/@hoge/testmodule3/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@hoge/testmodule2",
+  "version": "0.1.0",
+  "main": "./lib/index.js"
+}

--- a/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/package.json
+++ b/packages/akashic-cli-export/spec/fixtures/simple_game_with_operation_plugins/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "",
   "devDependencies": {
-    "@akashic/akashic-sandbox": "^0.13.3"
+    "@akashic/akashic-sandbox": "^0.13.3",
+    "@hoge/testmodule2": "0.1.0"
   }
 }

--- a/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
@@ -470,6 +470,12 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "script/bar.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule/lib/ModuleA.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule/lib/ModuleB.js"))).toBe(true);
+					// モジュール名で game.json の operationPlugins に記述されていても参照できる
+					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule2/lib/index.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule2/lib/ModuleA.js"))).toBe(true);
+					// モジュール名/lib 記述されていても参照できる
+					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule3/lib/index.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "node_modules/@hoge/testmodule3/lib/ModuleA.js"))).toBe(true);
 					done();
 				}, done.fail);
 		});

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -131,7 +131,8 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					actualPluginRoot = pluginRoot;
 				} else {
 					actualPluginRoot = path.relative(param.source, require.resolve(pluginRoot, { paths: [param.source] }));
-					if (actualPluginRoot.startsWith("../")) throw new Error(`${pluginRoot} refers outside of the game (${actualPluginRoot})`);
+					if (actualPluginRoot.startsWith("../"))
+						throw new Error(`${pluginRoot} refers outside of the game (${actualPluginRoot})`);
 				}
 				const pluginRootAbsPath = cmn.Util.makeUnixPath(path.join(param.source, actualPluginRoot));
 				const pluginRootDir = path.dirname(pluginRootAbsPath);

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -126,8 +126,6 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			// operation plugin に登録されているスクリプトファイルは bundle されていても残しておく必要がある
 			const operationPluginRoots = (gamejson.operationPlugins ?? []).map(plugin => plugin.script);
 			for (let pluginRoot of operationPluginRoots) {
-				console.log("trying require.resolve...:");
-				console.log("pluginRoot", pluginRoot, ", from: ", param.source, ", FLAG: " + (pluginRoot.indexOf("./") === 0));
 				let pluginRootPath: string;
 				if (pluginRoot.indexOf("./") === 0) {
 					pluginRootPath = pluginRoot.replace(/^\.\//g, "");
@@ -138,7 +136,6 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					pluginRootPath = relativeRootPath;
 				}
 				const pluginRootAbsPath = cmn.Util.makeUnixPath(path.join(param.source, pluginRootPath));
-				console.log("pluginRootAbsPath", pluginRootAbsPath);
 				const pluginRootDir = path.dirname(pluginRootAbsPath);
 				// TODO: Promise#then() と async/await が混在する状態を改め、 async/await に統一する
 				const pluginScripts = await cmn.NodeModules.listScriptFiles(

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -130,9 +130,8 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 				if (pluginRoot.startsWith("./")) {
 					actualPluginRoot = pluginRoot;
 				} else {
-					const relativeRootPath = path.relative(param.source, require.resolve(pluginRoot, { paths: [param.source] }));
-					if (relativeRootPath.startsWith("../")) throw new Error("Operation plugin path should not start with ../ .");
-					actualPluginRoot = relativeRootPath;
+					actualPluginRoot = path.relative(param.source, require.resolve(pluginRoot, { paths: [param.source] }));
+					if (actualPluginRoot.startsWith("../")) throw new Error(`${pluginRoot} refers outside of the game (${actualPluginRoot})`);
 				}
 				const pluginRootAbsPath = cmn.Util.makeUnixPath(path.join(param.source, actualPluginRoot));
 				const pluginRootDir = path.dirname(pluginRootAbsPath);

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -126,6 +126,10 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			// operation plugin に登録されているスクリプトファイルは bundle されていても残しておく必要がある
 			const operationPluginRoots = (gamejson.operationPlugins ?? []).map(plugin => plugin.script.replace(/^\.\//g, ""));
 			for (let pluginRoot of operationPluginRoots) {
+				const pluginRootOrModuleName = pluginRoot.replace(/\/$/, "");
+				if (gamejson.moduleMainScripts?.[pluginRootOrModuleName]) {
+					pluginRoot = gamejson.moduleMainScripts?.[pluginRootOrModuleName];
+				}
 				const pluginRootAbsPath = cmn.Util.makeUnixPath(path.join(param.source, pluginRoot));
 				const pluginRootDir = path.dirname(pluginRootAbsPath);
 				// TODO: Promise#then() と async/await が混在する状態を改め、 async/await に統一する


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
`akashic export zip` コマンドの対象コンテンツが Operation Plugin を利用しており、その script にルートスクリプトではなくモジュール名が指定されていた時、正常に export できない不具合を修正します。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

