### PR TITLE
fix(serve): avoid to reload twice when -w detects change

### DIFF
--- a/packages/akashic-cli-serve/src/server/domain/GameConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/GameConfigs.ts
@@ -37,57 +37,45 @@ export async function watchContent(
 	cb: (err: any, modTargetFlag: ModTargetFlags) => void,
 	watcher?: chokidar.FSWatcher
 ): Promise<void> {
+	watcher ??= chokidar.watch(targetDir, {
+		persistent: true,
+		ignoreInitial: true,
+		ignored: "**/node_modules/**/*"
+	});
+
 	// akashic-cli-scanはwatchオプション指定時しか使われないので動的importする
 	const scan = await import("@akashic/akashic-cli-scan/lib/scanAsset");
-	if (!watcher) {
-		watcher = chokidar.watch(targetDir, {
-			persistent: true,
-			ignoreInitial: true,
-			ignored: "**/node_modules/**/*"
-		});
-	}
-	let timer: NodeJS.Timer | undefined;
-	let mods: ModTargetFlags = ModTargetFlags.None;
-	const watcherHandler = (filePath: string): void => {
-		const handler = async (): Promise<void> => {
-			const lastMods = mods;
-			mods = ModTargetFlags.None;
-			if (lastMods & ModTargetFlags.Assets) {
-				try {
-					await scan.scanAsset({ target: "all", cwd: targetDir });
-					// scanAssets の過程でGameJsonのフラグが立ってしまい、落とさないとcb()が二重で呼ばれてしまうのでここで落としておく。
-					mods &= ~ModTargetFlags.GameJson;
-					cb(null, ModTargetFlags.Assets);
-				} catch (err: any) {
-					cb(err, ModTargetFlags.Assets);
-				} finally {
-					if (mods === ModTargetFlags.None) {
-						clearInterval(timer);
-						timer = undefined;
-					}
-				}
-			} else if (lastMods & ModTargetFlags.GameJson) {
-				try {
-					cb(null, ModTargetFlags.GameJson);
-				} finally {
-					if (mods === ModTargetFlags.None) {
-						clearInterval(timer);
-						timer = undefined;
-					}
-				}
-			}
-		};
 
-		if (["assets", "audio", "image", "script", "text"].some(dir => filePath.indexOf(path.join(targetDir, dir)) !== -1)) {
-			mods |= ModTargetFlags.Assets;
-		} else if (filePath === path.join(targetDir, "game.json")) {
-			mods |= ModTargetFlags.GameJson;
+	targetDir = path.resolve(targetDir); // 相対パスで監視すると chokidar の通知してくるパスがおかしい場合があるようなのですべて絶対パスで扱う
+	const assetDirs = ["assets", "audio", "image", "script", "text"].map(d => path.join(targetDir, d) + path.sep);
+	const gameJsonPath = path.join(targetDir, "game.json");
+
+	let suppressedGameJson = false;
+	let suppressedScan = false;
+	const watcherHandler = async (filePath: string): Promise<void> => {
+		filePath = path.resolve(filePath);
+
+		if (!suppressedScan && assetDirs.some(assetDir => filePath.startsWith(assetDir))) {
+			// scanAsset() によって起こる game.json の変更を通知すると二重になってしまうので、500ms だけ無視するように。時間は仮。
+			suppressedGameJson = true;
+			setTimeout(() => { suppressedGameJson = false; }, 500);
+
+			try {
+				suppressedScan = true; // scanAsset() 中に再帰的に scan しないよう抑制。
+				await scan.scanAsset({ target: "all", cwd: targetDir });
+			} finally {
+				suppressedScan = false;
+			}
+			cb(null, ModTargetFlags.Assets);
+			return;
 		}
 
-		if (!timer) {
-			timer = setInterval(handler, 1000);
+		if (!suppressedGameJson && filePath === gameJsonPath) {
+			cb(null, ModTargetFlags.GameJson);
+			return;
 		}
 	};
+
 	watcher.on("add", watcherHandler);
 	watcher.on("unlink", watcherHandler);
 	watcher.on("change", watcherHandler);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -229,9 +229,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 				if (err) {
 					getSystemLogger().error(err.message);
 				}
-				if (modTargetFlag === ModTargetFlags.GameJson) {
-					console.log("Reflect changes of game.json");
-				}
+				console.log("Reflect changes of ", (modTargetFlag === ModTargetFlags.GameJson) ? "game.json" : "assets");
 				// コンテンツに変更があったらplayを新規に作り直して再起動
 				const contentId = `${i}`;
 				const targetPlayIds: string[] = [];


### PR DESCRIPTION
掲題どおり。

serve で `-w` オプションを指定した時、アセットを変更すると、アセットの更新と (それが引き起こす akashic scan による) game.json 更新につられて二度リロードが走っており、体験としていまいちでした。これを修正します。

なお従前の実装でも、このような「複数の変更」をまとめて一度のリロードで済むように試みていました。が、正しく機能していませんでした。むしろ複数の変更が行われることを想定して 1000ms 待つことがリロードをワンテンポ遅らせ、体験を損ねていました。
