### PR TITLE
fix(serve): add initialization waiting

### DIFF
--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -56,7 +56,8 @@ export class PlayStore {
 		this._lastPlayId = null;
 		this._contentStore = param.contentStore;
 		this._creationWaiters = Object.create(null);
-		this._initializationWaiter = apiClient.getPlays()
+		this._initializationWaiter = this._contentStore.assertInitialized()
+			.then(() => apiClient.getPlays())
 			.then((res) => {
 				const playsInfo = res.data;
 				return Promise.all(playsInfo.map((playInfo) => {


### PR DESCRIPTION
掲題どおり。

`this._contentStore.find()` を呼び出す時点で初期化が終わっていない可能性があるので、 `assetInitialized()` の完了を待ちます。

動作確認: `ContentStore#_initialize()` の冒頭にダミーの待ち時間 10 秒を加えて実行し、ブラウザウィンドウで正常にインスタンス実行が始まることを確認しています。
