### PR TITLE
Fix duplicate scriptAssets for serve

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/TestbedScriptAsset.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/TestbedScriptAsset.ts
@@ -83,9 +83,9 @@ export const generateTestbedScriptAsset = <T extends Constructor<{}>>(Class: T):
 		}
 
 		execute(execEnv: ScriptAssetExecuteEnvironment): any {
-			// クライアント側でゲームコンテンツを一つしか実行しない前提なのでscriptIDをキーにしている
-			// TODO: ゲームコンテンツを複数起動する場合のキーを考える
-			window.gScriptContainer[this.id](execEnv);
+			// キーは "/conetnts/:contentId/content/script/main.js" のような相対 URL となる
+			const key = this.path.replace(window.location.origin, "");
+			window.gScriptContainer[key](execEnv);
 			return execEnv.module.exports;
 		}
 	};

--- a/packages/akashic-cli-serve/src/client/akashic/TestbedScriptAsset.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/TestbedScriptAsset.ts
@@ -83,9 +83,7 @@ export const generateTestbedScriptAsset = <T extends Constructor<{}>>(Class: T):
 		}
 
 		execute(execEnv: ScriptAssetExecuteEnvironment): any {
-			// キーは "/conetnts/:contentId/content/script/main.js" のような相対 URL となる
-			const key = this.path.replace(window.location.origin, "");
-			window.gScriptContainer[key](execEnv);
+			window.gScriptContainer[this.path](execEnv);
 			return execEnv.module.exports;
 		}
 	};

--- a/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
@@ -17,7 +17,7 @@ export const createScriptAssetController = (baseDir: string, index: number): exp
 		}
 
 		const content = fs.readFileSync(scriptPath);
-		const key = `/contents/${index.toString()}/content/${req.params.scriptName}`;
+		const key = `${req.protocol}://${req.get("host") + req.originalUrl}`;
 
 		const responseBody = `"use strict";
 			if (! ("gScriptContainer" in window)) {

--- a/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
@@ -15,18 +15,20 @@ export const createScriptAssetController = (baseDir: string, index: number): exp
 			next(err);
 			return;
 		}
-		const gameJson = gameConfigs.get(index.toString());
-		const id = Object.keys(gameJson.assets).find((id) => gameJson.assets[id].path === req.params.scriptName);
 
 		const content = fs.readFileSync(scriptPath);
+		const key = `/contents/${index.toString()}/content/${req.params.scriptName}`;
+
 		const responseBody = `"use strict";
 			if (! ("gScriptContainer" in window)) {
 				window.gScriptContainer = {};
 			}
-			gScriptContainer["${id === undefined ? req.params.scriptName : id}"] = function(g) {
-				(function(exports, require, module, __filename, __dirname) {
-					${content}
-				})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);
+			if (! gScriptContainer["${key}"]) {
+ 				gScriptContainer["${key}"] = function(g) {
+					(function(exports, require, module, __filename, __dirname) {
+						${content}
+					})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);
+				}
 			}
 		`;
 		res.contentType("text/javascript");


### PR DESCRIPTION
## 概要

akashic-cli-serve のスクリプトアセットの定義の重複する問題を修正。

akashic-hover-plugin のアセット定義 "hover_plugin" と globalScripts に入る ".../HoverPlugin.js" で重複登録され正常に動作しない問題があった。

`gScriptContainer` に `assetId` をキーにし保持していたが、絶対URL をキーにし保持するように修正。

修正前: `gScriptAssetContainer["main"]` 
修正後: `gScriptAssetContainer["http://localhost:3030/conetnts/0/content/script/main.js"]`