### PR TITLE
Fix subcommand version for akashic-cli

### DIFF
--- a/packages/akashic-cli/src/ui.ts
+++ b/packages/akashic-cli/src/ui.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { Command } from "commander";
-var ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
+const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "package.json"), "utf8")).version;
 
 const commander = new Command();
 commander
@@ -18,4 +18,5 @@ commander
 	.command("export", "Export a directory as a specified format")
 	.command("stat", "Show statistics information")
 	.command("serve", "Start a server that hosts a game to test multiplaying")
+	.passThroughOptions()
 	.parse(process.argv);


### PR DESCRIPTION
## 概要

akashic-cli のサブコマンド(akashic xxxx -V)の `-V` でサブコマンドのバージョンが表示されるように修正。


それぞれのパッケージにバージョン表示のロジックは入っているが、親に同じオプション(`-V`) がある場合、デフォルトではサブコマンドにはオプションが渡っていなかったため、親のバージョンが表示されていた。
`passThroughOptions()` を追加しサブコマンドにオプションを渡せるように修正。