### PR TITLE
fix behavior of template.json in init

### DIFF
--- a/packages/akashic-cli-init/src/__tests__/initSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/initSpec.ts
@@ -19,14 +19,6 @@ describe("init.ts", () => {
 						}
 					},
 					manual: {
-						"template.json": JSON.stringify({
-							formatVersion: "0",
-							files: [
-								{src: "a", dst: "a"},
-								{src: "b", dst: "y/z/e"}
-							],
-							gameJson: "a"
-						}),
 						a: "aaa",
 						b: "bbb",
 						"y": {

--- a/packages/akashic-cli-init/src/__tests__/initSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/initSpec.ts
@@ -104,7 +104,7 @@ describe("init.ts", () => {
 
 			await expect(_extractFromTemplate(conf, src, dest, { logger }))
 				.rejects.toThrow(
-					`aborted to copy files, because followings already exist. [a, c${path.sep}a]`
+					"aborted to copy files, because followings already exist. [a, c/a]"
 				);
 		});
 

--- a/packages/akashic-cli-init/src/__tests__/initSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/initSpec.ts
@@ -100,7 +100,7 @@ describe("init.ts", () => {
 			const logger = new ConsoleLogger({ quiet: true });
 			const src = ".akashic-templates/simple";
 			const dest = ".akashic-templates/copyTo";
-			const conf = await completeTemplateConfig({ files: [{ src: "a" }, { src: "a", dst: "c" }] }, src);
+			const conf = await completeTemplateConfig({ files: [{ src: "a" }, { src: "a", dst: "c/a" }] }, src);
 
 			await expect(_extractFromTemplate(conf, src, dest, { logger }))
 				.rejects.toThrow(
@@ -125,7 +125,7 @@ describe("init.ts", () => {
 			const logger = new ConsoleLogger({ quiet: true });
 			const src = ".akashic-templates/simple";
 			const dest = ".akashic-templates/copyTo";
-			const conf = await completeTemplateConfig({ files: [{ src: "a" }, { src: "a", dst: "c" }] }, src);
+			const conf = await completeTemplateConfig({ files: [{ src: "a" }, { src: "a", dst: "c/a" }] }, src);
 			await _extractFromTemplate(conf, src, dest, { logger, forceCopy: true });
 
 			expect(fs.readFileSync(path.join(".akashic-templates", "copyTo", "a")).toString("utf8")).toBe("aaa");

--- a/packages/akashic-cli-init/src/__tests__/initSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/initSpec.ts
@@ -18,15 +18,6 @@ describe("init.ts", () => {
 							d: "ddd"
 						}
 					},
-					manual: {
-						a: "aaa",
-						b: "bbb",
-						"y": {
-							"z": {
-								"e": ""
-							}
-						}
-					},
 					copyTo: {
 						a: "xxxxxxxxxx",
 						c: {
@@ -63,17 +54,6 @@ describe("init.ts", () => {
 					"The only valid value for this version is \"0\". " +
 					"Newer version of akashic-cli may support this formatVersion."
 				);
-		});
-
-		it("copy manual template", async () => {
-			const logger = new ConsoleLogger({ quiet: true });
-			const src = ".akashic-templates/manual";
-			const dest = "home";
-			const conf = await completeTemplateConfig({}, src);
-			await _extractFromTemplate(conf, src, dest, { logger });
-
-			expect(fs.statSync(path.join("home", "a")).isFile()).toBe(true);
-			expect(fs.statSync(path.join("home", "y", "z", "e")).isFile()).toBe(true);
 		});
 
 		it("can not copy when file exists", async () => {

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -92,12 +92,16 @@ async function _extractFromTemplate(
 	opts: ExtractFromTemplateOptions
 ): Promise<void> {
 	const { forceCopy, logger } = opts;
-	const copyReqs = conf.files.map(entry => ({
-		srcRelative: entry.src,
-		destRelative: path.join(entry.dst, entry.src),
-		src: path.join(src, entry.src),
-		dest: path.join(dest, entry.dst, entry.src)
-	}));
+	const copyReqs = conf.files.map(entry => {
+		const destPath = entry.dst ? path.join(dest, entry.dst) : path.join(dest, entry.src);
+		const destRelativePath = entry.dst || entry.src;
+		return {
+			srcRelative: entry.src,
+			destRelative: destRelativePath,
+			src: path.join(src, entry.src),
+			dest: destPath
+		};
+	});
 	if (!forceCopy) {
 		const existings = copyReqs.filter(req => existsSync(req.dest)).map(req => req.destRelative);
 		if (existings.length > 0)

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -92,15 +92,12 @@ async function _extractFromTemplate(
 	opts: ExtractFromTemplateOptions
 ): Promise<void> {
 	const { forceCopy, logger } = opts;
-	const copyReqs = conf.files.map(entry => {
-		const destPath = entry.dst ? path.join(dest, entry.dst) : path.join(dest, entry.src);
-		return {
-			srcRelative: entry.src,
-			destRelative: entry.dst || entry.src,
-			src: path.join(src, entry.src),
-			dest: destPath
-		};
-	});
+	const copyReqs = conf.files.map(entry => ({
+		srcRelative: entry.src,
+		destRelative: entry.dst || entry.src,
+		src: path.join(src, entry.src),
+		dest: path.join(dest, entry.dst || entry.src)
+	}));
 	if (!forceCopy) {
 		const existings = copyReqs.filter(req => existsSync(req.dest)).map(req => req.destRelative);
 		if (existings.length > 0)

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -94,10 +94,9 @@ async function _extractFromTemplate(
 	const { forceCopy, logger } = opts;
 	const copyReqs = conf.files.map(entry => {
 		const destPath = entry.dst ? path.join(dest, entry.dst) : path.join(dest, entry.src);
-		const destRelativePath = entry.dst || entry.src;
 		return {
 			srcRelative: entry.src,
-			destRelative: destRelativePath,
+			destRelative: entry.dst || entry.src,
 			src: path.join(src, entry.src),
 			dest: destPath
 		};


### PR DESCRIPTION
## 概要

akashic init で template.json の挙動が違う問題の修正。

template.json で下記のような値だと、テンプレート元 の `mainScene.js` が出力先では `script/mainScene.js` として出力されるはずだが実際の挙動が違っている。

```
{
  "files": [
    `{"src": "mainScene.js",　"dst": "script/mainScene.js"}`
  ]
}
```

現状実行すると下記のようなパスに出力されてしまう。
`./script/mainScene.js/mainScene.js`

`dst` に値がある場合は `dst` の値で出力先 path を生成するように修正。 
既存のデフォルトテンプレートとカスタムテンプレートにて動作確認済み。