### PR TITLE
Fix serve display bug

### DIFF
--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -93,6 +93,8 @@ export class Store {
 		this.currentLocalInstance = instance;
 		this.currentLocalInstance?.onWarn.add(this._warn, this);
 		this.devtoolUiStore.setEntityTrees([]);
+		if (this.currentLocalInstance?.intrinsicSize)
+			this.setGameViewSize(this.currentLocalInstance.intrinsicSize);
 	}
 
 	@action


### PR DESCRIPTION
## 概要

serve で displayOptions の `fitToScreen` と `showsGrid` が ON の時、ブラウザで初回表示時にグリッドの描画がおかしくなる。
grid-canvas が初回表示以降サイズが変わっていないためにおかしくなっていた。
store.currentLocalInstance 生成後に1度 viewSize を変更するよう修正。