### PR TITLE
add button to send event for test in akashic-cli-serve

### DIFF
--- a/packages/akashic-cli-serve/src/client/common/types/ScenarioEventData.ts
+++ b/packages/akashic-cli-serve/src/client/common/types/ScenarioEventData.ts
@@ -1,0 +1,11 @@
+type CommandName = "screenshot" | "finish";
+
+export interface ScenarioEventData {
+	type: "scenario";
+	command: {
+		name: CommandName;
+		options?: {
+			fileName: string;
+		};
+	};
+}

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -7,6 +7,7 @@ const TOOL_BAR_HEIGHT = 33;  // 厳密なツールバーの高さはフォント
 
 export class PlayOperator {
 	private store: Store;
+	private screenshotCount = 0;
 
 	constructor(store: Store) {
 		this.store = store;
@@ -32,6 +33,32 @@ export class PlayOperator {
 		} else {
 			this.store.currentPlay.leave(this.store.player.id);
 		}
+	};
+
+	sendScreenshotEvent = (): void => {
+		this.store.currentPlay.sendScenarioEvent(
+			this.store.player.id,
+			{
+				type: "scenario",
+				command: {
+					name: "screenshot",
+					options: { fileName: `screenshot_${this.screenshotCount}.png` }
+				}
+			}
+		);
+		this.screenshotCount++;
+	};
+
+	sendFinishEvent = (): void => {
+		this.store.currentPlay.sendScenarioEvent(
+			this.store.player.id,
+			{
+				type: "scenario",
+				command: {
+					name: "finish"
+				}
+			}
+		);
 	};
 
 	openNewClientInstance = (): void => {

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -13,6 +13,7 @@ import type { GameViewManager } from "../akashic/GameViewManager";
 import { SocketIOAMFlowClient } from "../akashic/SocketIOAMFlowClient";
 import { apiClient } from "../api/apiClientInstance";
 import { socketInstance } from "../api/socketInstance";
+import type { ScenarioEventData } from "../common/types/ScenarioEventData";
 import type { ContentEntity } from "./ContentEntity";
 import type { ExecutionMode } from "./ExecutionMode";
 import { LocalInstanceEntity } from "./LocalInstanceEntity";
@@ -163,6 +164,10 @@ export class PlayEntity {
 	leave(playerId: string): void {
 		const highestPriority = 3;
 		this.amflow.enqueueEvent([playlog.EventCode.Leave, highestPriority, playerId]);
+	}
+
+	sendScenarioEvent(playerId: string, data: ScenarioEventData): void {
+		this.amflow.sendEvent([playlog.EventCode.Message, 0, playerId, data]);
 	}
 
 	pauseActive(): void {

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -125,8 +125,7 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				onUseStopGameChanged: operator.devtool.toggleUseStopGame,
 				onTotalTimeLimitInputValueChanged: operator.devtool.setTotalTimeLimitInputValue
 			}}
-			miscDevtoolProps={{
-				downloadPlaylog: operator.play.downloadPlaylog,
+			internalDevtoolProps={{
 				sendScreenshotEvent: operator.play.sendScreenshotEvent,
 				sendFinishEvent: operator.play.sendFinishEvent
 			}}

--- a/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/DevtoolContainer.tsx
@@ -126,7 +126,9 @@ export class DevtoolContainer extends React.Component<DevtoolContainerProps, {}>
 				onTotalTimeLimitInputValueChanged: operator.devtool.setTotalTimeLimitInputValue
 			}}
 			miscDevtoolProps={{
-				downloadPlaylog: operator.play.downloadPlaylog
+				downloadPlaylog: operator.play.downloadPlaylog,
+				sendScreenshotEvent: operator.play.sendScreenshotEvent,
+				sendFinishEvent: operator.play.sendFinishEvent
 			}}
 		/>;
 	}

--- a/packages/akashic-cli-serve/src/client/view/molecule/InternalDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/InternalDevtool.tsx
@@ -2,37 +2,29 @@ import { observer } from "mobx-react";
 import * as React from "react";
 import { ToolLabelButton } from "../atom/ToolLabelButton";
 
-export interface MiscDevtoolProps {
-	downloadPlaylog: () => void;
+export interface InternalDevtoolProps {
 	sendScreenshotEvent: () => void;
 	sendFinishEvent: () => void;
 }
 
 @observer
 // 現状のUIでカテゴリ分けが難しいものを暫定的に置くためのタグ
-export class MiscDevtool extends React.Component<MiscDevtoolProps, {}> {
+export class InternalDevtool extends React.Component<InternalDevtoolProps, {}> {
 	render(): React.ReactNode {
 		return <div>
 			<ToolLabelButton
-				className="external-ref_button_download-playlog"
-				title="今までのリプレイ情報を保存"
-				onClick={this.props.downloadPlaylog}
-			>
-				今までのリプレイ情報を保存
-			</ToolLabelButton>
-			<ToolLabelButton
 				className="external-ref_button_send-screenshot-event"
-				title="Playlogにtype:screenshotのEvent追加(テスト用)"
+				title="コンテンツにtype:screenshotのMessageEvent送信(テスト用)"
 				onClick={this.props.sendScreenshotEvent}
 			>
-				Playlogにtype:screenshotのEvent追加(テスト用)
+				コンテンツにtype:screenshotのMessageEvent送信(テスト用)
 			</ToolLabelButton>
 			<ToolLabelButton
 				className="external-ref_button_send-finish-event"
-				title="Playlogにtype:finishのEvent追加(テスト用)"
+				title="コンテンツにtype:finishのMessageEvent送信(テスト用)"
 				onClick={this.props.sendFinishEvent}
 			>
-				Playlogにtype:finishのEvent追加(テスト用)
+				コンテンツにtype:finishのMessageEvent送信(テスト用)
 			</ToolLabelButton>
 		</div>;
 	}

--- a/packages/akashic-cli-serve/src/client/view/molecule/MiscDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/MiscDevtool.tsx
@@ -4,6 +4,8 @@ import { ToolLabelButton } from "../atom/ToolLabelButton";
 
 export interface MiscDevtoolProps {
 	downloadPlaylog: () => void;
+	sendScreenshotEvent: () => void;
+	sendFinishEvent: () => void;
 }
 
 @observer
@@ -17,6 +19,20 @@ export class MiscDevtool extends React.Component<MiscDevtoolProps, {}> {
 				onClick={this.props.downloadPlaylog}
 			>
 				今までのリプレイ情報を保存
+			</ToolLabelButton>
+			<ToolLabelButton
+				className="external-ref_button_send-screenshot-event"
+				title="Playlogにtype:screenshotのEvent追加(テスト用)"
+				onClick={this.props.sendScreenshotEvent}
+			>
+				Playlogにtype:screenshotのEvent追加(テスト用)
+			</ToolLabelButton>
+			<ToolLabelButton
+				className="external-ref_button_send-finish-event"
+				title="Playlogにtype:finishのEvent追加(テスト用)"
+				onClick={this.props.sendFinishEvent}
+			>
+				Playlogにtype:finishのEvent追加(テスト用)
 			</ToolLabelButton>
 		</div>;
 	}

--- a/packages/akashic-cli-serve/src/client/view/organism/Devtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/organism/Devtool.tsx
@@ -10,8 +10,8 @@ import type { EventsDevtoolProps } from "../molecule/EventsDevtool";
 import { EventsDevtool } from "../molecule/EventsDevtool";
 import type { InstancesDevtoolProps } from "../molecule/InstancesDevtool";
 import { InstancesDevtool } from "../molecule/InstancesDevtool";
-import type { MiscDevtoolProps } from "../molecule/MiscDevtool";
-import { MiscDevtool } from "../molecule/MiscDevtool";
+import type { InternalDevtoolProps } from "../molecule/InternalDevtool";
+import { InternalDevtool } from "../molecule/InternalDevtool";
 import type { NiconicoDevtoolProps } from "../molecule/NiconicoDevtool";
 import { NiconicoDevtool } from "../molecule/NiconicoDevtool";
 import type { PlaybackDevtoolProps } from "../molecule/PlaybackDevtool";
@@ -26,7 +26,7 @@ export const devtoolTypes = [
 	"EntityTree",
 	"Atsumaru",
 	"Niconico",
-	"Misc"
+	"Internal"
 ];
 
 export type DevtoolType = typeof devtoolTypes[number];
@@ -43,7 +43,7 @@ export interface DevtoolProps {
 	entityTreeDevtoolProps: EntityTreeDevtoolProps;
 	atsumaruDevtoolProps: AtsumaruDevtoolProps;
 	niconicoDevtoolProps: NiconicoDevtoolProps;
-	miscDevtoolProps: MiscDevtoolProps;
+	internalDevtoolProps: InternalDevtoolProps;
 }
 
 @observer
@@ -59,7 +59,7 @@ export class Devtool extends React.Component<DevtoolProps, {}> {
 			"EntityTree": this._onSelectEntityListTool,
 			"Atsumaru": this._onSelectAtsumaruTool,
 			"Niconico": this._onSelectNiconicoTool,
-			"Misc": this._onSelectMiscTool,
+			"Internal": this._onSelectInternalTool,
 		};
 	}
 
@@ -81,7 +81,7 @@ export class Devtool extends React.Component<DevtoolProps, {}> {
 				{ (activeDevtool === "EntityTree") && <EntityTreeDevtool {...props.entityTreeDevtoolProps} /> }
 				{ (activeDevtool === "Atsumaru") && <AtsumaruDevtool {...props.atsumaruDevtoolProps} /> }
 				{ (activeDevtool === "Niconico") && <NiconicoDevtool {...props.niconicoDevtoolProps} /> }
-				{ (activeDevtool === "Misc") && <MiscDevtool {...props.miscDevtoolProps} /> }
+				{ (activeDevtool === "Internal") && <InternalDevtool {...props.internalDevtoolProps} /> }
 			</div>
 		</TopResizable>;
 	}
@@ -110,7 +110,7 @@ export class Devtool extends React.Component<DevtoolProps, {}> {
 		this.props.onSelectDevtool("Niconico");
 	};
 
-	private _onSelectMiscTool = (): void => {
-		this.props.onSelectDevtool("Misc");
+	private _onSelectInternalTool = (): void => {
+		this.props.onSelectDevtool("Internal");
 	};
 }

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -263,8 +263,7 @@ const TestWithBehaviour = observer(() => (
 			dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 		}}
 		niconicoDevtoolProps={nicoProps}
-		miscDevtoolProps={{
-			downloadPlaylog: action("download-playlog"),
+		internalDevtoolProps={{
 			sendScreenshotEvent: action("send-screenshot-event"),
 			sendFinishEvent: action("send-finish-event")
 		}}
@@ -370,8 +369,7 @@ storiesOf("o-Devtool", module)
 				dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 			}}
 			niconicoDevtoolProps={nicoProps}
-			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog"),
+			internalDevtoolProps={{
 				sendScreenshotEvent: action("send-screenshot-event"),
 				sendFinishEvent: action("send-finish-event")
 			}}
@@ -467,8 +465,7 @@ storiesOf("o-Devtool", module)
 				dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 			}}
 			niconicoDevtoolProps={nicoProps}
-			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog"),
+			internalDevtoolProps={{
 				sendScreenshotEvent: action("send-screenshot-event"),
 				sendFinishEvent: action("send-finish-event")
 			}}
@@ -568,8 +565,7 @@ storiesOf("o-Devtool", module)
 				dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 			}}
 			niconicoDevtoolProps={nicoProps}
-			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog"),
+			internalDevtoolProps={{
 				sendScreenshotEvent: action("send-screenshot-event"),
 				sendFinishEvent: action("send-finish-event")
 			}}
@@ -623,8 +619,7 @@ storiesOf("o-Devtool", module)
 				dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 			}}
 			niconicoDevtoolProps={nicoProps}
-			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog"),
+			internalDevtoolProps={{
 				sendScreenshotEvent: action("send-screenshot-event"),
 				sendFinishEvent: action("send-finish-event")
 			}}
@@ -678,8 +673,7 @@ storiesOf("o-Devtool", module)
 				dicideVolume: (v => (store.isSeekingVolume = false, store.volume = v))
 			}}
 			niconicoDevtoolProps={nicoProps}
-			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog"),
+			internalDevtoolProps={{
 				sendScreenshotEvent: action("send-screenshot-event"),
 				sendFinishEvent: action("send-finish-event")
 			}}

--- a/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/Devtool.stories.tsx
@@ -264,7 +264,9 @@ const TestWithBehaviour = observer(() => (
 		}}
 		niconicoDevtoolProps={nicoProps}
 		miscDevtoolProps={{
-			downloadPlaylog: action("download-playlog")
+			downloadPlaylog: action("download-playlog"),
+			sendScreenshotEvent: action("send-screenshot-event"),
+			sendFinishEvent: action("send-finish-event")
 		}}
 	/>
 ));
@@ -369,7 +371,9 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog")
+				downloadPlaylog: action("download-playlog"),
+				sendScreenshotEvent: action("send-screenshot-event"),
+				sendFinishEvent: action("send-finish-event")
 			}}
 		/>
 	))
@@ -464,7 +468,9 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog")
+				downloadPlaylog: action("download-playlog"),
+				sendScreenshotEvent: action("send-screenshot-event"),
+				sendFinishEvent: action("send-finish-event")
 			}}
 		/>
 	))
@@ -563,7 +569,9 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog")
+				downloadPlaylog: action("download-playlog"),
+				sendScreenshotEvent: action("send-screenshot-event"),
+				sendFinishEvent: action("send-finish-event")
 			}}
 		/>
 	))
@@ -616,7 +624,9 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog")
+				downloadPlaylog: action("download-playlog"),
+				sendScreenshotEvent: action("send-screenshot-event"),
+				sendFinishEvent: action("send-finish-event")
 			}}
 		/>
 	))
@@ -669,7 +679,9 @@ storiesOf("o-Devtool", module)
 			}}
 			niconicoDevtoolProps={nicoProps}
 			miscDevtoolProps={{
-				downloadPlaylog: action("download-playlog")
+				downloadPlaylog: action("download-playlog"),
+				sendScreenshotEvent: action("send-screenshot-event"),
+				sendFinishEvent: action("send-finish-event")
 			}}
 		/>
 	))


### PR DESCRIPTION
### やったこと
akashic-cli-serveのDevtoolのMiscタブに以下の2つのボタンを追加しました。
* type:screenshotのMessageEventをコンテンツに送信
* type:finishのMessageEventをコンテンツに送信

エンジンのテストのための補助ツールなので、ゲーム開発者ではなくエンジン開発者が利用する想定です。