### PR TITLE
Fix eslint in devdependencies of commons

### DIFF
--- a/packages/akashic-cli-commons/package.json
+++ b/packages/akashic-cli-commons/package.json
@@ -29,7 +29,6 @@
     "@types/mock-fs": "4.13.1",
     "@types/node": "14.18.0",
     "@typescript-eslint/eslint-plugin": "4.33.0",
-    "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jest": "24.7.0",
@@ -41,6 +40,7 @@
   "typings": "lib/index.d.ts",
   "dependencies": {
     "browserify": "17.0.0",
+    "eslint": "7.32.0",
     "fs-extra": "10.0.0",
     "fs-readdir-recursive": "1.1.0",
     "js-sha256": "^0.9.0"

--- a/packages/akashic-cli-commons/src/LintUtil.ts
+++ b/packages/akashic-cli-commons/src/LintUtil.ts
@@ -1,4 +1,3 @@
-import * as eslint from "eslint";
 
 export interface LintErrorInfo {
 	column: number;
@@ -6,7 +5,8 @@ export interface LintErrorInfo {
 	message: string;
 }
 
-export function validateEs5Code(code: string): LintErrorInfo[] {
+export async function validateEs5Code(code: string): Promise<LintErrorInfo[]> {
+	const eslint = await import("eslint");
 	const errors = (new eslint.Linter()).verify(code, {
 		parserOptions: {
 			ecmaVersion: 5

--- a/packages/akashic-cli-export/spec/src/html/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/convertUtilSpec.ts
@@ -35,7 +35,7 @@ describe("convertUtil", function () {
 		});
 	});
 	describe("validateEs5Code", function () {
-		it("return empty array if code is written with ES5 syntax", function () {
+		it("return empty array if code is written with ES5 syntax", async function () {
 			const es5Code = `
 				"use strict";
 				var fn = function () {
@@ -45,9 +45,9 @@ describe("convertUtil", function () {
 				var a = array[0];
 				var b = array[1];
 			`;
-			expect(convert.validateEs5Code("es5.js", es5Code).length).toBe(0);
+			expect((await convert.validateEs5Code("es5.js", es5Code)).length).toBe(0);
 		});
-		it("return error messages if code is not written with ES5 syntax", function () {
+		it("return error messages if code is not written with ES5 syntax", async function () {
 			const es6Code = `
 				"use strict";
 				const fn = () => {
@@ -56,7 +56,7 @@ describe("convertUtil", function () {
 				const array = [1, 3];
 				const [a, b] = array;
 			`;
-			const result = convert.validateEs5Code("es6.js", es6Code);
+			const result = await convert.validateEs5Code("es6.js", es6Code);
 			expect(result.length).toBe(1);
 			expect(result[0]).toBe("es6.js(3:5): Parsing error: The keyword \'const\' is reserved");
 		});

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -57,14 +57,14 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		innerHTMLAssetNames = innerHTMLAssetNames.concat(extractAssetDefinitions(conf, "text"));
 	}
 
-	const tempAssetData = await Promise.all(innerHTMLAssetNames.map(async (assetName: string) => {
-		return await convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, options.lint, errorMessages);
+	const tempAssetData = await Promise.all(innerHTMLAssetNames.map((assetName: string) => {
+		return convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, options.lint, errorMessages);
 	}));
 	innerHTMLAssetArray = innerHTMLAssetArray.concat(tempAssetData);
 
 	if (conf._content.globalScripts) {
-		const tempScriptData = await Promise.all(conf._content.globalScripts.map(async (scriptName: string) => {
-			return await convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, options.lint, errorMessages);
+		const tempScriptData = await Promise.all(conf._content.globalScripts.map((scriptName: string) => {
+			return convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, options.lint, errorMessages);
 		}));
 		innerHTMLAssetArray = innerHTMLAssetArray.concat(tempScriptData);
 	}
@@ -98,8 +98,7 @@ async function convertAssetToInnerHTMLObj(
 	var isScript = assets[assetName].type === "script";
 	var assetString = fs.readFileSync(path.join(inputPath, assets[assetName].path), "utf8").replace(/\r\n|\r/g, "\n");
 	if (isScript && lint) {
-		const errInfo = await validateEs5Code(assets[assetName].path, assetString);
-		errors.push.apply(errors, errInfo);
+		errors.push.apply(errors, await validateEs5Code(assets[assetName].path, assetString));
 	}
 	return {
 		name: assetName,
@@ -119,8 +118,7 @@ async function convertScriptNameToInnerHTMLObj(
 		scriptString = encodeText(scriptString);
 	}
 	if (isScript && lint) {
-		const errInfo = await validateEs5Code(scriptName, scriptString);
-		errors.push.apply(errors, errInfo);
+		errors.push.apply(errors, await validateEs5Code(scriptName, scriptString));
 	}
 	return {
 		name: scriptName,

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -56,14 +56,17 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	if (!options.unbundleText) {
 		innerHTMLAssetNames = innerHTMLAssetNames.concat(extractAssetDefinitions(conf, "text"));
 	}
-	innerHTMLAssetArray = innerHTMLAssetArray.concat(innerHTMLAssetNames.map((assetName: string) => {
-		return convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, options.lint, errorMessages);
+
+	const tempAssetData = await Promise.all(innerHTMLAssetNames.map(async (assetName: string) => {
+		return await convertAssetToInnerHTMLObj(assetName, options.source, conf, options.minify, options.lint, errorMessages);
 	}));
+	innerHTMLAssetArray = innerHTMLAssetArray.concat(tempAssetData);
 
 	if (conf._content.globalScripts) {
-		innerHTMLAssetArray = innerHTMLAssetArray.concat(conf._content.globalScripts.map((scriptName: string) => {
-			return convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, options.lint, errorMessages);
+		const tempScriptData = await Promise.all(conf._content.globalScripts.map(async (scriptName: string) => {
+			return await convertScriptNameToInnerHTMLObj(scriptName, options.source, options.minify, options.lint, errorMessages);
 		}));
+		innerHTMLAssetArray = innerHTMLAssetArray.concat(tempScriptData);
 	}
 
 	if (errorMessages.length > 0) {
@@ -88,14 +91,15 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	writeCommonFiles(options.source, options.output, conf, options, templatePath);
 }
 
-function convertAssetToInnerHTMLObj(
+async function convertAssetToInnerHTMLObj(
 	assetName: string, inputPath: string, conf: cmn.Configuration,
-	minify?: boolean, lint?: boolean, errors?: string[]): InnerHTMLAssetData {
+	minify?: boolean, lint?: boolean, errors?: string[]): Promise<InnerHTMLAssetData> {
 	var assets = conf._content.assets;
 	var isScript = assets[assetName].type === "script";
 	var assetString = fs.readFileSync(path.join(inputPath, assets[assetName].path), "utf8").replace(/\r\n|\r/g, "\n");
 	if (isScript && lint) {
-		errors.push.apply(errors, validateEs5Code(assets[assetName].path, assetString));
+		const errInfo = await validateEs5Code(assets[assetName].path, assetString);
+		errors.push.apply(errors, errInfo);
 	}
 	return {
 		name: assetName,
@@ -104,9 +108,9 @@ function convertAssetToInnerHTMLObj(
 	};
 }
 
-function convertScriptNameToInnerHTMLObj(
+async function convertScriptNameToInnerHTMLObj(
 	scriptName: string, inputPath: string,
-	minify?: boolean, lint?: boolean, errors?: string[]): InnerHTMLAssetData {
+	minify?: boolean, lint?: boolean, errors?: string[]): Promise<InnerHTMLAssetData> {
 	var scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	var isScript = /\.js$/i.test(scriptName);
 
@@ -115,7 +119,8 @@ function convertScriptNameToInnerHTMLObj(
 		scriptString = encodeText(scriptString);
 	}
 	if (isScript && lint) {
-		errors.push.apply(errors, validateEs5Code(scriptName, scriptString));
+		const errInfo = await validateEs5Code(scriptName, scriptString);
+		errors.push.apply(errors, errInfo);
 	}
 	return {
 		name: scriptName,

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -50,7 +50,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	}));
 	assetPaths = assetPaths.concat(nonBinaryAssetPaths);
 	if (conf._content.globalScripts) {
-		const nonBinaryScriptPaths = await Promise.all(conf._content.globalScripts.map((scriptName: string) => {
+		const globalScriptPaths = await Promise.all(conf._content.globalScripts.map((scriptName: string) => {
 			return convertGlobalScriptAndOutput(
 				scriptName,
 				options.source,
@@ -59,7 +59,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 				options.lint,
 				errorMessages);
 		}));
-		assetPaths = assetPaths.concat(nonBinaryScriptPaths);
+		assetPaths = assetPaths.concat(globalScriptPaths);
 	}
 	if (errorMessages.length > 0) {
 		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -43,15 +43,15 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		}
 	}
 
-	var assetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
+	var nonBinaryAssetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
 	var errorMessages: string[] = [];
-	const tempAssetPaths = await Promise.all(assetNames.map(async (assetName: string) => {
-		return await convertAssetAndOutput(assetName, conf, options.source, options.output, options.minify, options.lint, errorMessages);
+	const nonBinaryAssetPaths = await Promise.all(nonBinaryAssetNames.map((assetName: string) => {
+		return convertAssetAndOutput(assetName, conf, options.source, options.output, options.minify, options.lint, errorMessages);
 	}));
-	assetPaths = assetPaths.concat(tempAssetPaths);
+	assetPaths = assetPaths.concat(nonBinaryAssetPaths);
 	if (conf._content.globalScripts) {
-		const tempScriptPaths = await Promise.all(conf._content.globalScripts.map(async (scriptName: string) => {
-			return await convertGlobalScriptAndOutput(
+		const nonBinaryScriptPaths = await Promise.all(conf._content.globalScripts.map((scriptName: string) => {
+			return convertGlobalScriptAndOutput(
 				scriptName,
 				options.source,
 				options.output,
@@ -59,7 +59,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 				options.lint,
 				errorMessages);
 		}));
-		assetPaths = assetPaths.concat(tempScriptPaths);
+		assetPaths = assetPaths.concat(nonBinaryScriptPaths);
 	}
 	if (errorMessages.length > 0) {
 		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -77,8 +77,7 @@ async function convertAssetAndOutput(
 	var assetString = fs.readFileSync(path.join(inputPath, assets[assetName].path), "utf8").replace(/\r\n|\r/g, "\n");
 	var assetPath = assets[assetName].path;
 	if (isScript && lint) {
-		const errInfo = await validateEs5Code(assetPath, assetString);
-		errors.push.apply(errors, errInfo); // ES5構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEs5Code(assetPath, assetString)); // ES5構文に反する箇所があるかのチェック
 	}
 
 	var code = (isScript ? wrapScript(assetString, assetName, minify) : wrapText(assetString, assetName));
@@ -96,8 +95,7 @@ async function convertGlobalScriptAndOutput(
 	var scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	var isScript = /\.js$/i.test(scriptName);
 	if (isScript && lint) {
-		const errInfo = await validateEs5Code(scriptName, scriptString);
-		errors.push.apply(errInfo); // ES5構文に反する箇所があるかのチェック
+		errors.push.apply(await validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
 	}
 
 	var code = isScript ? wrapScript(scriptString, scriptName, minify) : wrapText(scriptString, scriptName);

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -95,7 +95,7 @@ async function convertGlobalScriptAndOutput(
 	var scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	var isScript = /\.js$/i.test(scriptName);
 	if (isScript && lint) {
-		errors.push.apply(await validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
 	}
 
 	var code = isScript ? wrapScript(scriptString, scriptName, minify) : wrapText(scriptString, scriptName);

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -167,9 +167,9 @@ export function getInjectedContents(baseDir: string, injects: string[]): string[
 	return injectedContents;
 }
 
-export function validateEs5Code(fileName: string, code: string): string[] {
-	return cmn.LintUtil.validateEs5Code(code)
-		.map(info => `${fileName}(${info.line}:${info.column}): ${info.message}`);
+export async function validateEs5Code(fileName: string, code: string): Promise<string[]> {
+	const errInfo = await cmn.LintUtil.validateEs5Code(code);
+	return errInfo.map(info => `${fileName}(${info.line}:${info.column}): ${info.message}`);
 }
 
 export function readSandboxConfigJs(sourceDir: string): string {


### PR DESCRIPTION
## 概要

akashic-cli-commons  の `LintUtil` で使用している `eslint` が devDependencies にある問題を対応。

`eslint` を dependencies へ移動し、`LintUtil` の使用箇所では dynamic import へ変更。
