### PR TITLE
Add query parameter arguments option

### DIFF
--- a/packages/akashic-cli-serve/src/client/common/queryParameters.ts
+++ b/packages/akashic-cli-serve/src/client/common/queryParameters.ts
@@ -221,6 +221,17 @@ export interface ServeQueryParameters {
 	ignoreSession: boolean | null;
 
 	experimentalIsChildWindow: boolean | null;
+
+	/**
+	 * このインスタンスに適用する arguments 名を指定する。
+	 * arguments の実装は sandbox.config.js から読み込まれる。
+	 */
+	argumentsName: string | null;
+
+	/**
+	 * このインスタンスに適用する arguments の実装を指定する。
+	 */
+	argumentsValue: string | null;
 }
 
 function asString(v: string | string[] | null): string | null {
@@ -288,7 +299,9 @@ export function makeServeQueryParameters(query: RawParsedQuery): ServeQueryParam
 		showsDesignGuideline: asBool(query.showsDesignGuideline),
 		id: asString(query.id),
 		ignoreSession: asBool(query.ignoreSession),
-		experimentalIsChildWindow: asBool(query.experimentalIsChildWindow)
+		experimentalIsChildWindow: asBool(query.experimentalIsChildWindow),
+		argumentsName: asString(query.argumentsName),
+		argumentsValue: asString(query.argumentsValue)
 	};
 }
 

--- a/packages/akashic-cli-serve/src/client/common/queryParameters.ts
+++ b/packages/akashic-cli-serve/src/client/common/queryParameters.ts
@@ -230,6 +230,7 @@ export interface ServeQueryParameters {
 
 	/**
 	 * このインスタンスに適用する arguments の実装を指定する。
+	 * argumentsName と両方指定した場合の動作は不定である。
 	 */
 	argumentsValue: string | null;
 }

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -126,8 +126,10 @@ export class Operator {
 
 		if (query.argumentsValue) {
 			argument = JSON.parse(query.argumentsValue);
-		} else if (query.argumentsName && store.currentPlay.content.argumentsTable[query.argumentsName]) {
+			store.startupScreenUiStore.setInstanceArgumentEditContent(query.argumentsValue, false);
+		} else if (query.argumentsName) {
 			argument = JSON.parse(store.currentPlay.content.argumentsTable[query.argumentsName]);
+			this.ui.selectInstanceArguments(query.argumentsName);
 		}
 
 		if (store.appOptions.autoStart) {

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -126,10 +126,10 @@ export class Operator {
 
 		if (query.argumentsValue) {
 			argument = JSON.parse(query.argumentsValue);
-			store.startupScreenUiStore.setInstanceArgumentEditContent(query.argumentsValue, false);
-		} else if (query.argumentsName) {
+			store.startupScreenUiStore.setInstanceArgumentEditContent(query.argumentsValue, true);
+		} else if (query.argumentsName && !!store.currentPlay.content.argumentsTable[query.argumentsName]) {
 			argument = JSON.parse(store.currentPlay.content.argumentsTable[query.argumentsName]);
-			this.ui.selectInstanceArguments(query.argumentsName, false);
+			this.ui.selectInstanceArguments(query.argumentsName, true);
 		}
 
 		if (store.appOptions.autoStart) {

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -129,7 +129,7 @@ export class Operator {
 			store.startupScreenUiStore.setInstanceArgumentEditContent(query.argumentsValue, false);
 		} else if (query.argumentsName) {
 			argument = JSON.parse(store.currentPlay.content.argumentsTable[query.argumentsName]);
-			this.ui.selectInstanceArguments(query.argumentsName);
+			this.ui.selectInstanceArguments(query.argumentsName, false);
 		}
 
 		if (store.appOptions.autoStart) {

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -123,6 +123,13 @@ export class Operator {
 			}
 			argument = this._createInstanceArgumentForNicolive(isJoin);
 		}
+
+		if (query.argumentsValue) {
+			argument = JSON.parse(query.argumentsValue);
+		} else if (query.argumentsName && store.currentPlay.content.argumentsTable[query.argumentsName]) {
+			argument = JSON.parse(store.currentPlay.content.argumentsTable[query.argumentsName]);
+		}
+
 		if (store.appOptions.autoStart) {
 			await this.startContent({
 				joinsSelf: isJoin,

--- a/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/UiOperator.ts
@@ -80,12 +80,12 @@ export class UiOperator {
 		this.store.startupScreenUiStore.setInstanceArgumentListWidth(w);
 	};
 
-	selectInstanceArguments = (name: string | null): void => {
+	selectInstanceArguments = (name: string | null, noPutStrage: boolean = false): void => {
 		const argumentsTable = this.store.currentPlay.content.argumentsTable;
 		const argStr = (name != null) ? argumentsTable[name] : "";
 		const { startupScreenUiStore } = this.store;
-		startupScreenUiStore.setSelectedArgumentName(name);
-		startupScreenUiStore.setInstanceArgumentEditContent(argStr);
+		startupScreenUiStore.setSelectedArgumentName(name, noPutStrage);
+		startupScreenUiStore.setInstanceArgumentEditContent(argStr, noPutStrage);
 	};
 
 	setInstanceArgumentEditContent = (argStr: string): void => {

--- a/packages/akashic-cli-serve/src/client/store/StartupScreenUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/StartupScreenUiStore.ts
@@ -15,9 +15,9 @@ export class StartupScreenUiStore {
 	}
 
 	@action
-	setSelectedArgumentName(name: string | null, noPutStrage: boolean = false): void {
+	setSelectedArgumentName(name: string | null, noPutStorage: boolean = false): void {
 		this.selectedArgumentName = name;
-		if (noPutStrage) return;
+		if (noPutStorage) return;
 		storage.put({ selectedArgumentName: name });
 	}
 
@@ -28,9 +28,9 @@ export class StartupScreenUiStore {
 	}
 
 	@action
-	setInstanceArgumentEditContent(content: string, noPutStrage: boolean = false): void {
+	setInstanceArgumentEditContent(content: string, noPutStorage: boolean = false): void {
 		this.instanceArgumentEditContent = content;
-		if (noPutStrage) return;
+		if (noPutStorage) return;
 		storage.put({ instanceArgumentEditContent: content });
 	}
 

--- a/packages/akashic-cli-serve/src/client/store/StartupScreenUiStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/StartupScreenUiStore.ts
@@ -15,8 +15,9 @@ export class StartupScreenUiStore {
 	}
 
 	@action
-	setSelectedArgumentName(name: string | null): void {
+	setSelectedArgumentName(name: string | null, noPutStrage: boolean = false): void {
 		this.selectedArgumentName = name;
+		if (noPutStrage) return;
 		storage.put({ selectedArgumentName: name });
 	}
 
@@ -27,8 +28,9 @@ export class StartupScreenUiStore {
 	}
 
 	@action
-	setInstanceArgumentEditContent(content: string): void {
+	setInstanceArgumentEditContent(content: string, noPutStrage: boolean = false): void {
 		this.instanceArgumentEditContent = content;
+		if (noPutStrage) return;
 		storage.put({ instanceArgumentEditContent: content });
 	}
 


### PR DESCRIPTION
## このpull requestが解決する内容

<!-- Pull Requestの変更内容の概要を書いてください -->
akashic serveのインスタンスに渡されるargumentsをクエリパラメータで指定できるようにします。

- `argumentsName` が指定されたとき、その名前のargumentsを利用します。
- `argumentsValue` が指定されたとき、その文字列を `JSON.parse()` してargumentsとして利用します。

両方とも指定された場合は `argumentsValue` を優先します。
また、 `--no-auto-start` 有効時はStartScreenで指定されたargumentsが指定された状態になります。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->

