### PR TITLE
faet(serve): add --debug-pause-active

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -9,6 +9,7 @@ export interface CliConfigServe {
 	debugPlaylog?: string;
 	debugUntrusted?: boolean;
 	debugProxyAudio?: boolean;
+	debugPauseActive?: boolean;
 	allowExternal?: boolean;
 	targetDirs?: string[];
 	openBrowser?: boolean;

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -44,6 +44,7 @@ akashic-cli-serve [<options>] [<path>]
 |`--watch`|`-w`|アセットディレクトリを監視し、変更時に新規プレイを作成します。|N/A|
 |`--server-external-script <filepath>`|N/A|指定ファイルの js を評価し、アクティブインスタンスの g.game.external に代入します。|N/A|
 |`--debug-playlog <path>`|N/A|指定した playlog.json を読み込みます(エンジン開発用、または開発中のオプションです)。|N/A|
+|`--debug-pause-active`|N/A|アクティブインスタンスをポーズした状態でプレイを開始します。(エンジン開発用のオプションです)|N/A|
 |`--allow-external`|N/A|外部アセットを許可します。許可する値は sandbox.config.js から読み込みます。|N/A|
 |`--no-open-browser`|N/A|起動時に自動でブラウザを開かないようにします。|N/A|
 |`--preserve-disconnected`|N/A|サーバ切断時に開いている子ウィンドウを閉じないようにします。|N/A|

--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.15.11",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.14.0",
+        "@akashic/akashic-cli-commons": "0.14.3",
         "@akashic/akashic-cli-scan": "0.16.0",
         "@akashic/amflow-util": "^1.2.0",
         "@akashic/game-configuration": "^1.8.0",
@@ -87,38 +87,17 @@
       }
     },
     "node_modules/@akashic/akashic-cli-commons": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.0.tgz",
-      "integrity": "sha512-yg4EEg1qgng/nPtjQUQlbE+2gL6H62f9pkmrwe0cxJrN0SmETv7ZDZztDslmNHXBnbyuc2VsU7iaBO+DNZAS6w==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.3.tgz",
+      "integrity": "sha512-9CqeN/4l0vVa7A4l8kK7orlzL6cQXs42yoKaHnNDKodnd43/O0rEJFitt4N7My7jv0Hm5qA4d8t5rKGSB6XwMA==",
       "dependencies": {
-        "@akashic/game-configuration": "1.4.0",
+        "@akashic/game-configuration": "1.8.0",
         "browserify": "17.0.0",
         "editorconfig": "^1.0.1",
-        "eslint": "8.26.0",
+        "eslint": "8.27.0",
         "fs-extra": "10.1.0",
         "fs-readdir-recursive": "1.1.0",
         "js-sha256": "^0.9.0"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/@akashic/game-configuration": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
-      "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
-      "dependencies": {
-        "@akashic/pdi-types": "~1.3.0"
-      },
-      "optionalDependencies": {
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/@akashic/pdi-types": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
-      "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
-      "dependencies": {
-        "@akashic/amflow": "~3.1.0",
-        "@akashic/playlog": "~3.1.0",
-        "@akashic/trigger": "~1.0.1"
       }
     },
     "node_modules/@akashic/akashic-cli-commons/node_modules/brace-expansion": {
@@ -226,104 +205,12 @@
         "node": ">=10"
       }
     },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/eslint": {
-      "version": "8.26.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
-      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
-      "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.1.1",
-        "eslint-utils": "^3.0.0",
-        "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.4.0",
-        "esquery": "^1.4.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
-        "grapheme-splitter": "^1.0.4",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-sdsl": "^4.1.4",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.1",
-        "regexpp": "^3.2.0",
-        "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/eslint-scope": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/@akashic/akashic-cli-commons/node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@akashic/akashic-cli-commons/node_modules/lru-cache": {
@@ -335,22 +222,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@akashic/akashic-cli-commons/node_modules/optionator": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/@akashic/akashic-cli-commons/node_modules/path-browserify": {
@@ -429,6 +300,334 @@
       "bin": {
         "akashic-cli-scan": "bin/run"
       }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/@akashic/akashic-cli-commons": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.0.tgz",
+      "integrity": "sha512-yg4EEg1qgng/nPtjQUQlbE+2gL6H62f9pkmrwe0cxJrN0SmETv7ZDZztDslmNHXBnbyuc2VsU7iaBO+DNZAS6w==",
+      "dependencies": {
+        "@akashic/game-configuration": "1.4.0",
+        "browserify": "17.0.0",
+        "editorconfig": "^1.0.1",
+        "eslint": "8.26.0",
+        "fs-extra": "10.1.0",
+        "fs-readdir-recursive": "1.1.0",
+        "js-sha256": "^0.9.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/@akashic/game-configuration": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
+      "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
+      "dependencies": {
+        "@akashic/pdi-types": "~1.3.0"
+      },
+      "optionalDependencies": {
+        "es6-promise": "^4.2.8"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/@akashic/pdi-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
+      "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
+      "dependencies": {
+        "@akashic/amflow": "~3.1.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/browserify": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
+      "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+      "dependencies": {
+        "assert": "^1.4.0",
+        "browser-pack": "^6.0.1",
+        "browser-resolve": "^2.0.0",
+        "browserify-zlib": "~0.2.0",
+        "buffer": "~5.2.1",
+        "cached-path-relative": "^1.0.0",
+        "concat-stream": "^1.6.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "~1.0.0",
+        "crypto-browserify": "^3.0.0",
+        "defined": "^1.0.0",
+        "deps-sort": "^2.0.1",
+        "domain-browser": "^1.2.0",
+        "duplexer2": "~0.1.2",
+        "events": "^3.0.0",
+        "glob": "^7.1.0",
+        "has": "^1.0.0",
+        "htmlescape": "^1.1.0",
+        "https-browserify": "^1.0.0",
+        "inherits": "~2.0.1",
+        "insert-module-globals": "^7.2.1",
+        "JSONStream": "^1.0.3",
+        "labeled-stream-splicer": "^2.0.0",
+        "mkdirp-classic": "^0.5.2",
+        "module-deps": "^6.2.3",
+        "os-browserify": "~0.3.0",
+        "parents": "^1.0.1",
+        "path-browserify": "^1.0.0",
+        "process": "~0.11.0",
+        "punycode": "^1.3.2",
+        "querystring-es3": "~0.2.0",
+        "read-only-stream": "^2.0.0",
+        "readable-stream": "^2.0.2",
+        "resolve": "^1.1.4",
+        "shasum-object": "^1.0.0",
+        "shell-quote": "^1.6.1",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.0.0",
+        "string_decoder": "^1.1.1",
+        "subarg": "^1.0.0",
+        "syntax-error": "^1.1.1",
+        "through2": "^2.0.0",
+        "timers-browserify": "^1.0.1",
+        "tty-browserify": "0.0.1",
+        "url": "~0.11.0",
+        "util": "~0.12.0",
+        "vm-browserify": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "bin": {
+        "browserify": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/editorconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.2.tgz",
+      "integrity": "sha512-l8CnaNCz0dgCqJQ3hKqW2qtUavm1WLdJUvlxufaZ6JDkds3UFxgUKnKJz982yJPYko/78LkWAiwJadFnFtUBjw==",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "6.1.6",
+        "semver": "^7.3.8"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/editorconfig/node_modules/minimatch": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+      "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/eslint": {
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
+      "integrity": "sha512-kzJkpaw1Bfwheq4VXUezFriD1GxszX6dUekM7Z3aC2o4hju+tsR/XyTC3RcoSD7jmy9VkPU3+N6YjVU2e96Oyg==",
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.3",
+        "@humanwhocodes/config-array": "^0.11.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.4.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.15.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+      "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/globals": {
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/stream-browserify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "dependencies": {
+        "inherits": "~2.0.4",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/stream-browserify/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/@akashic/akashic-cli-scan/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@akashic/akashic-engine": {
       "version": "1.14.0",
@@ -23525,38 +23724,19 @@
   },
   "dependencies": {
     "@akashic/akashic-cli-commons": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.0.tgz",
-      "integrity": "sha512-yg4EEg1qgng/nPtjQUQlbE+2gL6H62f9pkmrwe0cxJrN0SmETv7ZDZztDslmNHXBnbyuc2VsU7iaBO+DNZAS6w==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.3.tgz",
+      "integrity": "sha512-9CqeN/4l0vVa7A4l8kK7orlzL6cQXs42yoKaHnNDKodnd43/O0rEJFitt4N7My7jv0Hm5qA4d8t5rKGSB6XwMA==",
       "requires": {
-        "@akashic/game-configuration": "1.4.0",
+        "@akashic/game-configuration": "1.8.0",
         "browserify": "17.0.0",
         "editorconfig": "^1.0.1",
-        "eslint": "8.26.0",
+        "eslint": "8.27.0",
         "fs-extra": "10.1.0",
         "fs-readdir-recursive": "1.1.0",
         "js-sha256": "^0.9.0"
       },
       "dependencies": {
-        "@akashic/game-configuration": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
-          "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
-          "requires": {
-            "@akashic/pdi-types": "~1.3.0",
-            "es6-promise": "^4.2.8"
-          }
-        },
-        "@akashic/pdi-types": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
-          "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
-          "requires": {
-            "@akashic/amflow": "~3.1.0",
-            "@akashic/playlog": "~3.1.0",
-            "@akashic/trigger": "~1.0.1"
-          }
-        },
         "brace-expansion": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -23646,6 +23826,210 @@
             }
           }
         },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "path-browserify": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+          "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "stream-browserify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+          "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+          "requires": {
+            "inherits": "~2.0.4",
+            "readable-stream": "^3.5.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.6.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+              "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
+        },
+        "util": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "is-arguments": "^1.0.4",
+            "is-generator-function": "^1.0.7",
+            "is-typed-array": "^1.1.3",
+            "which-typed-array": "^1.1.2"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "@akashic/akashic-cli-scan": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-scan/-/akashic-cli-scan-0.16.0.tgz",
+      "integrity": "sha512-O9QpJ82FGjYJ9Z7IOQlIxoLWm2QafnjMWC/bXobC5KdwXaKbQAW4Y+q+9g2eaM+YN8ikyidQ7y7fGGKFazWCjQ==",
+      "requires": {
+        "@akashic/akashic-cli-commons": "0.14.0",
+        "aac-duration": "0.0.1",
+        "chokidar": "^3.5.1",
+        "commander": "^8.0.0",
+        "fs-readdir-recursive": "1.1.0",
+        "image-size": "~1.0.0",
+        "music-metadata": "7.13.0",
+        "svgson": "^5.2.1",
+        "thumbcoil": "~1.2.0"
+      },
+      "dependencies": {
+        "@akashic/akashic-cli-commons": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-commons/-/akashic-cli-commons-0.14.0.tgz",
+          "integrity": "sha512-yg4EEg1qgng/nPtjQUQlbE+2gL6H62f9pkmrwe0cxJrN0SmETv7ZDZztDslmNHXBnbyuc2VsU7iaBO+DNZAS6w==",
+          "requires": {
+            "@akashic/game-configuration": "1.4.0",
+            "browserify": "17.0.0",
+            "editorconfig": "^1.0.1",
+            "eslint": "8.26.0",
+            "fs-extra": "10.1.0",
+            "fs-readdir-recursive": "1.1.0",
+            "js-sha256": "^0.9.0"
+          }
+        },
+        "@akashic/game-configuration": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@akashic/game-configuration/-/game-configuration-1.4.0.tgz",
+          "integrity": "sha512-AUfpwCKt2wpLzRrTd2l9KdpWNUR/aKyVDsY+9DPmms8kK2TWZ9vALv+FCliJZzf4zzkfswShcdAHQ4yb+YBa5A==",
+          "requires": {
+            "@akashic/pdi-types": "~1.3.0",
+            "es6-promise": "^4.2.8"
+          }
+        },
+        "@akashic/pdi-types": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.3.1.tgz",
+          "integrity": "sha512-9evGYvwamBRejSnqtPnuf5HNGqofzvQe7qSc+chb4mTq203DSC7ArE4WZ52FuCBHTuxwxB1EpHmLKx1QSX3NAw==",
+          "requires": {
+            "@akashic/amflow": "~3.1.0",
+            "@akashic/playlog": "~3.1.0",
+            "@akashic/trigger": "~1.0.1"
+          }
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "browserify": {
+          "version": "17.0.0",
+          "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
+          "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+          "requires": {
+            "assert": "^1.4.0",
+            "browser-pack": "^6.0.1",
+            "browser-resolve": "^2.0.0",
+            "browserify-zlib": "~0.2.0",
+            "buffer": "~5.2.1",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "^1.6.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "~1.0.0",
+            "crypto-browserify": "^3.0.0",
+            "defined": "^1.0.0",
+            "deps-sort": "^2.0.1",
+            "domain-browser": "^1.2.0",
+            "duplexer2": "~0.1.2",
+            "events": "^3.0.0",
+            "glob": "^7.1.0",
+            "has": "^1.0.0",
+            "htmlescape": "^1.1.0",
+            "https-browserify": "^1.0.0",
+            "inherits": "~2.0.1",
+            "insert-module-globals": "^7.2.1",
+            "JSONStream": "^1.0.3",
+            "labeled-stream-splicer": "^2.0.0",
+            "mkdirp-classic": "^0.5.2",
+            "module-deps": "^6.2.3",
+            "os-browserify": "~0.3.0",
+            "parents": "^1.0.1",
+            "path-browserify": "^1.0.0",
+            "process": "~0.11.0",
+            "punycode": "^1.3.2",
+            "querystring-es3": "~0.2.0",
+            "read-only-stream": "^2.0.0",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.4",
+            "shasum-object": "^1.0.0",
+            "shell-quote": "^1.6.1",
+            "stream-browserify": "^3.0.0",
+            "stream-http": "^3.0.0",
+            "string_decoder": "^1.1.1",
+            "subarg": "^1.0.0",
+            "syntax-error": "^1.1.1",
+            "through2": "^2.0.0",
+            "timers-browserify": "^1.0.1",
+            "tty-browserify": "0.0.1",
+            "url": "~0.11.0",
+            "util": "~0.12.0",
+            "vm-browserify": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "editorconfig": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.2.tgz",
+          "integrity": "sha512-l8CnaNCz0dgCqJQ3hKqW2qtUavm1WLdJUvlxufaZ6JDkds3UFxgUKnKJz982yJPYko/78LkWAiwJadFnFtUBjw==",
+          "requires": {
+            "@one-ini/wasm": "0.1.1",
+            "commander": "^10.0.0",
+            "minimatch": "6.1.6",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
+              "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA=="
+            },
+            "minimatch": {
+              "version": "6.1.6",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.1.6.tgz",
+              "integrity": "sha512-6bR3UIeh/DF8+p6A9Spyuy67ShOq42rOkHWi7eUe3Ua99Zo5lZfGC6lJJWkeoK4k9jQFT3Pl7czhTXimG2XheA==",
+              "requires": {
+                "brace-expansion": "^2.0.1"
+              }
+            }
+          }
+        },
         "eslint": {
           "version": "8.26.0",
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.26.0.tgz",
@@ -23715,9 +24099,9 @@
           }
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.20.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -23794,22 +24178,6 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
-      }
-    },
-    "@akashic/akashic-cli-scan": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-cli-scan/-/akashic-cli-scan-0.16.0.tgz",
-      "integrity": "sha512-O9QpJ82FGjYJ9Z7IOQlIxoLWm2QafnjMWC/bXobC5KdwXaKbQAW4Y+q+9g2eaM+YN8ikyidQ7y7fGGKFazWCjQ==",
-      "requires": {
-        "@akashic/akashic-cli-commons": "0.14.0",
-        "aac-duration": "0.0.1",
-        "chokidar": "^3.5.1",
-        "commander": "^8.0.0",
-        "fs-readdir-recursive": "1.1.0",
-        "image-size": "~1.0.0",
-        "music-metadata": "7.13.0",
-        "svgson": "^5.2.1",
-        "thumbcoil": "~1.2.0"
       }
     },
     "@akashic/akashic-engine": {

--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -13,7 +13,7 @@
         "@akashic/akashic-cli-scan": "0.16.0",
         "@akashic/amflow-util": "^1.2.0",
         "@akashic/game-configuration": "^1.8.0",
-        "@akashic/headless-driver": "2.5.2",
+        "@akashic/headless-driver": "2.6.0",
         "@akashic/sandbox-configuration": "^2.3.0",
         "@akashic/trigger": "1.0.1",
         "@msgpack/msgpack": "2.8.0",
@@ -720,9 +720,9 @@
       }
     },
     "node_modules/@akashic/headless-driver": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.5.2.tgz",
-      "integrity": "sha512-YDeszesfrJRbaiXkeMcXwlcQBoSRC8VWNCdt+cghdAxf8ZfkUA0zhxXP3xhsayrd+63RBimsW3S3+cdygtqn5g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.6.0.tgz",
+      "integrity": "sha512-B43zjP9gpTqO0ZW/CKMGOVnvJ8QW1E2hqKTqGGCPK52ZtkA2lUrIcWS4arN/WLN297MZlyXFscd2hoEIvYc0+g==",
       "dependencies": {
         "@akashic/amflow": "^3.1.0",
         "@akashic/playlog": "^3.1.0",
@@ -24260,9 +24260,9 @@
       }
     },
     "@akashic/headless-driver": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.5.2.tgz",
-      "integrity": "sha512-YDeszesfrJRbaiXkeMcXwlcQBoSRC8VWNCdt+cghdAxf8ZfkUA0zhxXP3xhsayrd+63RBimsW3S3+cdygtqn5g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.6.0.tgz",
+      "integrity": "sha512-B43zjP9gpTqO0ZW/CKMGOVnvJ8QW1E2hqKTqGGCPK52ZtkA2lUrIcWS4arN/WLN297MZlyXFscd2hoEIvYc0+g==",
       "requires": {
         "@akashic/amflow": "^3.1.0",
         "@akashic/playlog": "^3.1.0",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -25,7 +25,7 @@
     "akashic-cli-serve": "./bin/run"
   },
   "dependencies": {
-    "@akashic/akashic-cli-commons": "0.14.0",
+    "@akashic/akashic-cli-commons": "0.14.3",
     "@akashic/akashic-cli-scan": "0.16.0",
     "@akashic/amflow-util": "^1.2.0",
     "@akashic/game-configuration": "^1.8.0",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -29,7 +29,7 @@
     "@akashic/akashic-cli-scan": "0.16.0",
     "@akashic/amflow-util": "^1.2.0",
     "@akashic/game-configuration": "^1.8.0",
-    "@akashic/headless-driver": "2.5.2",
+    "@akashic/headless-driver": "2.6.0",
     "@akashic/sandbox-configuration": "^2.3.0",
     "@akashic/trigger": "1.0.1",
     "@msgpack/msgpack": "2.8.0",

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -81,10 +81,10 @@ export class ApiClient {
 		);
 	};
 
-	async createRunner(playId: string, isActive: boolean, token: string): Promise<RunnerPostApiResponse> {
+	async createRunner(playId: string, isActive: boolean, token: string, isPaused: boolean = false): Promise<RunnerPostApiResponse> {
 		return ApiRequest.post<RunnerPostApiResponse>(
 			`${this._baseUrl}/api/runners`,
-			{playId, isActive: isActive.toString(), token}
+			{playId, isActive: isActive.toString(), token, isPaused: isPaused.toString() }
 		);
 	};
 

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -194,8 +194,10 @@ export class Operator {
 		const content = this.store.contentStore.find(contentLocator);
 		const play = await this.store.playStore.createPlay({ contentLocator, audioState });
 		const tokenResult = await apiClient.createPlayToken(play.playId, "", true);  // TODO 空文字列でなくnullを使う
-		await play.createServerInstance({ playToken: tokenResult.data.playToken });
-		await apiClient.resumePlayDuration(play.playId);
+		const { pauseActive } = this.store.appOptions;
+		await play.createServerInstance({ playToken: tokenResult.data.playToken, isPaused: pauseActive });
+		if (!pauseActive)
+			await apiClient.resumePlayDuration(play.playId);
 
 		// autoSendEvents
 		const sandboxConfig = content.sandboxConfig;

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -34,6 +34,7 @@ export interface CreateLocalInstanceParameterObject {
 
 export interface CreateServerInstanceParameterObject {
 	playToken: string;
+	isPaused: boolean;
 }
 
 export interface PlayEntityParameterObject {
@@ -142,7 +143,7 @@ export class PlayEntity {
 	}
 
 	async createServerInstance(param: CreateServerInstanceParameterObject): Promise<ServerInstanceEntity> {
-		const runnerResult = await apiClient.createRunner(this.playId, true, param.playToken);
+		const runnerResult = await apiClient.createRunner(this.playId, true, param.playToken, param.isPaused);
 		const runnerId = runnerResult.data.runnerId;
 
 		// apiClient.createRunner() に対する onRunnerCreate 通知が先行していれば、この時点で ServerInstanceEntity が生成済みになっている

--- a/packages/akashic-cli-serve/src/client/tsconfig.module.json
+++ b/packages/akashic-cli-serve/src/client/tsconfig.module.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "sourceMap": true,
     "outDir": "../../lib/module",
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "types": ["node"]
   },
   "include": [
     "./akashic/**/*.ts",

--- a/packages/akashic-cli-serve/src/common/types/AppOptions.ts
+++ b/packages/akashic-cli-serve/src/common/types/AppOptions.ts
@@ -4,6 +4,7 @@ export interface AppOptions {
 	autoStart: boolean;
 	verbose: boolean;
 	proxyAudio: boolean;
+	pauseActive: boolean;
 	targetService: ServiceType;
 	preserveDisconnected: boolean;
 	experimentalOpen: number | null;

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -9,6 +9,7 @@ export interface ServerGlobalConfig {
 	verbose: boolean;
 	untrusted: boolean; // 簡易対応。究極的にはコンテンツごとに指定されるべき値
 	proxyAudio: boolean;
+	pauseActive: boolean;
 	targetService: ServiceType;
 	allowExternal: boolean;
 	preserveDisconnected: boolean;
@@ -28,6 +29,7 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	verbose: false,
 	untrusted: false,
 	proxyAudio: false,
+	pauseActive: false,
 	targetService: "none",
 	allowExternal: false,
 	preserveDisconnected: false,

--- a/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/RunnerController.ts
@@ -25,10 +25,11 @@ export const createHandlerToCreateRunner = (
 			if (!playInfo)
 				throw new BadRequestError({ errorMessage: `Play not found for ${playId}` });
 			const contentId = playInfo.contentLocatorData.contentId!;
-			const isActive = Boolean(req.body.isActive);
+			const isActive = (req.body.isActive === "true");
+			const isPaused = (req.body.isPaused === "true");
 			const token = req.body.token;
 			const amflow = playStore.createAMFlow(playId);
-			const runner = await runnerStore.createAndStartRunner({ playId, isActive, token, amflow, contentId });
+			const runner = await runnerStore.createAndStartRunner({ playId, isActive, token, amflow, contentId, isPaused });
 			responseSuccess<RunnerPostApiResponseData>(res, 200, { playId: runner.playId, runnerId: runner.runnerId });
 		} catch (e) {
 			next(e);

--- a/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
@@ -10,6 +10,7 @@ export const handleToGetStartupOptions = (_req: express.Request, res: express.Re
 			verbose: serverGlobalConfig.verbose,
 			targetService: serverGlobalConfig.targetService,
 			proxyAudio: serverGlobalConfig.proxyAudio,
+			pauseActive: serverGlobalConfig.pauseActive,
 			preserveDisconnected: serverGlobalConfig.preserveDisconnected,
 			experimentalOpen: serverGlobalConfig.experimentalOpen
 		});

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -22,6 +22,7 @@ export interface CreateAndStartRunnerParameterObject {
 	token: string;
 	amflow: AMFlowClient;
 	contentId: string;
+	isPaused: boolean;
 }
 
 export class RunnerStore {
@@ -79,6 +80,9 @@ export class RunnerStore {
 		await this.runnerManager.startRunner(runner.runnerId);
 		this.onRunnerCreate.fire({ playId: params.playId, runnerId, isActive: params.isActive });
 		this.playIdTable[runnerId] = params.playId;
+
+		if (params.isPaused)
+			this.pauseRunner(runnerId);
 		return runner;
 	}
 

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -77,12 +77,11 @@ export class RunnerStore {
 		}
 
 		const runner = this.runnerManager.getRunner(runnerId)!;
-		await this.runnerManager.startRunner(runner.runnerId);
+		await this.runnerManager.startRunner(runner.runnerId, { paused: params.isPaused });
 		this.onRunnerCreate.fire({ playId: params.playId, runnerId, isActive: params.isActive });
-		this.playIdTable[runnerId] = params.playId;
-
 		if (params.isPaused)
-			this.pauseRunner(runnerId);
+			this.onRunnerPause.fire({ playId: params.playId, runnerId });
+		this.playIdTable[runnerId] = params.playId;
 		return runner;
 	}
 

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -47,6 +47,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 
 	serverGlobalConfig.untrusted = !!cliConfigParam.debugUntrusted;
 	serverGlobalConfig.proxyAudio = !!cliConfigParam.debugProxyAudio;
+	serverGlobalConfig.pauseActive = !!cliConfigParam.debugPauseActive;
 	serverGlobalConfig.preserveDisconnected = !!cliConfigParam.preserveDisconnected;
 
 	if (cliConfigParam.hostname) {
@@ -251,7 +252,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 				const playId = await playStore.createPlay(new ServerContentLocator({ contentId }), audioState, undefined);
 				const token = amflowManager.createPlayToken(playId, "", "", true, {});
 				const amflow = playStore.createAMFlow(playId);
-				await runnerStore.createAndStartRunner({ playId, isActive: true, token, amflow, contentId });
+				await runnerStore.createAndStartRunner({ playId, isActive: true, token, amflow, contentId, isPaused: false });
 				await playStore.resumePlayDuration(playId);
 				targetPlayIds.forEach(id => {
 					io.emit("playBroadcast", { playId: id, message: { type: "switchPlay", nextPlayId: playId } });
@@ -420,6 +421,7 @@ export async function run(argv: any): Promise<void> {
 		.option("--debug-playlog <path>", "Specify path of playlog-json.")
 		.option("--debug-untrusted", "An internal debug option")
 		.option("--debug-proxy-audio", "An internal debug option")
+		.option("--debug-pause-active", "An internal debug options: start with paused the active instance")
 		.option("--allow-external", "Read the URL allowing external access from sandbox.config.js")
 		.option("--no-open-browser", "Disable to open a browser window at startup")
 		.option("--preserve-disconnected", "Disable auto closing for disconnected windows.")
@@ -447,6 +449,7 @@ export async function run(argv: any): Promise<void> {
 			debugPlaylog: options.debugPlaylog ?? conf.debugPlaylog,
 			debugUntrusted: options.debugUntrusted ?? conf.debugUntrusted,
 			debugProxyAudio: options.debugProxyAudio ?? conf.debugProxyAudio,
+			debugPauseActive: options.debugPauseActive ?? conf.debugPauseActive,
 			allowExternal: options.allowExternal ?? conf.allowExternal,
 			targetDirs: commander.args.length > 0 ? commander.args : (conf.targetDirs ?? [process.cwd()]),
 			openBrowser: options.openBrowser ?? conf.openBrowser,


### PR DESCRIPTION
掲題どおり。

serve で、アクティブインスタンスをポーズした状態でプレイを開始するオプション `--debug-pause-active` を追加します。

~~別件で、https://github.com/akashic-games/headless-driver/pull/584 の修正が入らないと動作がかくつく不具合がありますが、この PR には関係ないこと、この PR はデバッグ用機能であることから独立の PR としています。~~ 追記: PR 指摘の別の問題対処のために当該 PR を含む headless-driver@2.6.0 まで取り込みました。
