### PR TITLE
Fix error when akashic.config.js has no commandOptions

### DIFF
--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -106,7 +106,7 @@ export function run(argv: string[]): void {
 			}
 		}
 
-		const conf = configuration!.commandOptions.export ? (configuration.commandOptions.export.html || {}) : {};
+		const conf = configuration!.commandOptions?.export ? (configuration.commandOptions.export.html || {}) : {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			force: options.force ?? conf.force,

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -106,7 +106,7 @@ export function run(argv: string[]): void {
 			}
 		}
 
-		const conf = configuration!.commandOptions?.export ? (configuration.commandOptions.export.html || {}) : {};
+		const conf = configuration!.commandOptions?.export?.html ?? {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			force: options.force ?? conf.force,

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -92,7 +92,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.export ? (configuration.commandOptions.export.zip || {}) : {};
+		const conf = configuration!.commandOptions?.export?.zip ?? {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -92,7 +92,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.export ? (configuration.commandOptions.export.zip || {}) : {};
+		const conf = configuration!.commandOptions?.export ? (configuration.commandOptions.export.zip || {}) : {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-extra/src/modify/cli.ts
+++ b/packages/akashic-cli-extra/src/modify/cli.ts
@@ -30,7 +30,7 @@ function defineCommand(commandName: string): void {
 					process.exit(1);
 				}
 
-				const conf = configuration!.commandOptions?.modify || {};
+				const conf = configuration!.commandOptions?.modify ?? {};
 				cliBasicParameter(commandName, value, {
 					cwd: opts.cwd ?? conf.cwd,
 					quiet: opts.quiet ?? conf.quiet

--- a/packages/akashic-cli-extra/src/modify/cli.ts
+++ b/packages/akashic-cli-extra/src/modify/cli.ts
@@ -30,7 +30,7 @@ function defineCommand(commandName: string): void {
 					process.exit(1);
 				}
 
-				const conf = configuration!.commandOptions.modify || {};
+				const conf = configuration!.commandOptions?.modify || {};
 				cliBasicParameter(commandName, value, {
 					cwd: opts.cwd ?? conf.cwd,
 					quiet: opts.quiet ?? conf.quiet

--- a/packages/akashic-cli-extra/src/stat/cli.ts
+++ b/packages/akashic-cli-extra/src/stat/cli.ts
@@ -59,7 +59,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.stat || {};
+		const conf = configuration!.commandOptions?.stat ?? {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-extra/src/stat/cli.ts
+++ b/packages/akashic-cli-extra/src/stat/cli.ts
@@ -59,7 +59,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.stat || {};
+		const conf = configuration!.commandOptions?.stat || {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -60,7 +60,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.init || {};
+		const conf = configuration!.commandOptions?.init || {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -60,7 +60,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.init || {};
+		const conf = configuration!.commandOptions?.init ?? {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -47,7 +47,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.install || {};
+		const conf = configuration!.commandOptions?.install ?? {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -47,7 +47,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.install || {};
+		const conf = configuration!.commandOptions?.install || {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
@@ -39,7 +39,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.uninstall || {};
+		const conf = configuration!.commandOptions?.uninstall ?? {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
@@ -39,7 +39,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.uninstall || {};
+		const conf = configuration!.commandOptions?.uninstall || {};
 		cli({
 			args: commander.args ?? conf.args,
 			cwd: options.cwd ?? conf.cwd,

--- a/packages/akashic-cli-lib-manage/src/update/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/update/cli.ts
@@ -34,7 +34,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.update || {};
+		const conf = configuration!.commandOptions?.update || {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-lib-manage/src/update/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/update/cli.ts
@@ -34,7 +34,7 @@ export function run(argv: string[]): void {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.update || {};
+		const conf = configuration!.commandOptions?.update ?? {};
 		cli({
 			cwd: options.cwd ?? conf.cwd,
 			quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -39,7 +39,7 @@ commander
 				process.exit(1);
 			}
 
-			const conf = configuration!.commandOptions.scan ? (configuration.commandOptions.scan.asset ?? {}) : {};
+			const conf = configuration!.commandOptions?.scan ? (configuration.commandOptions.scan.asset ?? {}) : {};
 			const logger = new ConsoleLogger({ quiet: opts.quiet ?? conf.quiet });
 			const assetScanDirectoryTable = {
 				audio: opts.audioAssetDir ?? conf.audioAssetDir,

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -39,7 +39,7 @@ commander
 				process.exit(1);
 			}
 
-			const conf = configuration!.commandOptions?.scan ? (configuration.commandOptions.scan.asset ?? {}) : {};
+			const conf = configuration!.commandOptions?.scan?.asset ?? {};
 			const logger = new ConsoleLogger({ quiet: opts.quiet ?? conf.quiet });
 			const assetScanDirectoryTable = {
 				audio: opts.audioAssetDir ?? conf.audioAssetDir,

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -438,7 +438,7 @@ export async function run(argv: any): Promise<void> {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions?.serve || {};
+		const conf = configuration!.commandOptions?.serve ?? {};
 		const cliConfigParam: CliConfigServe = {
 			port: options.port ?? conf.port,
 			hostname: options.hostname ?? conf.hostname,

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -438,7 +438,7 @@ export async function run(argv: any): Promise<void> {
 			process.exit(1);
 		}
 
-		const conf = configuration!.commandOptions.serve || {};
+		const conf = configuration!.commandOptions?.serve || {};
 		const cliConfigParam: CliConfigServe = {
 			port: options.port ?? conf.port,
 			hostname: options.hostname ?? conf.hostname,


### PR DESCRIPTION
## 概要

akashic.config.js に `commandOptions` がない場合、akashic-cli がクラッシュするため参照している `commandOptions` をオプショナルチェーンとして対応。
