### PR TITLE
Fix scriptAsset update for watch option in serve

### DIFF
--- a/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ScriptAssetController.ts
@@ -23,14 +23,12 @@ export const createScriptAssetController = (baseDir: string, index: number): exp
 			if (! ("gScriptContainer" in window)) {
 				window.gScriptContainer = {};
 			}
-			if (! gScriptContainer["${key}"]) {
- 				gScriptContainer["${key}"] = function(g) {
-					var Math = window.akashicServe.scriptHelper.overrides.MeddlingMath;
+			gScriptContainer["${key}"] = function(g) {
+				var Math = window.akashicServe.scriptHelper.overrides.MeddlingMath;
 
-					(function(exports, require, module, __filename, __dirname) {
-						${content}
-					})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);
-				}
+				(function(exports, require, module, __filename, __dirname) {
+					${content}
+				})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);
 			}
 		`;
 		res.contentType("text/javascript");


### PR DESCRIPTION
## 概要

akashic-cli-serve の `-w` オプションで スクリプト更新時に反映されない問題を修正。

`ScriptAssetControlle#createScriptAssetController()`  で返されるスクリプト文字列の中で `gScriptContainer` に既にスクリプトが存在すれば上書きしていなかったのでその条件を削除。
