### PR TITLE
Fix to enable hash-length in nicolive option of export-zip

### DIFF
--- a/packages/akashic-cli-export/spec/src/zip/cliSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/cliSpec.ts
@@ -1,0 +1,158 @@
+import { CliConfigExportZip } from "@akashic/akashic-cli-commons";
+import { cli } from "../../../lib/zip/cli";
+import * as exp from "../../../lib/zip/exportZip";
+
+describe("Parameter checking from cli() to exportZip()", () => {
+	const mockFn = jest.spyOn(exp, "promiseExportZip");
+	afterEach(() => {
+		mockFn.mockReset();
+	});
+	afterAll(() => {
+		mockFn.mockRestore();
+	});
+
+	it("no configs", (done) => {
+		const configs = {};
+		mockFn.mockImplementation(params => {
+			expect(params.bundle).toBeUndefined();
+			expect(params.babel).toBeTruthy();
+			expect(params.minify).toBeUndefined();
+			expect(params.minifyJs).toBeUndefined();
+			expect(params.minifyJson).toBeUndefined();
+			expect(params.packImage).toBeUndefined();
+			expect(params.strip).toBeTruthy();
+			expect(params.source).toBeUndefined();
+			expect(params.dest).toBeUndefined();
+			expect(params.force).toBeUndefined();
+			expect(params.hashLength).toBe(0);
+			expect(params.logger).toBeDefined();
+			expect(params.omitUnbundledJs).toBeUndefined();
+			expect(params.targetService).toBeUndefined();
+			expect(params.nicolive).toBeUndefined();
+
+			const infoOption = params.exportInfo.option;
+			expect(infoOption.quiet).toBeUndefined();
+			expect(infoOption.force).toBeUndefined();
+			expect(infoOption.strip).toBeUndefined();
+			expect(infoOption.minify).toBeUndefined();
+			expect(infoOption.minifyJs).toBeUndefined();
+			expect(infoOption.minifyJson).toBeUndefined();
+			expect(infoOption.bundle).toBeUndefined();
+			expect(infoOption.babel).toBeUndefined();
+			expect(infoOption.hashFilename).toBeUndefined();
+			expect(infoOption.targetService).toBe("none");
+			expect(infoOption.nicolive).toBeUndefined();
+			return Promise.resolve();
+		 });
+		 Promise.resolve().then(() => cli(configs))
+			.then(done, done.fail);
+	});
+
+
+	it("with all configs", (done) => {
+		const configs: CliConfigExportZip = {
+			cwd: "./somewhere",
+			quiet: true,
+			output: "out.zip",
+			force: true,
+			strip: true,
+			minify: true,
+			minifyJs: true,
+			minifyJson: true,
+			packImage: true,
+			bundle: true,
+			babel: true,
+			hashFilename: 11,
+			omitEmptyJs: true,
+			omitUnbundledJs: true,
+			targetService: "nicolive",
+			nicolive: true
+		};
+		mockFn.mockImplementation(params => {
+			expect(params.bundle).toBeTruthy();
+			expect(params.babel).toBeTruthy();
+			expect(params.minify).toBeTruthy();
+			expect(params.minifyJs).toBeTruthy();
+			expect(params.minifyJson).toBeTruthy();
+			expect(params.packImage).toBeTruthy();
+			expect(params.strip).toBeTruthy();
+			expect(params.source).toBe("./somewhere");
+			expect(params.dest).toBe("out.zip");
+			expect(params.force).toBeTruthy();
+			expect(params.hashLength).toBe(11);
+			expect(params.logger).toBeDefined();
+			expect(params.omitUnbundledJs).toBeTruthy();
+			expect(params.targetService).toBe("nicolive");
+			expect(params.nicolive).toBeTruthy();
+
+			const infoOption = params.exportInfo.option;
+			expect(infoOption.quiet).toBeTruthy();
+			expect(infoOption.force).toBeTruthy();
+			expect(infoOption.strip).toBeTruthy();
+			expect(infoOption.minify).toBeTruthy();
+			expect(infoOption.minifyJs).toBeTruthy();
+			expect(infoOption.minifyJson).toBeTruthy();
+			expect(infoOption.bundle).toBeTruthy();
+			expect(infoOption.babel).toBeTruthy();
+			expect(infoOption.hashFilename).toBe(11);
+			expect(infoOption.targetService).toBe("nicolive");
+			expect(infoOption.nicolive).toBeTruthy();
+			return Promise.resolve();
+		 });
+		 Promise.resolve().then(() => cli(configs))
+			.then(done, done.fail);
+	});
+
+
+	it("nicolive parameter is true", (done) => {
+		const configs = { nicolive: true };
+		mockFn.mockImplementation(params => {
+			expect(params.bundle).toBeTruthy();
+			expect(params.babel).toBeTruthy();
+			expect(params.strip).toBeTruthy();
+			expect(params.bundle).toBeTruthy();
+			expect(params.hashLength).toBe(20);
+			expect(params.logger).toBeDefined();
+			expect(params.targetService).toBe("nicolive");
+			expect(params.nicolive).toBeTruthy();
+
+			const infoOption = params.exportInfo.option;
+			expect(infoOption.hashFilename).toBe(20);
+			expect(infoOption.targetService).toBe("nicolive");
+			expect(infoOption.nicolive).toBeTruthy();
+			return Promise.resolve();
+		});
+		Promise.resolve().then(() => cli(configs))
+			.then(done, done.fail);
+	});
+
+	it("when nicolive is true and there are other parameters", (done) => {
+		const configs: CliConfigExportZip = {
+			nicolive: true,
+			bundle: false,
+			hashFilename: 22,
+			targetService: "none",
+			omitUnbundledJs: true
+		};
+		mockFn.mockImplementation(params => {
+			console.log(params);
+			expect(params.bundle).toBeTruthy();
+			expect(params.babel).toBeTruthy();
+			expect(params.strip).toBeTruthy();
+			expect(params.bundle).toBeTruthy();
+			expect(params.omitUnbundledJs).toBeTruthy();
+			expect(params.hashLength).toBe(22);
+			expect(params.logger).toBeDefined();
+			expect(params.targetService).toBe("nicolive");
+			expect(params.nicolive).toBeTruthy();
+
+			const infoOption = params.exportInfo.option;
+			expect(infoOption.hashFilename).toBe(22);
+			expect(infoOption.targetService).toBe("nicolive");
+			expect(infoOption.nicolive).toBeTruthy();
+			return Promise.resolve();
+		});
+		Promise.resolve().then(() => cli(configs))
+			.then(done, done.fail);
+	});
+});

--- a/packages/akashic-cli-export/spec/src/zip/cliSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/cliSpec.ts
@@ -43,11 +43,10 @@ describe("Parameter checking from cli() to exportZip()", () => {
 			expect(infoOption.targetService).toBe("none");
 			expect(infoOption.nicolive).toBeUndefined();
 			return Promise.resolve();
-		 });
-		 Promise.resolve().then(() => cli(configs))
+		});
+		Promise.resolve().then(() => cli(configs))
 			.then(done, done.fail);
 	});
-
 
 	it("with all configs", (done) => {
 		const configs: CliConfigExportZip = {
@@ -103,7 +102,6 @@ describe("Parameter checking from cli() to exportZip()", () => {
 			.then(done, done.fail);
 	});
 
-
 	it("nicolive parameter is true", (done) => {
 		const configs = { nicolive: true };
 		mockFn.mockImplementation(params => {
@@ -117,7 +115,7 @@ describe("Parameter checking from cli() to exportZip()", () => {
 			expect(params.nicolive).toBeTruthy();
 
 			const infoOption = params.exportInfo.option;
-			expect(infoOption.hashFilename).toBe(20);
+			expect(infoOption.hashFilename).toBeTruthy();
 			expect(infoOption.targetService).toBe("nicolive");
 			expect(infoOption.nicolive).toBeTruthy();
 			return Promise.resolve();
@@ -135,7 +133,6 @@ describe("Parameter checking from cli() to exportZip()", () => {
 			omitUnbundledJs: true
 		};
 		mockFn.mockImplementation(params => {
-			console.log(params);
 			expect(params.bundle).toBeTruthy();
 			expect(params.babel).toBeTruthy();
 			expect(params.strip).toBeTruthy();

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -12,6 +12,9 @@ export function cli(param: CliConfigExportZip): void {
 	if (!param.omitEmptyJs) {
 		logger.info("deprecated: --no-omit-empty-js is now always enabled since output may be broken without this option.");
 	}
+	if (param.nicolive && !param.hashFilename) {
+		param.hashFilename = true;
+	}
 
 	Promise.resolve()
 		.then(() => promiseExportZip({
@@ -25,7 +28,7 @@ export function cli(param: CliConfigExportZip): void {
 			source: param.cwd,
 			dest: param.output,
 			force: param.force,
-			hashLength: !param.hashFilename && !param.nicolive ? 0 :
+			hashLength: !param.hashFilename ? 0 :
 				(param.hashFilename === true) ? 20 : Number(param.hashFilename),
 			logger,
 			omitUnbundledJs: (param.bundle || param.nicolive) && param.omitUnbundledJs,


### PR DESCRIPTION
## 概要

export-zip で `--nicolive` オプションが真の場合に `--hash-filename` も真に設定します。
cli から exportZip にパラメータをを渡す部分のテストを追加。
