### PR TITLE
Add --debug-override-engine-files option to export html

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -15,4 +15,5 @@ export interface CliConfigExportHtml {
 	autoSendEvents?: string | boolean;
 	autoSendEventName?: string | boolean;
 	omitUnbundledJs?: boolean;
+	injectEngineFiles?: string;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -15,5 +15,5 @@ export interface CliConfigExportHtml {
 	autoSendEvents?: string | boolean;
 	autoSendEventName?: string | boolean;
 	omitUnbundledJs?: boolean;
-	injectEngineFiles?: string;
+	debugOverrideEngineFiles?: string;
 }

--- a/packages/akashic-cli-export/spec/fixtures/engineFilesV3_1_99.js
+++ b/packages/akashic-cli-export/spec/fixtures/engineFilesV3_1_99.js
@@ -1,0 +1,1 @@
+dummy-engineFilesV3_1_99

--- a/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
@@ -111,4 +111,61 @@ describe("exportHTML", function () {
 			.then(done, done.fail);
 	});
 
+	it("promiseExportHTML with debugOverrideEngineFiles option", (done) => {
+		Promise.resolve()
+			.then(() => {
+				const param: exp.ExportHTMLParameterObject = {
+					logger: undefined,
+					cwd: path.join(__dirname, "..", "..", "fixtures", "sample_game_v3"),
+					source: ".",
+					output: undefined,
+					force: true,
+					strip: false,
+					minify: false,
+					magnify: false,
+					unbundleText: false,
+					lint: false,
+					debugOverrideEngineFiles: path.join(__dirname, "..", "..", "fixtures", "engineFilesV3_1_99.js")
+				};
+				return exp.promiseExportHTML(param);
+			})
+			.then((dest) => {
+				expect(dest).toMatch(/^.*akashic-export-html-tmp-.+$/);
+				expect(fsx.statSync(path.join(dest, "js", "engineFilesV3_1_99.js"))).toBeTruthy();
+				const buff = fsx.readFileSync(path.join(dest, "index.html"));
+				// index.html で指定したengineFiles が読み込まれている
+				expect(buff.toString().includes("<script src=\"./js/engineFilesV3_1_99.js\"")).toBeTruthy();
+				fsx.removeSync(dest);
+			})
+			.then(done, done.fail);
+	});
+
+	it("promiseExportHTML with bundole and debugOverrideEngineFiles option", (done) => {
+		Promise.resolve()
+			.then(() => {
+				const param: exp.ExportHTMLParameterObject = {
+					logger: undefined,
+					cwd: path.join(__dirname, "..", "..", "fixtures", "sample_game_v3"),
+					source: ".",
+					output: undefined,
+					force: true,
+					strip: false,
+					minify: false,
+					magnify: false,
+					unbundleText: false,
+					lint: false,
+					bundle: true,
+					debugOverrideEngineFiles: path.join(__dirname, "..", "..", "fixtures", "engineFilesV3_1_99.js")
+				};
+				return exp.promiseExportHTML(param);
+			})
+			.then((dest) => {
+				expect(dest).toMatch(/^.*akashic-export-html-tmp-.+$/);
+				expect(fsx.existsSync(path.join(dest, "js"))).toBeFalsy();
+				const buff = fsx.readFileSync(path.join(dest, "index.html"));
+				expect(buff.toString().includes("dummy-engineFilesV3_1_99")).toBeTruthy(); // engineFiles の中身が index.html に存在する
+				fsx.removeSync(dest);
+			})
+			.then(done, done.fail);
+	});
 });

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -98,7 +98,6 @@ export function run(argv: string[]): void {
 			console.error(error);
 			process.exit(1);
 		}
-		console.log("***val:", options.debugOverrideEngineFiles);
 		if (options.debugOverrideEngineFiles) {
 			if (!/^engineFilesV\d+_\d+_\d+.*\.js$/.test(path.basename(options.debugOverrideEngineFiles))) {
 				console.error(`Invalid ---debug-override-engine-files option argument:${options.debugOverrideEngineFiles},`

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -29,7 +29,7 @@ function cli(param: CliConfigExportHtml): void {
 		needsUntaintedImageAsset: param.atsumaru,
 		omitUnbundledJs: param.atsumaru && param.omitUnbundledJs,
 		compress: param.output && !param.atsumaru ? path.extname(param.output) === ".zip" : false,
-		injectEngineFiles: param.injectEngineFiles,
+		debugOverrideEngineFiles: param.debugOverrideEngineFiles,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version: ver, // export実行時のバージョン
@@ -85,7 +85,7 @@ commander
 	.option("-A, --auto-send-event-name [eventName]", "event name that send automatically when game start")
 	.option("-a, --atsumaru", "generate files that can be posted to GAME-atsumaru")
 	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.")
-	.option("--inject-engine-files <filePath>", "Use the injected engineFiles");
+	.option("--debug-override-engine-files <filePath>", "Use the specified engineFiles");
 
 export function run(argv: string[]): void {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
@@ -98,10 +98,10 @@ export function run(argv: string[]): void {
 			console.error(error);
 			process.exit(1);
 		}
-
-		if (options.injectEngineFiles) {
-			if (!/^engineFilesV\d_\d_\d+.*.js/.test(path.basename(options.injectEngineFiles))) {
-				console.error(`Invalid --inject-engine-files option argument:${options.injectEngineFiles},`
+		console.log("***val:", options.debugOverrideEngineFiles);
+		if (options.debugOverrideEngineFiles) {
+			if (!/^engineFilesV\d_\d_\d+.*.js/.test(path.basename(options.debugOverrideEngineFiles))) {
+				console.error(`Invalid ---debug-override-engine-files option argument:${options.debugOverrideEngineFiles},`
 					+ "File name should be in engineFilesVx_x_x format");
 				process.exit(1);
 			}
@@ -123,7 +123,7 @@ export function run(argv: string[]): void {
 			atsumaru: options.atsumaru ?? conf.atsumaru,
 			autoSendEventName: options.autoSendEventName ?? options.autoSendEvents ?? conf.autoSendEventName ?? conf.autoSendEvents,
 			omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
-			injectEngineFiles: options.injectEngineFiles ?? conf.injectEngineFiles
+			debugOverrideEngineFiles: options.debugOverrideEngineFiles ?? conf.debugOverrideEngineFiles
 		});
 	});
 }

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -29,6 +29,7 @@ function cli(param: CliConfigExportHtml): void {
 		needsUntaintedImageAsset: param.atsumaru,
 		omitUnbundledJs: param.atsumaru && param.omitUnbundledJs,
 		compress: param.output && !param.atsumaru ? path.extname(param.output) === ".zip" : false,
+		injectEngineFiles: param.injectEngineFiles,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version: ver, // export実行時のバージョン
@@ -83,7 +84,8 @@ commander
 	.option("--autoSendEvents [eventName]", "(deprecated)event name that send automatically when game start")
 	.option("-A, --auto-send-event-name [eventName]", "event name that send automatically when game start")
 	.option("-a, --atsumaru", "generate files that can be posted to GAME-atsumaru")
-	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.");
+	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.")
+	.option("--inject-engine-files <filePath>", "Use the injected engineFiles");
 
 export function run(argv: string[]): void {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
@@ -95,6 +97,14 @@ export function run(argv: string[]): void {
 		if (error) {
 			console.error(error);
 			process.exit(1);
+		}
+
+		if (options.injectEngineFiles) {
+			if (!/^engineFilesV\d_\d_\d+.*.js/.test(options.injectEngineFiles)) {
+				console.error(`Invalid --inject-engine-files option argument:${options.injectEngineFiles},`
+					+ "File name should be in engineFilesVx_x_x format");
+				process.exit(1);
+			}
 		}
 
 		const conf = configuration.commandOptions.export ? (configuration.commandOptions.export.html || {}) : {};
@@ -112,7 +122,8 @@ export function run(argv: string[]): void {
 			injects: options.inject ?? conf.injects,
 			atsumaru: options.atsumaru ?? conf.atsumaru,
 			autoSendEventName: options.autoSendEventName ?? options.autoSendEvents ?? conf.autoSendEventName ?? conf.autoSendEvents,
-			omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs
+			omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
+			injectEngineFiles: options.injectEngineFiles ?? conf.injectEngineFiles
 		});
 	});
 }

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -100,7 +100,7 @@ export function run(argv: string[]): void {
 		}
 		console.log("***val:", options.debugOverrideEngineFiles);
 		if (options.debugOverrideEngineFiles) {
-			if (!/^engineFilesV\d_\d_\d+.*.js/.test(path.basename(options.debugOverrideEngineFiles))) {
+			if (!/^engineFilesV\d+_\d+_\d+.*\.js$/.test(path.basename(options.debugOverrideEngineFiles))) {
 				console.error(`Invalid ---debug-override-engine-files option argument:${options.debugOverrideEngineFiles},`
 					+ "File name should be in engineFilesVx_x_x format");
 				process.exit(1);

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -100,7 +100,7 @@ export function run(argv: string[]): void {
 		}
 
 		if (options.injectEngineFiles) {
-			if (!/^engineFilesV\d_\d_\d+.*.js/.test(options.injectEngineFiles)) {
+			if (!/^engineFilesV\d_\d_\d+.*.js/.test(path.basename(options.injectEngineFiles))) {
 				console.error(`Invalid --inject-engine-files option argument:${options.injectEngineFiles},`
 					+ "File name should be in engineFilesVx_x_x format");
 				process.exit(1);

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -85,7 +85,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 			templatePath = "template/v3";
 			break;
 		default:
-			throw Error ("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".");
+			throw Error("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".");
 	}
 	await writeHtmlFile(innerHTMLAssetArray, options.output, conf, options, templatePath);
 	writeCommonFiles(options.source, options.output, conf, options, templatePath);

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -85,7 +85,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 			templatePath = "template/v3";
 			break;
 		default:
-			throw Error("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".");
+			throw "Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".";
 	}
 	await writeHtmlFile(innerHTMLAssetArray, options.output, conf, options, templatePath);
 	writeCommonFiles(options.source, options.output, conf, options, templatePath);

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -85,7 +85,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 			templatePath = "template/v3";
 			break;
 		default:
-			throw "Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".";
+			throw Error ("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".");
 	}
 	await writeHtmlFile(innerHTMLAssetArray, options.output, conf, options, templatePath);
 	writeCommonFiles(options.source, options.output, conf, options, templatePath);

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -135,7 +135,8 @@ async function writeHtmlFile(
 		templatePath,
 		conf._content.environment["sandbox-runtime"],
 		options.minify,
-		!options.unbundleText
+		!options.unbundleText,
+		options.injectEngineFiles
 	);
 	const filePath = path.resolve(__dirname + "/../template/bundle-index.ejs");
 	const html = await ejs.renderFile(filePath, {

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -136,7 +136,7 @@ async function writeHtmlFile(
 		conf._content.environment["sandbox-runtime"],
 		options.minify,
 		!options.unbundleText,
-		options.injectEngineFiles
+		options.debugOverrideEngineFiles
 	);
 	const filePath = path.resolve(__dirname + "/../template/bundle-index.ejs");
 	const html = await ejs.renderFile(filePath, {

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -159,7 +159,7 @@ function writeCommonFiles(
 			templatePath = "template/v3";
 			break;
 		default:
-			throw "Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".";
+			throw Error("Unknown engine version: `environment[\"sandbox-runtime\"]` field in game.json should be \"1\", \"2\", or \"3\".");
 	}
 
 	fsx.copySync(

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -14,7 +14,7 @@ import {
 	validateEs5Code,
 	readSandboxConfigJs,
 	addUntaintedToImageAssets,
-	substrEngineFilesVersion
+	validateEngineFileAndGameJsonVersion
 } from "./convertUtil";
 
 export async function promiseConvertNoBundle(options: ConvertTemplateParameterObject): Promise<void> {
@@ -120,11 +120,7 @@ async function writeHtmlFile(
 	const filePath = path.resolve(__dirname + "/../template/no-bundle-index.ejs");
 
 	if (options.debugOverrideEngineFiles) {
-		const engineFilesVersion = substrEngineFilesVersion(options.debugOverrideEngineFiles);
-		if (engineFilesVersion && version !== engineFilesVersion) {
-			throw "Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
-				+ ` environment[\"sandbox-runtime\"]:${version}, engineFiles:${engineFilesVersion}`;
-		}
+		validateEngineFileAndGameJsonVersion(options.debugOverrideEngineFiles, version);
 		engineFilesVariable = path.basename(options.debugOverrideEngineFiles, ".js");
 	}
 

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -14,7 +14,7 @@ import {
 	validateEs5Code,
 	readSandboxConfigJs,
 	addUntaintedToImageAssets,
-	validateEngineFileAndGameJsonVersion
+	validateEngineFilesName
 } from "./convertUtil";
 
 export async function promiseConvertNoBundle(options: ConvertTemplateParameterObject): Promise<void> {
@@ -120,7 +120,7 @@ async function writeHtmlFile(
 	const filePath = path.resolve(__dirname + "/../template/no-bundle-index.ejs");
 
 	if (options.debugOverrideEngineFiles) {
-		validateEngineFileAndGameJsonVersion(options.debugOverrideEngineFiles, version);
+		validateEngineFilesName(options.debugOverrideEngineFiles, version);
 		engineFilesVariable = path.basename(options.debugOverrideEngineFiles, ".js");
 	}
 
@@ -172,7 +172,7 @@ function writeCommonFiles(
 			.map(f => fsx.removeSync(path.join(jsDir, f)));
 		fsx.copySync(
 			path.resolve(options.debugOverrideEngineFiles),
-			path.join(jsDir, options.debugOverrideEngineFiles)
+			path.join(jsDir, path.basename(options.debugOverrideEngineFiles))
 		);
 	}
 }

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -118,10 +118,10 @@ async function writeHtmlFile(
 	let engineFilesVariable = versionsJson[`v${version}`].variable;
 	const filePath = path.resolve(__dirname + "/../template/no-bundle-index.ejs");
 
-	if (options.injectEngineFiles) {
-		const matches = options.injectEngineFiles.match(/\d_\d_\d/);
+	if (options.debugOverrideEngineFiles) {
+		const matches = options.debugOverrideEngineFiles.match(/\d_\d_\d/);
 		if (matches) version = matches[0].slice(0, 1);
-		engineFilesVariable = path.basename(options.injectEngineFiles, ".js");
+		engineFilesVariable = path.basename(options.debugOverrideEngineFiles, ".js");
 	}
 
 	const html = await ejs.renderFile(filePath, {
@@ -166,13 +166,13 @@ function writeCommonFiles(
 		path.resolve(__dirname, "..", templatePath),
 		outputPath);
 
-	if (options.injectEngineFiles) {
+	if (options.debugOverrideEngineFiles) {
 		const jsDir = path.join(outputPath, "js");
 		fsx.readdirSync(jsDir).filter(f => /^engineFilesV*/.test(f))
 			.map(f => fsx.removeSync(path.join(jsDir, f)));
 		fsx.copySync(
-			path.resolve(options.injectEngineFiles),
-			path.join(jsDir, options.injectEngineFiles)
+			path.resolve(options.debugOverrideEngineFiles),
+			path.join(jsDir, options.debugOverrideEngineFiles)
 		);
 	}
 }

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -216,10 +216,10 @@ export function validateEngineFileAndGameJsonVersion(overrideEngineFilesPath: st
 
 	if (!engineFilesVersion) {
 		// 実行途中でファイル名を変更されない限りこのパスに入ることはないが念の為。
-		throw "Invalid File name should be in engineFilesVx_x_x format";
+		throw new Error("Invalid File name should be in engineFilesVx_x_x format");
 	} else if (gameJsonVersion !== engineFilesVersion) {
-		throw "Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
-		+ ` environment[\"sandbox-runtime\"]:${gameJsonVersion}, engineFiles:${engineFilesVersion}`;
+		throw new Error("Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
+		+ ` environment[\"sandbox-runtime\"]:${gameJsonVersion}, engineFiles:${engineFilesVersion}`);
 	}
 }
 
@@ -233,7 +233,7 @@ function loadScriptFile(filePath: string): string {
 		return fs.readFileSync(filePath, "utf8").replace(/\r\n|\r/g, "\n");
 	} catch (e) {
 		if (e.code === "ENOENT") {
-			throw path.basename(filePath) + " is not found. Try re-install akashic-cli" + filePath;
+			throw new Error(path.basename(filePath) + " is not found. Try re-install akashic-cli" + filePath);
 		} else {
 			throw e;
 		}

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -114,11 +114,7 @@ export function getDefaultBundleScripts(
 	let engineFilesVariable = versionsJson[`v${version}`].variable;
 
 	if (overrideEngineFilesPath) {
-		const engineFilesVersion = substrEngineFilesVersion(overrideEngineFilesPath);
-		if (engineFilesVersion && version !== engineFilesVersion) {
-			throw "Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
-				+ ` environment[\"sandbox-runtime\"]:${version}, engineFiles:${engineFilesVersion}`;
-		}
+		validateEngineFileAndGameJsonVersion(overrideEngineFilesPath, version);
 		engineFilesVariable = path.basename(overrideEngineFilesPath, ".js");
 	}
 
@@ -214,9 +210,17 @@ export function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void
 	});
 }
 
-export function substrEngineFilesVersion(overrideEngineFilesPath: string): string | null {
+export function validateEngineFileAndGameJsonVersion(overrideEngineFilesPath: string, gameJsonVersion: string): void {
 	const matches = overrideEngineFilesPath.match(/(\d+)_\d+_\d+/);
-	return matches ? matches[1] : null;
+	const engineFilesVersion = matches ? matches[1] : null;
+
+	if (!engineFilesVersion) {
+		// 実行途中でファイル名を変更されない限りこのパスに入ることはないが念の為。
+		throw "Invalid File name should be in engineFilesVx_x_x format";
+	} else if (gameJsonVersion !== engineFilesVersion) {
+		throw "Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
+		+ ` environment[\"sandbox-runtime\"]:${gameJsonVersion}, engineFiles:${engineFilesVersion}`;
+	}
 }
 
 function getFileContentsFromDirectory(inputDirPath: string): string[] {

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -25,6 +25,7 @@ export interface ConvertTemplateParameterObject {
 	sandboxConfigJsCode?: string;
 	needsUntaintedImageAsset?: boolean;
 	omitUnbundledJs?: boolean;
+	injectEngineFiles?: string;
 }
 
 export function extractAssetDefinitions (conf: cmn.Configuration, type: string): string[] {
@@ -101,12 +102,25 @@ export function wrap(code: string, minify?: boolean): string {
 	return minify ? UglifyJS.minify(ret, { sourceMap: true }).code : ret;
 }
 
-export function getDefaultBundleScripts(templatePath: string, version: string, minify?: boolean, bundleText: boolean = true): any {
+export function getDefaultBundleScripts(
+	templatePath: string,
+	version: string,
+	minify?: boolean,
+	bundleText: boolean = true,
+	injectEngineFilesPath?: string
+): any {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
-	var versionsJson = require("../engineFilesVersion.json");
-	var engineFilesVariable = versionsJson[`v${version}`].variable;
-	var preloadScriptNames = [`${engineFilesVariable}.js`];
-	var preloadScript = `
+	const versionsJson = require("../engineFilesVersion.json");
+	let engineFilesVariable = versionsJson[`v${version}`].variable;
+
+	if (injectEngineFilesPath) {
+		const matches = injectEngineFilesPath.match(/\d_\d_\d/);
+		if (matches) version = matches[0].slice(0, 1);
+		engineFilesVariable = path.basename(injectEngineFilesPath, ".js");
+	}
+
+	const preloadScriptNames = [`${engineFilesVariable}.js`];
+	const preloadScript = `
 		window.engineFiles = ${engineFilesVariable};
 		window.g = engineFiles.akashicEngine;
 		(function() {
@@ -121,7 +135,7 @@ export function getDefaultBundleScripts(templatePath: string, version: string, m
 			};
 		})();
 	`;
-	var postloadScriptNames =
+	let postloadScriptNames =
 		["sandbox.js", "initGlobals.js"];
 	if (version === "3") {
 		postloadScriptNames.push("pdi/LocalScriptAssetV3.js");
@@ -136,9 +150,9 @@ export function getDefaultBundleScripts(templatePath: string, version: string, m
 	}
 	if (version === "1") postloadScriptNames.push("logger.js");
 
-	var preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
+	let preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
 	preloadScripts.push(preloadScript);
-	var postloadScripts = postloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
+	let postloadScripts = postloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
 	if (minify) {
 		preloadScripts = preloadScripts.map(script => UglifyJS.minify(script, { sourceMap: true }).code);
 		postloadScripts = postloadScripts.map(script => UglifyJS.minify(script, { sourceMap: true }).code);

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -150,7 +150,7 @@ export function getDefaultBundleScripts(
 	}
 	if (version === "1") postloadScriptNames.push("logger.js");
 
-	let preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
+	let preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath, injectEngineFilesPath));
 	preloadScripts.push(preloadScript);
 	let postloadScripts = postloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
 	if (minify) {
@@ -210,9 +210,10 @@ function getFileContentsFromDirectory(inputDirPath: string): string[] {
 		.map(fileName => fs.readFileSync(path.join(inputDirPath, fileName), "utf8").replace(/\r\n|\r/g, "\n"));
 }
 
-function loadScriptFile(fileName: string, templatePath: string): string {
+function loadScriptFile(fileName: string, templatePath: string, injectEngineFilesPath?: string): string {
 	try {
-		const filepath = path.resolve(__dirname, "..", templatePath, "js", fileName);
+		const filepath = injectEngineFilesPath ?
+			path.resolve(injectEngineFilesPath) : path.resolve(__dirname, "..", templatePath, "js", fileName);
 		return fs.readFileSync(filepath, "utf8").replace(/\r\n|\r/g, "\n");
 	} catch (e) {
 		if (e.code === "ENOENT") {

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -25,7 +25,7 @@ export interface ConvertTemplateParameterObject {
 	sandboxConfigJsCode?: string;
 	needsUntaintedImageAsset?: boolean;
 	omitUnbundledJs?: boolean;
-	injectEngineFiles?: string;
+	debugOverrideEngineFiles?: string;
 }
 
 export function extractAssetDefinitions (conf: cmn.Configuration, type: string): string[] {
@@ -107,16 +107,16 @@ export function getDefaultBundleScripts(
 	version: string,
 	minify?: boolean,
 	bundleText: boolean = true,
-	injectEngineFilesPath?: string
+	debugOverrideEngineFilesPath?: string
 ): any {
 	// eslint-disable-next-line @typescript-eslint/no-var-requires
 	const versionsJson = require("../engineFilesVersion.json");
 	let engineFilesVariable = versionsJson[`v${version}`].variable;
 
-	if (injectEngineFilesPath) {
-		const matches = injectEngineFilesPath.match(/\d_\d_\d/);
+	if (debugOverrideEngineFilesPath) {
+		const matches = debugOverrideEngineFilesPath.match(/\d_\d_\d/);
 		if (matches) version = matches[0].slice(0, 1);
-		engineFilesVariable = path.basename(injectEngineFilesPath, ".js");
+		engineFilesVariable = path.basename(debugOverrideEngineFilesPath, ".js");
 	}
 
 	const preloadScriptNames = [`${engineFilesVariable}.js`];
@@ -150,7 +150,7 @@ export function getDefaultBundleScripts(
 	}
 	if (version === "1") postloadScriptNames.push("logger.js");
 
-	let preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath, injectEngineFilesPath));
+	let preloadScripts = preloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath, debugOverrideEngineFilesPath));
 	preloadScripts.push(preloadScript);
 	let postloadScripts = postloadScriptNames.map((fileName) => loadScriptFile(fileName, templatePath));
 	if (minify) {
@@ -210,10 +210,10 @@ function getFileContentsFromDirectory(inputDirPath: string): string[] {
 		.map(fileName => fs.readFileSync(path.join(inputDirPath, fileName), "utf8").replace(/\r\n|\r/g, "\n"));
 }
 
-function loadScriptFile(fileName: string, templatePath: string, injectEngineFilesPath?: string): string {
+function loadScriptFile(fileName: string, templatePath: string, debugOverrideEngineFilesPath?: string): string {
 	try {
-		const filepath = injectEngineFilesPath ?
-			path.resolve(injectEngineFilesPath) : path.resolve(__dirname, "..", templatePath, "js", fileName);
+		const filepath = debugOverrideEngineFilesPath ?
+			path.resolve(debugOverrideEngineFilesPath) : path.resolve(__dirname, "..", templatePath, "js", fileName);
 		return fs.readFileSync(filepath, "utf8").replace(/\r\n|\r/g, "\n");
 	} catch (e) {
 		if (e.code === "ENOENT") {

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -114,7 +114,7 @@ export function getDefaultBundleScripts(
 	let engineFilesVariable = versionsJson[`v${version}`].variable;
 
 	if (overrideEngineFilesPath) {
-		validateEngineFileAndGameJsonVersion(overrideEngineFilesPath, version);
+		validateEngineFilesName(overrideEngineFilesPath, version);
 		engineFilesVariable = path.basename(overrideEngineFilesPath, ".js");
 	}
 
@@ -210,16 +210,12 @@ export function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void
 	});
 }
 
-export function validateEngineFileAndGameJsonVersion(overrideEngineFilesPath: string, gameJsonVersion: string): void {
-	const matches = overrideEngineFilesPath.match(/(\d+)_\d+_\d+/);
+export function validateEngineFilesName(filename: string, expectedMajorVersion: string): void {
+	const matches = filename.match(/(\d+)_\d+_\d+/);
 	const engineFilesVersion = matches ? matches[1] : null;
-
-	if (!engineFilesVersion) {
-		// 実行途中でファイル名を変更されない限りこのパスに入ることはないが念の為。
-		throw new Error("Invalid File name should be in engineFilesVx_x_x format");
-	} else if (gameJsonVersion !== engineFilesVersion) {
+	if (expectedMajorVersion !== engineFilesVersion) {
 		throw new Error("Versions of environment[\"sandbox-runtime\"] in game.json and the version of engineFiles do not match."
-		+ ` environment[\"sandbox-runtime\"]:${gameJsonVersion}, engineFiles:${engineFilesVersion}`);
+			+ ` environment[\"sandbox-runtime\"]:${expectedMajorVersion}, engineFiles:${engineFilesVersion}`);
 	}
 }
 

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -81,7 +81,8 @@ export function promiseExportHtmlRaw(param: ExportHTMLParameterObject): Promise<
 				lint: param.lint,
 				exportInfo: param.exportInfo,
 				autoSendEventName: param.autoSendEventName,
-				needsUntaintedImageAsset: param.needsUntaintedImageAsset
+				needsUntaintedImageAsset: param.needsUntaintedImageAsset,
+				injectEngineFiles: param.injectEngineFiles
 			};
 			if (param.bundle) {
 				return promiseConvertBundle(convertParam);

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -82,7 +82,7 @@ export function promiseExportHtmlRaw(param: ExportHTMLParameterObject): Promise<
 				exportInfo: param.exportInfo,
 				autoSendEventName: param.autoSendEventName,
 				needsUntaintedImageAsset: param.needsUntaintedImageAsset,
-				injectEngineFiles: param.injectEngineFiles
+				debugOverrideEngineFiles: param.debugOverrideEngineFiles
 			};
 			if (param.bundle) {
 				return promiseConvertBundle(convertParam);


### PR DESCRIPTION
## 概要

export html のオプションに指定した engineFiles を使用して export を行う `--debug-override-engine-files` を追加。
指定された engineFiles のファイル名が `engineFilesVx_x_x` にマッチしない場合はエラーとします。

動作確認
`--bundle`の有無と `--debug-override-engine-files` で指定された engineFiles で export されコンテンツが実行されることを確認。 
