### PR TITLE
fix(serve): fix lost join in -s nicolive mode

### DIFF
--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -10412,6 +10412,16 @@
         "@akashic/trigger": "^1.0.1"
       }
     },
+    "node_modules/engine-files-v3/node_modules/@akashic/pdi-types": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.7.0.tgz",
+      "integrity": "sha512-wTOmdQwdpX1vfV/QK7b5X25/YwnnkudIPDaSUb0pbE+k+w4UNDM15MqOqAZDpclH+jiV+yjwPaQNohsSX+L+Ww==",
+      "dependencies": {
+        "@akashic/amflow": "~3.1.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
+    },
     "node_modules/engine.io": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
@@ -31510,6 +31520,16 @@
           "integrity": "sha512-s4DpDimM/wiC5HJrdg60tE51J0ZIBu0eEcgxR8v8gXGDMyv7Kxf72SivQVZm/HRxbi3xqcE81O+e1EzqNd/t4w==",
           "requires": {
             "@akashic/trigger": "^1.0.1"
+          }
+        },
+        "@akashic/pdi-types": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-types/-/pdi-types-1.7.0.tgz",
+          "integrity": "sha512-wTOmdQwdpX1vfV/QK7b5X25/YwnnkudIPDaSUb0pbE+k+w4UNDM15MqOqAZDpclH+jiV+yjwPaQNohsSX+L+Ww==",
+          "requires": {
+            "@akashic/amflow": "~3.1.0",
+            "@akashic/playlog": "~3.1.0",
+            "@akashic/trigger": "~1.0.1"
           }
         }
       }

--- a/packages/akashic-cli-serve/spec/server/SocketIOAMFlowManagerSpec.js
+++ b/packages/akashic-cli-serve/spec/server/SocketIOAMFlowManagerSpec.js
@@ -51,7 +51,7 @@ describe("SocketIOAMFlowManager", () => {
 				socket = io("http://localhost:" + testServerPort);
 				const contentLocator = new ServerContentLocator({ path: "dummycontenturl" });
 
-				const playId1 = await playStore.createPlay(contentLocator);
+				const playId1 = await playStore.createPlay({ contentLocator });
 				const serverAMFlow = playStore.createAMFlow(playId1);
 				const serverToken = playStore.createPlayToken(playId1, true);
 				const token = amflowManager.createPlayToken(playId1, "playerId0", "john", false, null);
@@ -133,8 +133,8 @@ describe("SocketIOAMFlowManager", () => {
 				socketB = io("http://localhost:" + testServerPort);
 				const contentLocator = new ServerContentLocator({ path: "dummycontenturl" });
 
-				const playId1 = await playStore.createPlay(contentLocator);
-				const playId2 = await playStore.createPlay(contentLocator);
+				const playId1 = await playStore.createPlay({ contentLocator });
+				const playId2 = await playStore.createPlay({ contentLocator });
 				const token1a = amflowManager.createPlayToken(playId1, "playerId0", "john", true, null);
 				const token1p1 = amflowManager.createPlayToken(playId1, "playerId1", "bob", false, null);
 				const token1p2 = amflowManager.createPlayToken(playId1, "playerId2", "jack", false, null);

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../common/types/ApiResponse";
 import type { ContentLocatorData } from "../../common/types/ContentLocatorData";
 import type { PlayAudioState } from "../../common/types/PlayAudioState";
+import { Player } from "../../common/types/Player";
 import * as ApiRequest from "./ApiRequest";
 
 export class ApiClient {
@@ -30,8 +31,19 @@ export class ApiClient {
 		return ApiRequest.get<PlayGetAllApiResponse>(`${this._baseUrl}/api/plays`);
 	};
 
-	async createPlay(contentLocator: ContentLocatorData, audioState?: PlayAudioState): Promise<PlayPostApiResponse> {
-		return ApiRequest.post<PlayPostApiResponse>(`${this._baseUrl}/api/plays`, { contentLocator, audioState });
+	async createPlay(
+		contentLocator: ContentLocatorData,
+		initialJoinPlayer?: Player,
+		inheritsJoinedFromLatest: boolean = false,
+		inheritsAudioFromLatest: boolean = false
+	): Promise<PlayPostApiResponse> {
+		return ApiRequest.post<PlayPostApiResponse>(`${this._baseUrl}/api/plays`, {
+			contentLocator,
+			initialJoinPlayerId: initialJoinPlayer?.id,
+			initialJoinPlayerName: initialJoinPlayer?.name,
+			inheritsJoinedFromLatest,
+			inheritsAudioFromLatest
+		});
 	};
 
 	async suspendPlay(playId: string): Promise<PlayDeleteApiResponse> {

--- a/packages/akashic-cli-serve/src/client/api/ApiClient.ts
+++ b/packages/akashic-cli-serve/src/client/api/ApiClient.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../common/types/ApiResponse";
 import type { ContentLocatorData } from "../../common/types/ContentLocatorData";
 import type { PlayAudioState } from "../../common/types/PlayAudioState";
-import { Player } from "../../common/types/Player";
+import type { Player } from "../../common/types/Player";
 import * as ApiRequest from "./ApiRequest";
 
 export class ApiClient {

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -181,7 +181,8 @@ export class Operator {
 	// TODO: このメソッドの処理は本来サーバー側で行うべき
 	restartWithNewPlay = async (): Promise<void> => {
 		await this.store!.currentPlay!.content.updateSandboxConfig();
-		const play = await this._createServerLoop(this.store.currentPlay!.content.locator, undefined, isServiceTypeNicoliveLike(this.store.targetService), true);
+		const inheritsJoined = isServiceTypeNicoliveLike(this.store.targetService);
+		const play = await this._createServerLoop(this.store.currentPlay!.content.locator, undefined, inheritsJoined, true);
 		await this.store.currentPlay!.deleteAllServerInstances();
 		await apiClient.broadcast(this.store.currentPlay!.playId, { type: "switchPlay", nextPlayId: play.playId });
 		this.ui.hideNotification();
@@ -198,7 +199,12 @@ export class Operator {
 		inheritsAudioFromLatest: boolean
 	): Promise<PlayEntity> {
 		const content = this.store.contentStore.find(contentLocator);
-		const play = await this.store.playStore.createPlay({ contentLocator, initialJoinPlayer, inheritsJoinedFromLatest, inheritsAudioFromLatest });
+		const play = await this.store.playStore.createPlay({
+			contentLocator,
+			initialJoinPlayer,
+			inheritsJoinedFromLatest,
+			inheritsAudioFromLatest
+		});
 		const tokenResult = await apiClient.createPlayToken(play.playId, "", true);  // TODO 空文字列でなくnullを使う
 		const { pauseActive } = this.store.appOptions;
 		await play.createServerInstance({ playToken: tokenResult.data.playToken, isPaused: pauseActive });

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -1,4 +1,5 @@
-import type { PlayAudioState } from "../../common/types/PlayAudioState";
+import { isServiceTypeNicoliveLike } from "../../common/targetServiceUtil";
+import type { Player } from "../../common/types/Player";
 import type { PlayBroadcastTestbedEvent } from "../../common/types/TestbedEvent";
 import type { GameViewManager } from "../akashic/GameViewManager";
 import type { PlayerInfoResolverResultMessage } from "../akashic/plugin/CoeLimitedPlugin";
@@ -13,7 +14,7 @@ import { RPGAtsumaruApi } from "../atsumaru/RPGAtsumaruApi";
 import { ClientContentLocator } from "../common/ClientContentLocator";
 import { createSessionParameter } from "../common/createSessionParameter";
 import { queryParameters as query } from "../common/queryParameters";
-import type {ProfilerValue} from "../common/types/Profiler";
+import type { ProfilerValue } from "../common/types/Profiler";
 import type { ScreenSize } from "../common/types/ScreenSize";
 import type { LocalInstanceEntity } from "../store/LocalInstanceEntity";
 import type { PlayEntity } from "../store/PlayEntity";
@@ -61,6 +62,7 @@ export class Operator {
 	async bootstrap(contentLocator?: ClientContentLocator): Promise<void> {
 		this._initializePlugins(contentLocator || this.store.contentStore.defaultContent().locator);
 		const store = this.store;
+		const initialJoinPlayer = (isServiceTypeNicoliveLike(store.targetService) && store.player) || undefined;
 		let play: PlayEntity | null = null;
 		if (query.playId != null) {
 			play = store.playStore.plays[query.playId];
@@ -68,12 +70,12 @@ export class Operator {
 				throw new Error(`play(id: ${query.playId}) is not found.`);
 			}
 		} else if (contentLocator) {
-			play = await this._createServerLoop(contentLocator);
+			play = await this._createServerLoop(contentLocator, initialJoinPlayer, false, false);
 		} else {
 			play = store.playStore.getLastPlay();
 			if (!play) {
 				const loc = store.contentStore.defaultContent().locator;
-				play = await this._createServerLoop(loc, undefined); // TODO: (起動時の最初のプレイで) audioState を指定する方法
+				play = await this._createServerLoop(loc, initialJoinPlayer, false, false); // TODO: (起動時の最初のプレイで) audioState を指定する方法
 			}
 		}
 		if (store.targetService === "atsumaru:single") {
@@ -114,15 +116,15 @@ export class Operator {
 
 		store.setCurrentPlay(play);
 
-		let isJoin = false;
 		let argument = undefined;
-		if (/^nicolive.*/.test(store.targetService) || store.targetService === "atsumaru:multi") {
+		if (isServiceTypeNicoliveLike(store.targetService)) {
+			let isBroadcaster = false;
 			if (previousPlay) {
-				isJoin = previousPlay.joinedPlayerTable.has(store.player!.id);
+				isBroadcaster = previousPlay.joinedPlayerTable.has(store.player!.id);
 			} else {
-				isJoin = play.joinedPlayerTable.size === 0;
+				isBroadcaster = play.joinedPlayerTable.size === 0;
 			}
-			argument = this._createInstanceArgumentForNicolive(isJoin);
+			argument = this._createInstanceArgumentForNicolive(isBroadcaster);
 		}
 
 		if (query.argumentsValue) {
@@ -135,7 +137,7 @@ export class Operator {
 
 		if (store.appOptions.autoStart) {
 			await this.startContent({
-				joinsSelf: isJoin,
+				joinsSelf: false,
 				instanceArgument: argument,
 				isReplay
 			});
@@ -179,8 +181,7 @@ export class Operator {
 	// TODO: このメソッドの処理は本来サーバー側で行うべき
 	restartWithNewPlay = async (): Promise<void> => {
 		await this.store!.currentPlay!.content.updateSandboxConfig();
-		const audioState = this.store.playStore.getLastPlay()?.audioState;
-		const play = await this._createServerLoop(this.store!.currentPlay!.content.locator, audioState);
+		const play = await this._createServerLoop(this.store.currentPlay!.content.locator, undefined, isServiceTypeNicoliveLike(this.store.targetService), true);
 		await this.store.currentPlay!.deleteAllServerInstances();
 		await apiClient.broadcast(this.store.currentPlay!.playId, { type: "switchPlay", nextPlayId: play.playId });
 		this.ui.hideNotification();
@@ -190,9 +191,14 @@ export class Operator {
 		this.store.setGameViewSize(size);
 	};
 
-	private async _createServerLoop(contentLocator: ClientContentLocator, audioState?: PlayAudioState): Promise<PlayEntity> {
+	private async _createServerLoop(
+		contentLocator: ClientContentLocator,
+		initialJoinPlayer: Player | undefined,
+		inheritsJoinedFromLatest: boolean,
+		inheritsAudioFromLatest: boolean
+	): Promise<PlayEntity> {
 		const content = this.store.contentStore.find(contentLocator);
-		const play = await this.store.playStore.createPlay({ contentLocator, audioState });
+		const play = await this.store.playStore.createPlay({ contentLocator, initialJoinPlayer, inheritsJoinedFromLatest, inheritsAudioFromLatest });
 		const tokenResult = await apiClient.createPlayToken(play.playId, "", true);  // TODO 空文字列でなくnullを使う
 		const { pauseActive } = this.store.appOptions;
 		await play.createServerInstance({ playToken: tokenResult.data.playToken, isPaused: pauseActive });
@@ -205,7 +211,7 @@ export class Operator {
 		const { events, autoSendEventName } = sandboxConfig;
 		if (events && autoSendEventName && events[autoSendEventName] instanceof Array) {
 			events[autoSendEventName].forEach((pev: any) => play.amflow.enqueueEvent(pev));
-		} else if (!autoSendEventName && (/^nicolive.*/.test(this.store.targetService) || this.store.targetService === "atsumaru:multi")) {
+		} else if (!autoSendEventName && isServiceTypeNicoliveLike(this.store.targetService)) {
 			play.amflow.enqueueEvent(createSessionParameter(this.store.targetService)); // セッションパラメータを送る
 		}
 

--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -1,6 +1,6 @@
 import { observable } from "mobx";
 import type { ContentLocatorData } from "../../common/types/ContentLocatorData";
-import type { PlayAudioState } from "../../common/types/PlayAudioState";
+import type { Player } from "../../common/types/Player";
 import type {
 	PlayCreateTestbedEvent,
 	PlayStatusChangedTestbedEvent,
@@ -30,8 +30,10 @@ export interface PlayStoreParameterObject {
 
 export interface CreatePlayParameterObject {
 	contentLocator: ContentLocatorData;
-	audioState?: PlayAudioState;
 	parent?: PlayEntity;
+	initialJoinPlayer?: Player;
+	inheritsJoinedFromLatest?: boolean;
+	inheritsAudioFromLatest?: boolean;
 }
 
 export interface CreateStandalonePlayParameterObject {
@@ -106,7 +108,7 @@ export class PlayStore {
 	}
 
 	async createPlay(param: CreatePlayParameterObject): Promise<PlayEntity> {
-		const playInfo = await apiClient.createPlay(param.contentLocator, param.audioState);
+		const playInfo = await apiClient.createPlay(param.contentLocator, param.initialJoinPlayer, param.inheritsJoinedFromLatest, param.inheritsAudioFromLatest);
 		const playId = playInfo.data.playId;
 
 		// apiClient.createPlay() に対する onPlayCreate 通知が先行していれば、この時点で PlayEntity が生成済みになっている

--- a/packages/akashic-cli-serve/src/client/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayStore.ts
@@ -108,7 +108,12 @@ export class PlayStore {
 	}
 
 	async createPlay(param: CreatePlayParameterObject): Promise<PlayEntity> {
-		const playInfo = await apiClient.createPlay(param.contentLocator, param.initialJoinPlayer, param.inheritsJoinedFromLatest, param.inheritsAudioFromLatest);
+		const playInfo = await apiClient.createPlay(
+			param.contentLocator,
+			param.initialJoinPlayer,
+			param.inheritsJoinedFromLatest,
+			param.inheritsAudioFromLatest
+		);
 		const playId = playInfo.data.playId;
 
 		// apiClient.createPlay() に対する onPlayCreate 通知が先行していれば、この時点で PlayEntity が生成済みになっている

--- a/packages/akashic-cli-serve/src/common/targetServiceUtil.ts
+++ b/packages/akashic-cli-serve/src/common/targetServiceUtil.ts
@@ -1,4 +1,4 @@
 
 export function isServiceTypeNicoliveLike(targetService: string): boolean {
-    return (/^nicolive.*/.test(targetService) || targetService === "atsumaru:multi")
+	return (/^nicolive.*/.test(targetService) || targetService === "atsumaru:multi");
 }

--- a/packages/akashic-cli-serve/src/common/targetServiceUtil.ts
+++ b/packages/akashic-cli-serve/src/common/targetServiceUtil.ts
@@ -1,0 +1,4 @@
+
+export function isServiceTypeNicoliveLike(targetService: string): boolean {
+    return (/^nicolive.*/.test(targetService) || targetService === "atsumaru:multi")
+}

--- a/packages/akashic-cli-serve/src/common/types/TestbedEvent.ts
+++ b/packages/akashic-cli-serve/src/common/types/TestbedEvent.ts
@@ -9,6 +9,7 @@ export interface PlayCreateTestbedEvent {
 	playId: string;
 	status: PlayStatus;
 	contentLocatorData: ContentLocatorData;
+	joinedPlayers: Player[];
 	audioState: PlayAudioState;
 }
 

--- a/packages/akashic-cli-serve/src/server/controller/PlayController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/PlayController.ts
@@ -22,7 +22,12 @@ export const createHandlerToCreatePlay = (playStore: PlayStore): express.Request
 			const initialJoinPlayer = initialJoinPlayerId ? { id: initialJoinPlayerId, name: initialJoinPlayerName } : undefined;
 			const inheritsJoinedFromLatest = req.body.inheritsJoinedFromLatest;
 			const inheritsAudioFromLatest = req.body.inheritsAudioFromLatest;
-			const playId = await playStore.createPlay({ contentLocator, initialJoinPlayer, inheritsJoinedFromLatest, inheritsAudioFromLatest });
+			const playId = await playStore.createPlay({
+				contentLocator,
+				initialJoinPlayer,
+				inheritsJoinedFromLatest,
+				inheritsAudioFromLatest
+			});
 			responseSuccess<PlayApiResponseData>(res, 200, playStore.getPlayInfo(playId));
 		} catch (e) {
 			next(e);

--- a/packages/akashic-cli-serve/src/server/controller/PlayController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/PlayController.ts
@@ -16,9 +16,13 @@ export const createHandlerToCreatePlay = (playStore: PlayStore): express.Request
 			if (!req.body.contentLocator || (!req.body.contentLocator.contentId && !req.body.contentLocator.path)) {
 				throw new BadRequestError({ errorMessage: "handleCreatePlay(): contentLocator is not given or invalid" });
 			}
-			const audioState = req.body.audioState ?? { muteType: "none", soloPlayerId: null };
 			const contentLocator = new ServerContentLocator(req.body.contentLocator);
-			const playId = await playStore.createPlay(contentLocator, audioState);
+			const initialJoinPlayerId = req.body.initialJoinPlayerId;
+			const initialJoinPlayerName = req.body.initialJoinPlayerName;
+			const initialJoinPlayer = initialJoinPlayerId ? { id: initialJoinPlayerId, name: initialJoinPlayerName } : undefined;
+			const inheritsJoinedFromLatest = req.body.inheritsJoinedFromLatest;
+			const inheritsAudioFromLatest = req.body.inheritsAudioFromLatest;
+			const playId = await playStore.createPlay({ contentLocator, initialJoinPlayer, inheritsJoinedFromLatest, inheritsAudioFromLatest });
 			responseSuccess<PlayApiResponseData>(res, 200, playStore.getPlayInfo(playId));
 		} catch (e) {
 			next(e);

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -1,8 +1,8 @@
 import { calculateFinishedTime } from "@akashic/amflow-util/lib/calculateFinishedTime";
 import { PromisifiedAMFlowProxy } from "@akashic/amflow-util/lib/PromisifiedAMFlowProxy";
 import type { AMFlowClient, Play, PlayManager } from "@akashic/headless-driver";
-import { Trigger } from "@akashic/trigger";
 import * as pl from "@akashic/playlog";
+import { Trigger } from "@akashic/trigger";
 import { TimeKeeper } from "../../common/TimeKeeper";
 import type { PlayAudioState } from "../../common/types/PlayAudioState";
 import type { Player } from "../../common/types/Player";
@@ -148,7 +148,9 @@ export class PlayStore {
 		// TODO: Join/Leave の特殊な sendEvent() をこのクラスに集約する (現状は SocketIOAMFlowManager で Join/Leave の送信をハンドリングしている)
 		if (joinedPlayers.length > 0) {
 			const amflow = (await this.getDebugAMFlow(playId))!;
-			joinedPlayers.forEach(player => { amflow.sendEvent([pl.EventCode.Join, 3, player.id, player.name]); });
+			joinedPlayers.forEach(player => {
+				amflow.sendEvent([pl.EventCode.Join, 3, player.id, player.name]);
+			});
 		}
 		return playId;
 	}

--- a/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/PlayStore.ts
@@ -2,6 +2,7 @@ import { calculateFinishedTime } from "@akashic/amflow-util/lib/calculateFinishe
 import { PromisifiedAMFlowProxy } from "@akashic/amflow-util/lib/PromisifiedAMFlowProxy";
 import type { AMFlowClient, Play, PlayManager } from "@akashic/headless-driver";
 import { Trigger } from "@akashic/trigger";
+import * as pl from "@akashic/playlog";
 import { TimeKeeper } from "../../common/TimeKeeper";
 import type { PlayAudioState } from "../../common/types/PlayAudioState";
 import type { Player } from "../../common/types/Player";
@@ -27,6 +28,34 @@ import { activePermission, passivePermission, debugPermission } from "./AMFlowPe
 
 export interface PlayStoreParameterObject {
 	playManager: PlayManager;
+}
+
+export interface CreatePlayParameterObject {
+	/**
+	 * 実行するコンテンツ。
+	 */
+	contentLocator: ServerContentLocator;
+
+	/**
+	 * 流し込むプレイログ。
+	 * 指定した場合、このプレイに active instance を生成してはならない。
+	 */
+	playlog?: DumpedPlaylog;
+
+	/**
+	 * 初期 join プレイヤー。
+	 */
+	initialJoinPlayer?: Player;
+
+	/**
+	 * 直前のプレイから join 済みプレイヤー情報を引き継ぐか。
+	 */
+	inheritsJoinedFromLatest?: boolean;
+
+	/**
+	 * 直前のプレイから PlayAudioState を引き継ぐか。
+	 */
+	inheritsAudioFromLatest?: boolean;
 }
 
 /**
@@ -81,14 +110,15 @@ export class PlayStore {
 	/**
 	 * Playを生成するが、返すものはPlayId
 	 */
-	async createPlay(
-		loc: ServerContentLocator,
-		audioState: PlayAudioState = { muteType: "none" },
-		playlog?: DumpedPlaylog
-	): Promise<string> {
-		const playId = await this.playManager.createPlay({
-			contentUrl: loc.asAbsoluteUrl()
-		}, playlog);
+	async createPlay(params: CreatePlayParameterObject): Promise<string> {
+		const { contentLocator: loc, playlog, initialJoinPlayer, inheritsJoinedFromLatest, inheritsAudioFromLatest } = params;
+		const latestPlay = this.getLatestPlayInfo();
+		const audioState: PlayAudioState = (latestPlay && inheritsAudioFromLatest) ? { ...latestPlay.audioState } : { muteType: "none" };
+		const joinedPlayers = (latestPlay && inheritsJoinedFromLatest) ? latestPlay.joinedPlayers.concat() : [];
+		if (initialJoinPlayer)
+			joinedPlayers.push(initialJoinPlayer);
+
+		const playId = await this.playManager.createPlay({ contentUrl: loc.asAbsoluteUrl() }, playlog, { preservesUnhandledEvents: true });
 		const status = "preparing";
 		this.playEntities[playId] = {
 			contentLocator: loc,
@@ -96,7 +126,7 @@ export class PlayStore {
 			timeKeeper: new TimeKeeper(),
 			clientInstances: [],
 			runners: [],
-			joinedPlayers: [],
+			joinedPlayers,
 			audioState,
 			debugAMFlow: null
 		};
@@ -111,8 +141,15 @@ export class PlayStore {
 			);
 			timeKeeper.setTime(finishedTime);
 		}
-		this.onPlayCreate.fire({playId, status, contentLocatorData: loc.asContentLocatorData(), audioState});
+
+		this.onPlayCreate.fire({playId, status, contentLocatorData: loc.asContentLocatorData(), joinedPlayers, audioState });
 		this.setPlayStatus(playId, "running");
+
+		// TODO: Join/Leave の特殊な sendEvent() をこのクラスに集約する (現状は SocketIOAMFlowManager で Join/Leave の送信をハンドリングしている)
+		if (joinedPlayers.length > 0) {
+			const amflow = (await this.getDebugAMFlow(playId))!;
+			joinedPlayers.forEach(player => { amflow.sendEvent([pl.EventCode.Join, 3, player.id, player.name]); });
+		}
 		return playId;
 	}
 
@@ -155,6 +192,11 @@ export class PlayStore {
 
 	getPlaysInfo(): PlayInfo[] {
 		return this.getPlays().map(p => this.getPlayInfo(p.playId)!);
+	}
+
+	getLatestPlayInfo(): PlayInfo | null {
+		const play = this.getLatestPlay();
+		return play ? this.getPlayInfo(play.playId) : null;
 	}
 
 	getPlayIdsFromContentId(contentId: string): string[] {

--- a/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
+++ b/packages/akashic-cli-serve/src/server/domain/RunnerStore.ts
@@ -78,10 +78,10 @@ export class RunnerStore {
 
 		const runner = this.runnerManager.getRunner(runnerId)!;
 		await this.runnerManager.startRunner(runner.runnerId, { paused: params.isPaused });
+		this.playIdTable[runnerId] = params.playId;
 		this.onRunnerCreate.fire({ playId: params.playId, runnerId, isActive: params.isActive });
 		if (params.isPaused)
 			this.onRunnerPause.fire({ playId: params.playId, runnerId });
-		this.playIdTable[runnerId] = params.playId;
 		return runner;
 	}
 

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -14,6 +14,7 @@ import * as express from "express";
 import * as open from "open";
 import * as socketio from "socket.io";
 import parser from "../common/MsgpackParser";
+import { isServiceTypeNicoliveLike } from "../common/targetServiceUtil";
 import type { PutStartPointEvent } from "../common/types/TestbedEvent";
 import { ServerContentLocator } from "./common/ServerContentLocator";
 import { serverGlobalConfig } from "./common/ServerGlobalConfig";
@@ -26,7 +27,6 @@ import { SocketIOAMFlowManager } from "./domain/SocketIOAMFlowManager";
 import { createApiRouter } from "./route/ApiRoute";
 import { createContentsRouter } from "./route/ContentsRoute";
 import { createHealthCheckRouter } from "./route/HealthCheckRoute";
-import { isServiceTypeNicoliveLike } from "../common/targetServiceUtil";
 
 // 渡されたパラメータを全てstringに変換する
 // chalkを使用する場合、ログ出力時objectの中身を展開してくれないためstringに変換する必要がある


### PR DESCRIPTION
掲題どおり。

新規プレイボタンを誤って二度連打した時など、タイミングによって時折 `-s nicolive` の自動 Join が働かなくなり、再起動するまで直らない現象を修正します。

### 背景

serve はサーバの状態など「プレイヤー間で共有される情報」を主に次のようなフローで扱っています:

1. いずれかのクライアントがサーバ側の API を叩く
2. API 呼び出しを受けたサーバが処理を行う
3. それによる変化をサーバからプッシュで全クライアントにブロードキャストする
4. ブロードキャストを受けた各クライアントが自分の状態を更新する

マルチプレイの参加人数、プレイに誰が join しているか、オーディオのミュート状態などがこれで管理されています。また serve は可能な限り制御をクライアント側で行う形になっています (これは今にして思えばいまいちな実装) 。

### 問題と原因

 `-s nicolive` で起動した場合、Join するプレイヤーは「最初に開かれたウィンドウのプレイヤー」で固定です。新規プレイボタンを押して次のプレイに行った場合も、Join するプレイヤーは引き継がれます。

前述のとおり serve の制御はかなりクライアント側に寄ったものになっていて、この時「プレイヤーを join させる」処理は「新規プレイボタンが押されたウィンドウ」が行ってきました。

ここで新規プレイボタンを誤って連打すると、**(4) の (Join の) 状態更新が間に合わないことがあります**。プレイヤーを join させるために「直前のプレイの join 状態」を参照した時、(4) が間に合っていないと「誰も join していない」扱いになってしまいます。一度この状態に陥った場合、以降の新規プレイが「引き継ぐ」 join 状態も全て空になるため、現象は serve を再起動するまで再現し続けます。

### 対応

「プレイの作成」と「初期プレイヤーの join」が非同期的に分離している限り、この問題には対処できません。また「サーバの最新の状態をクライアントが知っている」前提を置くのはやめた方がよさそうです。

そこで、新規プレイを作成する API で次を指定できるようにします:

- (a) 初期 join プレイヤー
- (b) 直前のプレイからjoin プレイヤーを引き継ぐか否かのフラグ
- (c) 直前のプレイからオーディオのミュート状態を引き継ぐか否かのフラグ

最初の起動時には (a) を使って指定するものの、以降は (b) を使うことでクライアント側の状態更新に依存しないようにします。また (c) を加えることで、概念的に同じ扱いであるべきオーディオのミュート状態 (`-s` オプションなどに関係なく常に前プレイから引き継ぐ) も統一的に扱うようにします。

### 動作確認

元がタイミング問題なので非常に確認しづらいのですが、[ニコニコスネーク](https://github.com/akashic-contents/niconicoSnake) を実行中に「新規プレイ」ボタンを連打して、修正後に問題を再現できないことを確認しています。
