### PR TITLE
chore(commons): refactor command option types

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -1,19 +1,32 @@
-export interface CliConfigExportHtml {
-	output: string;
-	cwd?: string;
-	source?: string;
+/**
+ * export html のオプションのうち、ファイルパスなどを含まず index.html にダンプ情報として含められるもの。
+ */
+export interface CliConfigExportHtmlDumpableOptions {
 	force?: boolean;
 	quiet?: boolean;
-	exclude?: string[];
 	strip?: boolean;
 	hashFilename?: number | boolean;
 	minify?: boolean;
+	minifyJs?: boolean;
+	minifyJson?: boolean;
+	packImage?: boolean;
 	bundle?: boolean;
 	magnify?: boolean;
-	injects?: string[];
 	atsumaru?: boolean;
+	omitUnbundledJs?: boolean;
+}
+
+/**
+ * export html のオプション。
+ */
+export interface CliConfigExportHtml extends CliConfigExportHtmlDumpableOptions {
+	output: string;
+	cwd?: string;
+	source?: string;
+	exclude?: string[];
+	injects?: string[];
 	autoSendEvents?: string | boolean;
 	autoSendEventName?: string | boolean;
-	omitUnbundledJs?: boolean;
 	debugOverrideEngineFiles?: string;
 }
+

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -1,9 +1,10 @@
 import type { ServiceType } from "../ServiceType";
 
-export interface CliConfigExportZip {
-	cwd?: string;
+/**
+ * export zip のオプションのうち、ファイルパスなどを含まず出力の game.json にダンプ情報として含められるもの。
+ */
+export interface CliConfigExportZipDumpableOption {
 	quiet?: boolean;
-	output?: string;
 	force?: boolean;
 	strip?: boolean;
 	minify?: boolean;
@@ -13,7 +14,20 @@ export interface CliConfigExportZip {
 	bundle?: boolean;
 	babel?: boolean;
 	hashFilename?: number | boolean;
-	omitEmptyJs?: boolean;
 	omitUnbundledJs?: boolean;
 	targetService?: ServiceType;
 }
+
+/**
+ * export zip のオプション。
+ */
+export interface CliConfigExportZip extends CliConfigExportZipDumpableOption {
+	cwd?: string;
+	output?: string;
+
+	/**
+	 * @deprecated 非推奨。現在この値は常に false と見なされる。
+	 */
+	omitEmptyJs?: boolean;
+}
+

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
@@ -13,7 +13,7 @@ import type { CliConfigUpdate } from "./CliConfigUpdate";
  * akashic.config.js の型。
  */
 export interface CliConfiguration {
-	commandOptions?: {
+	commandOptions: {
 		export?: {
 			html?: Partial<CliConfigExportHtml>;
 			zip?: Partial<CliConfigExportZip>;

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
@@ -13,7 +13,7 @@ import type { CliConfigUpdate } from "./CliConfigUpdate";
  * akashic.config.js の型。
  */
 export interface CliConfiguration {
-	commandOptions: {
+	commandOptions?: {
 		export?: {
 			html?: Partial<CliConfigExportHtml>;
 			zip?: Partial<CliConfigExportZip>;

--- a/packages/akashic-cli-commons/src/GameConfiguration.ts
+++ b/packages/akashic-cli-commons/src/GameConfiguration.ts
@@ -1,11 +1,12 @@
-import type { AssetConfigurationMap, GameConfiguration as Configuration } from "@akashic/game-configuration";
-import type { ServiceType } from "./ServiceType";
+import type { AssetConfigurationMap, Environment, GameConfiguration as Configuration } from "@akashic/game-configuration";
+import type { CliConfigExportZipDumpableOption } from "./CliConfig/CliConfigExportZip";
 
 /**
  * game.json の型。
  */
-export interface GameConfiguration extends Configuration{
+export interface GameConfiguration extends Configuration {
 	assets: AssetConfigurationMap;
+	environment?: Environment;
 	exportZipInfo?: ExportZipInfo;
 }
 
@@ -15,18 +16,5 @@ export interface GameConfiguration extends Configuration{
  */
 export interface ExportZipInfo {
 	version: string;
-	option: {
-		quiet?: boolean;
-		force?: boolean;
-		strip?: boolean;
-		minify?: boolean;
-		minifyJs?: boolean;
-		minifyJson?: boolean;
-		packImage?: boolean;
-		bundle?: boolean;
-		babel?: boolean;
-		hashFilename?: number | boolean;
-		omitEmptyJs?: boolean;
-		targetService?: ServiceType;
-	};
+	option: CliConfigExportZipDumpableOption;
 }

--- a/packages/akashic-cli-commons/src/index.ts
+++ b/packages/akashic-cli-commons/src/index.ts
@@ -1,5 +1,5 @@
-export { CliConfigExportHtml } from "./CliConfig/CliConfigExportHtml";
-export { CliConfigExportZip } from "./CliConfig/CliConfigExportZip";
+export { CliConfigExportHtml, CliConfigExportHtmlDumpableOptions } from "./CliConfig/CliConfigExportHtml";
+export { CliConfigExportZip, CliConfigExportZipDumpableOption } from "./CliConfig/CliConfigExportZip";
 export { CliConfigInit } from "./CliConfig/CliConfigInit";
 export { CliConfigInstall } from "./CliConfig/CliConfigInstall";
 export { CliConfigModify } from "./CliConfig/CliConfigModify";
@@ -14,10 +14,7 @@ export { Configuration, ConfigurationParameterObject } from "./Configuration";
 export { ConfigurationFile } from "./ConfigurationFile";
 export { ConsoleLogger } from "./ConsoleLogger";
 export * as FileSystem from "./FileSystem";
-export {
-	GameConfiguration,
-	ExportZipInfo
-} from "./GameConfiguration";
+export { GameConfiguration, ExportZipInfo } from "./GameConfiguration";
 export { LibConfiguration } from "./LibConfiguration";
 export * as LintUtil from "./LintUtil";
 export { Logger } from "./Logger";


### PR DESCRIPTION
export コマンド整理の一環で、コマンドラインオプションの型を整理します。マージ先は export コマンド整理用ブランチです。変更は型のみ、追加した型は未利用で、動作への影響はありません。
