### PR TITLE
akashic export html --minify --atsumaruを実行した際にバンドルされるスクリプトにminifyを適用

### DIFF
--- a/packages/akashic-cli-export/src/html/exportAtsumaru.ts
+++ b/packages/akashic-cli-export/src/html/exportAtsumaru.ts
@@ -26,6 +26,7 @@ export function promiseExportAtsumaru(param: ExportHTMLParameterObject): Promise
 				bundle: completedParam.bundle,
 				dest: completedParam.output,
 				hashLength: completedParam.hashLength,
+				minify: completedParam.minify,
 				strip: true,
 				force: true,
 				babel: true,


### PR DESCRIPTION
### 概要
`akashic export html --minify --atsumaru`
上記のようなコマンドオプションを指定した際に生成されるzip内のfilesフォルダ以下に配置されるスクリプトがminifyされていないのを修正。
### 目的
ファイルサイズの縮小とニコ生でプレイする際のパフォーマンス改善に役立ちます。