### PR TITLE
feat(serve): playlogClientファイルを外部から指定できるようにする対応

### DIFF
--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -52,7 +52,7 @@ akashic-cli-serve [<options>] [<path>]
 | 環境変数 | 説明 | 注釈 |
 |--------|-----|-----|
 | `ENGINE_FILES_V3_PATH` | engine-files v3 のビルド成果物のパス。 (e.g. `./engineFilesV3_x_y.js`) <br> この値が指定された場合、 対象の engine-files を akashic-engine v3 コンテンツ実行時に利用します。 | エンジン開発用のオプションです。通常、ゲーム開発時に利用する必要はありません。 |
-| `PLAYLOG_CLIENT_PATH` | playlog-client のビルド成果物のパス。 (e.g. `./playlogClientVx_y_z.js`) <br> この値が指定された場合、 `/public/external/playlogClientVx_y_z.js`というパスが生成され、`content.raw.json`からも参照されるようになります。 | エンジン開発用のオプションです。通常、ゲーム開発時に利用する必要はありません。 |
+| `PLAYLOG_CLIENT_PATH` | playlog-client のビルド成果物のパス。 (e.g. `./playlogClientVx_y_z.js`) <br> この値が指定された場合、 `/contents/:contentId/content.raw.json` からも参照され利用されます。 | エンジン開発用のオプションです。通常、ゲーム開発時に利用する必要はありません。 |
 
 ## 外部参照できる DOM 要素
 

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -52,6 +52,7 @@ akashic-cli-serve [<options>] [<path>]
 | 環境変数 | 説明 | 注釈 |
 |--------|-----|-----|
 | `ENGINE_FILES_V3_PATH` | engine-files v3 のビルド成果物のパス。 (e.g. `./engineFilesV3_x_y.js`) <br> この値が指定された場合、 対象の engine-files を akashic-engine v3 コンテンツ実行時に利用します。 | エンジン開発用のオプションです。通常、ゲーム開発時に利用する必要はありません。 |
+| `PLAYLOG_CLIENT_PATH` | playlog-client のビルド成果物のパス。 (e.g. `./playlogClientVx_y_z.js`) <br> この値が指定された場合、 `/public/external/playlogClientVx_y_z.js`というパスが生成され、`content.raw.json`からも参照されるようになります。 | エンジン開発用のオプションです。通常、ゲーム開発時に利用する必要はありません。 |
 
 ## 外部参照できる DOM 要素
 

--- a/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
+++ b/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
@@ -43,7 +43,7 @@ export const getEngineConfig = (param: GetEngineConfigParameterObject): EngineCo
 	];
 
 	if (param.isRaw && process.env.PLAYLOG_CLIENT_PATH) {
-		engineUrls.push(`${param.baseUrl}/public/external/${path.basename(process.env.PLAYLOG_CLIENT_PATH)}`);
+		engineUrls.push(`${param.baseUrl}/dynamic/${path.basename(process.env.PLAYLOG_CLIENT_PATH)}`);
 		engineUrls.push(`${param.baseUrl}/socket.io/socket.io.js`); // playlogclientがsocket.ioを利用する想定なので追加しておく
 	} else {
 		engineUrls.push(`${param.baseUrl}/public/external/playlogClientV3_2_1.js`);

--- a/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
+++ b/packages/akashic-cli-serve/src/server/domain/EngineConfig.ts
@@ -38,11 +38,19 @@ export const getEngineConfig = (param: GetEngineConfigParameterObject): EngineCo
 		versionsJson.v3.fileName = path.basename(process.env.ENGINE_FILES_V3_PATH);
 	}
 
+	const engineUrls = [
+		`${param.baseUrl}/public/external/${versionsJson[`v${version}`].fileName}`
+	];
+
+	if (param.isRaw && process.env.PLAYLOG_CLIENT_PATH) {
+		engineUrls.push(`${param.baseUrl}/public/external/${path.basename(process.env.PLAYLOG_CLIENT_PATH)}`);
+		engineUrls.push(`${param.baseUrl}/socket.io/socket.io.js`); // playlogclientがsocket.ioを利用する想定なので追加しておく
+	} else {
+		engineUrls.push(`${param.baseUrl}/public/external/playlogClientV3_2_1.js`);
+	}
+
 	return {
-		engine_urls: [
-			`${param.baseUrl}/public/external/${versionsJson[`v${version}`].fileName}`,
-			`${param.baseUrl}/public/external/playlogClientV3_2_1.js`
-		],
+		engine_urls: engineUrls,
 		untrusted,
 		external,
 		content_url: `${param.baseUrl}/contents/${param.contentId}/${gameContentDir}/game.json`,

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -290,10 +290,12 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 
 	if (process.env.PLAYLOG_CLIENT_PATH) {
 		app.get("/dynamic/playlogClientV*.js", (req, res, _next) => {
-			const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH));
-			const responseBody = `var HOST = "${req.header("host")}";
-${playlogClientSrc}
-`;
+			const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH)).toString();
+			const apiEndpointUrl = `${req.protocol}://${req.hostname}`;
+			const socketEndpointUrl = `${req.protocol.includes("https") ? "wss" : "ws"}://${req.hostname}`;
+			const responseBody =
+				playlogClientSrc.replace(/:API_ENDPOINT_URL_PLACEHOLDER:/, apiEndpointUrl)
+					.replace(/:SOCKET_ENDPOINT_URL_PLACEHOLDER:/, socketEndpointUrl);
 			res.contentType("text/javascript");
 			res.send(responseBody);
 		});

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -291,8 +291,8 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	if (process.env.PLAYLOG_CLIENT_PATH) {
 		const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH)).toString();
 		app.get("/dynamic/playlogClientV*.js", (req, res, _next) => {
-			const apiEndpointUrl = `${req.protocol}://${req.hostname}`;
-			const socketEndpointUrl = `${req.protocol.includes("https") ? "wss" : "ws"}://${req.hostname}`;
+			const apiEndpointUrl = `${req.protocol}://${req.header("host")}`;
+			const socketEndpointUrl = `${req.protocol.includes("https") ? "wss" : "ws"}://${req.header("host")}`;
 			const responseBody =
 				playlogClientSrc.replace(/:SERVE_API_ENDPOINT_URL_PLACEHOLDER:/, apiEndpointUrl)
 					.replace(/:SERVE_SOCKET_ENDPOINT_URL_PLACEHOLDER:/, socketEndpointUrl);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -289,7 +289,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	}
 
 	if (process.env.PLAYLOG_CLIENT_PATH) {
-		app.get("/public/external/playlogClientV*.js", (req, res, _next) => {
+		app.get("/dynamic/playlogClientV*.js", (req, res, _next) => {
 			const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH));
 			const responseBody = `var HOST = "${req.header("host")}";
 ${playlogClientSrc}

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -289,13 +289,13 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	}
 
 	if (process.env.PLAYLOG_CLIENT_PATH) {
+		const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH)).toString();
 		app.get("/dynamic/playlogClientV*.js", (req, res, _next) => {
-			const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH)).toString();
 			const apiEndpointUrl = `${req.protocol}://${req.hostname}`;
 			const socketEndpointUrl = `${req.protocol.includes("https") ? "wss" : "ws"}://${req.hostname}`;
 			const responseBody =
-				playlogClientSrc.replace(/:API_ENDPOINT_URL_PLACEHOLDER:/, apiEndpointUrl)
-					.replace(/:SOCKET_ENDPOINT_URL_PLACEHOLDER:/, socketEndpointUrl);
+				playlogClientSrc.replace(/:SERVE_API_ENDPOINT_URL_PLACEHOLDER:/, apiEndpointUrl)
+					.replace(/:SERVE_SOCKET_ENDPOINT_URL_PLACEHOLDER:/, socketEndpointUrl);
 			res.contentType("text/javascript");
 			res.send(responseBody);
 		});

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -288,6 +288,17 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 		});
 	}
 
+	if (process.env.PLAYLOG_CLIENT_PATH) {
+		app.get("/public/external/playlogClientV*.js", (req, res, _next) => {
+			const playlogClientSrc = fs.readFileSync(path.resolve(process.cwd(), process.env.PLAYLOG_CLIENT_PATH));
+			const responseBody = `var HOST = "${req.header("host")}";
+${playlogClientSrc}
+`;
+			res.contentType("text/javascript");
+			res.send(responseBody);
+		});
+	}
+
 	app.use("/public/", express.static(path.join(__dirname, "..", "..", "www", "public")));
 	app.use("/internal/", express.static(path.join(__dirname, "..", "..", "www", "internal")));
 	app.use("/api/", createApiRouter({ playStore, runnerStore, playerIdStore, amflowManager, io }));


### PR DESCRIPTION
### やったこと
* 環境変数`PLAYLOG_CLIENT_PATH`でplaylogClientファイルを外部から指定できるようにしました。
* 指定された場合、`/public/external/playlogClientVx_y_z.js`というパスをserve側で生成するようにしました。
  * content.raw.jsonのengine-urlsからそのパスを参照できるようにしました。