### PR TITLE
Support server.external in akashic-cli-serve

### DIFF
--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import type { AMFlowClient, RunnerManager, RunnerV1, RunnerV2, RunnerV3 } from "@akashic/headless-driver";
 import { Trigger } from "@akashic/trigger";
 import type {
@@ -40,7 +41,7 @@ export class RunnerStore {
 		this.onRunnerResume = new Trigger<RunnerResumeTestbedEvent>();
 		this.onRunnerPutStartPoint = new Trigger<RunnerPutStartPointTestbedEvent>();
 		this.runnerManager = params.runnerManager;
-		this.gameExternalFactory = params.gameExternalFactory;
+		this.gameExternalFactory = params.gameExternalFactory() || {};
 		this.playIdTable = {};
 	}
 
@@ -49,13 +50,22 @@ export class RunnerStore {
 		const externalAssets = (sandboxConfig ? sandboxConfig.externalAssets : undefined) === undefined ? [] : sandboxConfig.externalAssets;
 		const allowedUrls = this.createAllowedUrls(params.contentId, externalAssets);
 
+		const serverExternal = sandboxConfig?.server?.external;
+		if (serverExternal) {
+			for (const pluginName of Object.keys(serverExternal)) {
+				// eslint-disable-next-line @typescript-eslint/no-var-requires
+				const externalFactory = require(path.resolve(serverExternal[pluginName]));
+				this.gameExternalFactory = Object.assign(this.gameExternalFactory, externalFactory());
+			}
+		}
+
 		const runnerId = await this.runnerManager.createRunner({
 			playId: params.playId,
 			amflow: params.amflow,
 			executionMode: params.isActive ? "active" : "passive",
 			playToken: params.token,
 			allowedUrls,
-			externalValue: this.gameExternalFactory(),
+			externalValue: this.gameExternalFactory,
 			trusted: !serverGlobalConfig.untrusted
 		});
 		if (params.isActive) {

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -31,7 +31,7 @@ export class RunnerStore {
 	onRunnerResume: Trigger<RunnerResumeTestbedEvent>;
 	onRunnerPutStartPoint: Trigger<RunnerPutStartPointTestbedEvent>;
 	private runnerManager: RunnerManager;
-	private gameExternalFactory: () => any;
+	private gameExternalFactory: { [key: string]: any };
 	private playIdTable: { [runnerId: string]: string };
 
 	constructor(params: RunnerStoreParameterObject) {

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -54,8 +54,9 @@ export class RunnerStore {
 		if (serverExternal) {
 			for (const pluginName of Object.keys(serverExternal)) {
 				// eslint-disable-next-line @typescript-eslint/no-var-requires
-				const externalFactory = require(path.resolve(serverExternal[pluginName]));
-				this.gameExternalFactory = Object.assign(this.gameExternalFactory, externalFactory());
+				const externalSource = require(path.resolve(serverExternal[pluginName]));
+				const externalFactory = { [pluginName]: externalSource() };
+				this.gameExternalFactory = Object.assign(this.gameExternalFactory, externalFactory);
 			}
 		}
 


### PR DESCRIPTION
## 概要

akashic-cli-serve で [sandbox-configuration の server.external](https://github.com/akashic-games/sandbox-configuration/blob/03d7c13182160cfad74be806d4ea4050d19cdd1d/src/SandboxConfiguration.ts#L56) をサポートします。
serve の server 側 に sandbox.config.js で指定されたモジュールをプラグインとして登録します。

下記のような sandobx.config.js に server.external.serverPlugin が存在する場合に値の js ファイルを読み込み、g.game.external.serverPlugin.test() や g.game.external.hogePlugin.xxxxx()で利用できるようになります。

sandbox.config.js
```
...
"server": {
  "external": {
    "serverPlugin": "./plugin/pluginMock.js",
    "hogePlugin": "./plugin/hoge.js"
   }
}
```
pluginMock.js
```
module.exports = () => ({
  test: () => {
    console.log("serverPlugin");
  },
  foo: true
})
```