### PR TITLE
Fix tests involving NodeModules#extractModuleMainInfo

### DIFF
--- a/packages/akashic-cli-commons/spec/src/NodeModulesSpec.ts
+++ b/packages/akashic-cli-commons/spec/src/NodeModulesSpec.ts
@@ -4,6 +4,7 @@ import * as mockfs from "mock-fs";
 import { ConsoleLogger } from "../../lib/ConsoleLogger";
 import { Logger } from "../../lib/Logger";
 import { NodeModules } from "../../lib/NodeModules";
+import { Util } from "../../lib";
 
 describe("NodeModules", function () {
 
@@ -146,11 +147,11 @@ describe("NodeModules", function () {
 
 	describe(".listModuleMainScripts()", function () {
 		it("list the files named package.json", function (done) {
-			jest.spyOn(NodeModules, "extractModuleMainInfo").mockImplementation((packageJsonPath: string) => {
-				const pkgData =  JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+			jest.spyOn(Util, "requireResolve").mockImplementation((id: string, opts: { paths?: string[] | undefined }): string => {
+				const pkgJsonPath = path.join(opts.paths[0], "package.json");
+				const pkgData =  JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
 				const mainScriptName = pkgData.main.split(".").pop() === "js" ? pkgData.main : pkgData.main + ".js";
-				const mainScriptPath = path.join(path.dirname(packageJsonPath), mainScriptName);
-				return {moduleName: pkgData.name, mainScriptPath };
+				return path.join(path.resolve("."), path.dirname(pkgJsonPath), mainScriptName);
 			});
 
 			mockfs(mockFsContent);

--- a/packages/akashic-cli-commons/src/NodeModules.ts
+++ b/packages/akashic-cli-commons/src/NodeModules.ts
@@ -60,7 +60,7 @@ export module NodeModules {
 	export function extractModuleMainInfo(packageJsonPath: string): ModuleMainInfo {
 		const packageJsonData = fs.readFileSync(packageJsonPath, "utf-8");
 		const d = JSON.parse(packageJsonData);
-		let mainScriptPath = require.resolve(d.name, {paths: [path.join(path.dirname(packageJsonPath))]});
+		let mainScriptPath = Util.requireResolve(d.name, {paths: [path.join(path.dirname(packageJsonPath))]});
 		if (!mainScriptPath) {
 			throw new Error(`No ${d.name} in node_modules`);
 		}

--- a/packages/akashic-cli-commons/src/Util.ts
+++ b/packages/akashic-cli-commons/src/Util.ts
@@ -96,3 +96,8 @@ export async function getTotalFileSize(directoryPath: string): Promise<number> {
 
 	return totalSize;
 }
+
+// require.resolve() がモックできないので関数をモックするため require.resolve() するだけの関数を切り出している
+export function requireResolve(id: string, opts?: { paths?: string[] | undefined }): string {
+	return require.resolve(id, opts);
+}

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -98,7 +98,7 @@ export function run(argv: string[]): void {
 			}
 		}
 		if (options.atsumaru) {
-			console.error("--atsumaru is an obsolete option. Use \"akashic import zip --nicolive\" instead.");
+			console.error("--atsumaru is an obsolete option. Use \"akashic export zip --nicolive\" instead.");
 			process.exit(1);
 		}
 

--- a/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
@@ -105,11 +105,11 @@ describe("install()", function () {
 			}
 		};
 
-		jest.spyOn(cmn.NodeModules, "extractModuleMainInfo").mockImplementation((packageJsonPath: string) => {
-			const pkgData = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+		jest.spyOn(cmn.Util, "requireResolve").mockImplementation((id: string, opts: { paths?: string[] | undefined }): string => {
+			const pkgJsonPath = path.join(opts.paths[0], "package.json");
+			const pkgData =  JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
 			const mainScriptName = pkgData.main.split(".").pop() === "js" ? pkgData.main : pkgData.main + ".js";
-			const mainScriptPath = path.join(path.dirname(packageJsonPath), mainScriptName);
-			return {moduleName: pkgData.name, mainScriptPath };
+			return path.join(path.resolve("."), path.dirname(pkgJsonPath), mainScriptName);
 		});
 
 		mockfs(mockFsContent);

--- a/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
@@ -115,11 +115,11 @@ describe("uninstall()", function () {
 		}
 		var dummyNpm = new DummyNpm();
 
-		jest.spyOn(cmn.NodeModules, "extractModuleMainInfo").mockImplementation((packageJsonPath: string) => {
-			const pkgData = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+		jest.spyOn(cmn.Util, "requireResolve").mockImplementation((id: string, opts: { paths?: string[] | undefined }): string => {
+			const pkgJsonPath = path.join(opts.paths[0], "package.json");
+			const pkgData =  JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
 			const mainScriptName = pkgData.main.split(".").pop() === "js" ? pkgData.main : pkgData.main + ".js";
-			const mainScriptPath = path.join(path.dirname(packageJsonPath), mainScriptName);
-			return {moduleName: pkgData.name, mainScriptPath };
+			return path.join(path.resolve("."), path.dirname(pkgJsonPath), mainScriptName);
 		});
 
 		Promise.resolve()

--- a/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
+++ b/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
@@ -999,5 +999,4 @@ describe("scanNodeModules", () => {
 			"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
 		);
 	});
-
 });

--- a/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
+++ b/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
@@ -3,22 +3,20 @@ import * as path from "path";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
 import * as mockfs from "mock-fs";
 import { scanNodeModules } from "../../../lib/scanNodeModules";
-import { NodeModules } from "@akashic/akashic-cli-commons";
+import { Util } from "@akashic/akashic-cli-commons";
 import { MockPromisedNpm } from "./helpers/MockPromisedNpm";
 
 describe("scanNodeModules", () => {
 	const nullLogger = new ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 	let spy: jest.SpyInstance;
 	beforeAll(() => {
-		spy = jest.spyOn(NodeModules, "extractModuleMainInfo").mockImplementation((packageJsonPath: string) => {
-			const pkgData = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+		spy = jest.spyOn(Util, "requireResolve").mockImplementation((id: string, opts: { paths?: string[] | undefined }): string => {
+			const pkgJsonPath = path.join(opts.paths[0], "package.json");
+			const pkgData =  JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+			if (!pkgData.name) return "";
 			const mainScriptName = pkgData.main.split(".").pop() === "js" ? pkgData.main : pkgData.main + ".js";
-			const mainScriptPath = path.join(path.dirname(packageJsonPath), mainScriptName);
-			if (!pkgData.name) {
-				throw new Error(`No ${pkgData.name} in node_modules`);
-			}	
-			return {moduleName: pkgData.name, mainScriptPath };
-		});		   
+			return path.join(path.resolve("."), path.dirname(pkgJsonPath), mainScriptName);
+		});
 	});
 
 	afterEach(() => {
@@ -1001,4 +999,5 @@ describe("scanNodeModules", () => {
 			"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
 		);
 	});
+
 });


### PR DESCRIPTION
## 概要

akashic-cli-scan の globalScripts オプションで Windowsの場合に、game.json に追加されたパスがホームディレクトリからのパスとなるバグ(#1213)があったが windows のテストを通ってしまっていた問題の修正。
(バグ自体は #1229 で対応済み。)

**原因**

原因のロジックとなる commons の `NodeModules#extractModuleMainInfo()` のテストは、`require.resolve()` がモックできないため、各テストで `extractModuleMainInfo()` をモックしていて `require.resolve()`の箇所をテスト用のロジックとなっていたため windows のテストで通ってしまった。

**対応**

`NodeModules#extractModuleMainInfo()` 内で `require.resolve()` を利用している箇所を `require.resolve()` するだけの最小限の関数として切り出し、テストではその関数をモックするように修正。