### PR TITLE
fix(common): fix overwritten virtualPath on Renamer

### DIFF
--- a/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
+++ b/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
@@ -36,6 +36,12 @@ describe("Renamer", function () {
 								path: "script/mainScene.js",
 								global: true
 							},
+							sub: {
+								type: "script",
+								path: "script/sub.js",
+								virtualPath: "script/virtualSub.js",
+								global: true
+							},
 							hoge: {
 								type: "image",
 								path: "image/hoge.png",
@@ -55,7 +61,8 @@ describe("Renamer", function () {
 						}
 					}),
 					script: {
-						"mainScene.js": "console.log('main');"
+						"mainScene.js": "require('./sub');",
+						"sub.js": "console.log('sub');"
 					},
 					image: {
 						"hoge.png": ""
@@ -90,6 +97,12 @@ describe("Renamer", function () {
 					type: "script",
 					path: "files/04ef22b752657e08b66f.js",
 					virtualPath: "script/mainScene.js",
+					global: true
+				});
+				expect(gamejson.assets["sub"]).toEqual({
+					type: "script",
+					path: "files/ec09c6fef46489affb10.js",
+					virtualPath: "script/virtualSub.js", // 最初から指定されていた virtualPath は保存される。
 					global: true
 				});
 				expect(gamejson.assets["hoge"]).toEqual({

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -73,7 +73,7 @@ function _renameAssets(content: GameConfiguration, basedir: string, maxHashLengt
 		const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
 
 		content.assets[name].path = hashedFilePath;
-		content.assets[name].virtualPath = filePath;
+		content.assets[name].virtualPath = content.assets[name].virtualPath ?? filePath;
 		processedAssetPaths.add(hashedFilePath);
 		if (isRenamedAsset) return; // 同じパスのアセットを既にハッシュ化済みの場合、ファイルはリネーム済み
 		if (content.assets[name].type !== "audio") {


### PR DESCRIPTION
掲題どおり。 `Renamer` のファイル名ランダム化が正しく動作しないことがある問題を修正します。

### 現象と対応

以下の全てを満たすコンテンツを、 `akashic export html --atsumaru` などで zip 化した場合に、実行時にエラーになっていました。

- game.json でアセット定義に `virtualPath` 指定を利用している
- v3 コンテンツで、 シーン生成時の `assetPaths` や `g.Scene#asset.getImage()` など、パスベースのアセットアクセスを利用しており、その値として  `virtualPath` の値を使っている

原因は `Renamer` のファイル名変更処理が `virtualPath` を上書きしてしまうため。もともと指定がある場合はその値を維持するようにします。
