### PR TITLE
Add nicolive option to export-zip

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -16,4 +16,5 @@ export interface CliConfigExportZip {
 	omitEmptyJs?: boolean;
 	omitUnbundledJs?: boolean;
 	targetService?: ServiceType;
+	nicolive?: boolean;
 }

--- a/packages/akashic-cli-commons/src/GameConfiguration.ts
+++ b/packages/akashic-cli-commons/src/GameConfiguration.ts
@@ -1,4 +1,4 @@
-import type { AssetConfigurationMap, GameConfiguration as Configuration } from "@akashic/game-configuration";
+import type { AkashicRuntime, AssetConfigurationMap, GameConfiguration as Configuration } from "@akashic/game-configuration";
 import type { ServiceType } from "./ServiceType";
 
 /**
@@ -12,6 +12,7 @@ export interface GameConfiguration extends Configuration{
 
 export interface ModuleEnvironment {
 	"sandbox-runtime"?: string;
+	"akashic-runtime"?: AkashicRuntime;
 	external?: {[key: string]: string};
 }
 
@@ -34,5 +35,6 @@ export interface ExportZipInfo {
 		hashFilename?: number | boolean;
 		omitEmptyJs?: boolean;
 		targetService?: ServiceType;
+		nicolive?: boolean;
 	};
 }

--- a/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
@@ -479,5 +479,49 @@ describe("convert", () => {
 					done();
 				}, done.fail);
 		});
+
+		it("nicolive option, can add akashic-runtime to gamejson.", (done) => {
+			const param = {
+				source: path.resolve(__dirname, "..", "..", "fixtures", "sample_game_v3"),
+				dest: destDir,
+				bundle: true,
+				nicolive: true
+			};
+			convertGame(param)
+				.then(() => {
+					expect(fs.existsSync(path.join(destDir, "script/aez_bundle_main.js"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
+					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
+					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
+					expect(gameJson.assets.aez_bundle_main.path).toBe("script/aez_bundle_main.js");
+					expect(gameJson.assets.aez_bundle_main.type).toBe("script");
+					expect(gameJson.assets.aez_bundle_main.global).toBe(true);
+					expect(gameJson.environment["sandbox-runtime"]).toBe("3");
+					expect(gameJson.environment.external).toEqual({ send: "0" });
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d\.\d+(-.*)?$/);
+					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
+					done();
+				}, done.fail);
+		});
+
+		it("nicolive option, Do not add akashic-runtime if it already exists in game.json.", (done) => {
+			const param = {
+				source: path.resolve(__dirname, "..", "..", "fixtures", "sample_game_with_akashic_runtime"),
+				dest: destDir,
+				bundle: true,
+				nicolive: true
+			};
+			convertGame(param)
+				.then(() => {
+					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
+					expect(gameJson.environment.external.send).toBe("0");
+					expect(gameJson.environment["akashic-runtime"].version).toBe("~1.0.9-beta");
+					expect(gameJson.environment["akashic-runtime"].flavor).toBe(undefined);
+					expect(gameJson.environment.nicolive.supportedModes.length).toBe(2);
+					expect(gameJson.environment.nicolive.supportedModes).toContain("single");
+					expect(gameJson.environment.nicolive.supportedModes).toContain("ranking");
+					done();
+				}, done.fail);
+		});
 	});
 });

--- a/packages/akashic-cli-export/src/zip/apiUtil.ts
+++ b/packages/akashic-cli-export/src/zip/apiUtil.ts
@@ -1,0 +1,17 @@
+import * as https from "https";
+
+export function getFromHttps(url: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const request = https.get(url, (res) => {
+			if (res.statusCode >= 400) {
+				return reject(new Error(`Failed to get resource. url: ${url}. status code: ${res.statusCode}.`));
+			}
+			const bodies: string[] = [];
+			res.on("data", (chunk) => {
+				bodies.push(chunk.toString());
+			});
+			res.on("end", () => resolve(bodies.join("")));
+		});
+		request.on("error", (err) => reject(err));
+	});
+}

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -16,7 +16,7 @@ export function cli(param: CliConfigExportZip): void {
 
 	Promise.resolve()
 		.then(() => promiseExportZip({
-			bundle: param.bundle,
+			bundle: param.bundle || param.nicolive,
 			babel: (param.babel != null) ? param.babel : true,
 			minify: param.minify,
 			minifyJs: param.minifyJs,
@@ -26,10 +26,12 @@ export function cli(param: CliConfigExportZip): void {
 			source: param.cwd,
 			dest: param.output,
 			force: param.force,
-			hashLength: !param.hashFilename ? 0 : (param.hashFilename === true) ? 20 : Number(param.hashFilename),
+			hashLength: !param.hashFilename && !param.nicolive ? 0 :
+				(param.hashFilename === true) ? 20 : Number(param.hashFilename),
 			logger,
-			omitUnbundledJs: param.bundle && param.omitUnbundledJs,
-			targetService: param.targetService,
+			omitUnbundledJs: (param.bundle || param.nicolive) && param.omitUnbundledJs,
+			targetService: param.nicolive ? "nicolive" : param.targetService,
+			nicolive: param.nicolive,
 			exportInfo: {
 				version: ver,
 				option: {
@@ -42,7 +44,8 @@ export function cli(param: CliConfigExportZip): void {
 					bundle: param.bundle,
 					babel: param.babel,
 					hashFilename: param.hashFilename,
-					targetService: param.targetService || "none"
+					targetService: param.nicolive ? "nicolive" : param.targetService || "none",
+					nicolive: param.nicolive
 				}
 			}
 		}))
@@ -73,7 +76,8 @@ commander
 	.option("--minify-js", "Minify JavaScript files")
 	.option("--minify-json", "Minify JSON files")
 	.option("--pack-image", "Pack small images")
-	.option("--target-service <service>", `Specify the target service of the exported content:${availableServices}`);
+	.option("--target-service <service>", `Specify the target service of the exported content:${availableServices}`)
+	.option("--nicolive", "Export zip file for nicolive");
 
 export function run(argv: string[]): void {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
@@ -108,7 +112,8 @@ export function run(argv: string[]): void {
 			babel: options.es5Downpile ?? conf.babel,
 			omitEmptyJs: options.omitEmptyJs ?? conf.omitEmptyJs,
 			omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
-			targetService: options.targetService ?? conf.targetService
+			targetService: options.targetService ?? conf.targetService,
+			nicolive: options.nicolive ?? conf.nicolive
 		});
 	});
 }

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -8,6 +8,7 @@ import * as browserify from "browserify";
 import * as fsx from "fs-extra";
 import readdir = require("fs-readdir-recursive");
 import * as UglifyJS from "uglify-js";
+import { getFromHttps } from "./apiUtil";
 import * as gcu from "./GameConfigurationUtil";
 import { transformPackSmallImages } from "./transformPackImages";
 
@@ -30,6 +31,7 @@ export interface ConvertGameParameterObject {
 	exportInfo?: cmn.ExportZipInfo;
 	omitUnbundledJs?: boolean;
 	targetService?: cmn.ServiceType;
+	nicolive?: boolean;
 }
 
 export function _completeConvertGameParameterObject(param: ConvertGameParameterObject): void {
@@ -45,6 +47,7 @@ export function _completeConvertGameParameterObject(param: ConvertGameParameterO
 	param.exportInfo = param.exportInfo;
 	param.omitUnbundledJs = !!param.omitUnbundledJs;
 	param.targetService = param.targetService || "none";
+	param.nicolive = !!param.nicolive;
 }
 
 export interface BundleResult {
@@ -82,6 +85,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 		.then(() => cmn.ConfigurationFile.read(path.join(param.source, "game.json"), param.logger))
 		.then(async (result: cmn.GameConfiguration) => {
 			gamejson = result;
+
 			// export-zip実行時のバージョンとオプションを追記
 			if (param.exportInfo) {
 				gamejson.exportZipInfo = {
@@ -194,6 +198,10 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 				addUntaintedToImageAssets(gamejson);
 			}
 
+			if (param.nicolive) {
+				await addGameJsonValuesForNicoLive(gamejson);
+			}
+
 			if (bundleResult === null) {
 				return;
 			}
@@ -261,3 +269,37 @@ function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void {
 		}
 	});
 }
+
+/**
+ * nicolive 用に game.json に値を追加する。
+ */
+async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration): Promise<void> {
+	// game.jsonへの追記
+	if (!gameJson.environment) {
+		gameJson.environment = {};
+	}
+	if (!gameJson.environment.external) {
+		gameJson.environment.external = {};
+	}
+	gameJson.environment.external.send = "0";
+	if (gameJson.environment["akashic-runtime"]) {
+		return;
+	}
+	gameJson.environment["akashic-runtime"] = { version: "" };
+	gameJson = await getFromHttps(
+		"https://raw.githubusercontent.com/akashic-games/akashic-runtime-version-table/master/versions.json").then((data) => {
+		const versionInfo = JSON.parse(data);
+		if (!gameJson.environment["sandbox-runtime"] || gameJson.environment["sandbox-runtime"] === "1") {
+			gameJson.environment["akashic-runtime"].version = "~" + versionInfo.latest["1"];
+		} else {
+			gameJson.environment["akashic-runtime"].version =
+				"~" + versionInfo.latest[gameJson.environment["sandbox-runtime"]];
+			if (!gameJson.renderers || gameJson.renderers.indexOf("webgl") === -1) {
+				gameJson.environment["akashic-runtime"].flavor = "-canvas";
+			}
+		}
+		return gameJson;
+	});
+
+}
+

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -22,6 +22,7 @@ export interface ExportZipParameterObject {
 	exportInfo?: cmn.ExportZipInfo;
 	omitUnbundledJs?: boolean;
 	targetService?: cmn.ServiceType;
+	nicolive?: boolean;
 }
 
 function _createExportInfo(param: ExportZipParameterObject): cmn.ExportZipInfo {
@@ -57,7 +58,8 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		hashLength: param.hashLength,
 		exportInfo: param.exportInfo || _createExportInfo(param),
 		omitUnbundledJs: param.omitUnbundledJs,
-		targetService: param.targetService || "none"
+		targetService: param.targetService || "none",
+		nicolive: !!param.nicolive
 	};
 }
 
@@ -102,7 +104,8 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 				logger: param.logger,
 				exportInfo: param.exportInfo,
 				omitUnbundledJs: param.omitUnbundledJs,
-				targetService: param.targetService
+				targetService: param.targetService,
+				nicolive: param.nicolive
 			});
 		})
 		.then(() => {


### PR DESCRIPTION
## 概要

akashic-cli-export-zip に `--nicolive` オプションを追加します。(export-html の --atsumaru オプションの zip版)
--nicolive オプションが指定された場合の動作は下記となります。
- game.jsonの environment .akashic-runtime の情報を追加。
- bundle オプションを有効に
- hashLength オプションの条件に追加
- omitUnbundledJs オプションの条件に追加
- targetService を "nicolive" に設定
