### PR TITLE
feat(serve): add Dockerfile

### DIFF
--- a/.github/workflows/serve_dockerfile_build_test.yml
+++ b/.github/workflows/serve_dockerfile_build_test.yml
@@ -1,0 +1,34 @@
+name: Build Test for serve Dockerfile
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "packages/akashic-cli-serve/**"
+
+env:
+  WORKING_DIR: packages/akashic-cli-serve
+  TEST_TAG: akashic/akashic-cli-serve:test
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Install
+        run: npm ci
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ env.WORKING_DIR }}
+          load: true
+          tags: ${{ env.TEST_TAG }}
+      - name: Test
+        run: |
+          docker run --rm ${{ env.TEST_TAG }} --version

--- a/packages/akashic-cli-serve/.dockerignore
+++ b/packages/akashic-cli-serve/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.git/
+.storybook/
+
+*.log

--- a/packages/akashic-cli-serve/.gitignore
+++ b/packages/akashic-cli-serve/.gitignore
@@ -6,3 +6,4 @@ www/internal
 lib
 config/
 www/public/external/engineFilesV*
+*.tar

--- a/packages/akashic-cli-serve/Dockerfile
+++ b/packages/akashic-cli-serve/Dockerfile
@@ -12,6 +12,7 @@ COPY www/ ./www/
 COPY build/ ./build/
 COPY src/ ./src/
 
+# lerna 環境だと各リポジトリ内の package-lock.json が不整合を起こすため npm ci は使えない
 RUN npm install
 
 COPY . .

--- a/packages/akashic-cli-serve/Dockerfile
+++ b/packages/akashic-cli-serve/Dockerfile
@@ -1,0 +1,42 @@
+FROM node:18.17-slim as build
+
+WORKDIR /app
+
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+# Required files for the build
+COPY package*.json ./
+COPY www/ ./www/
+COPY build/ ./build/
+COPY src/ ./src/
+
+RUN npm install
+
+COPY . .
+RUN npm prune --omit=dev
+
+FROM node:18.17-slim
+
+ENV TZ Asia/Tokyo
+ENV LANG ja_JP.UTF-8
+
+WORKDIR /app
+
+COPY --from=build --chown=node:node /tini /tini
+
+# Required files for startup
+COPY --from=build --chown=node:node /app/package.json ./
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+COPY --from=build --chown=node:node /app/bin ./bin
+COPY --from=build --chown=node:node /app/lib ./lib
+COPY --from=build --chown=node:node /app/www ./www
+COPY --from=build --chown=node:node /app/views ./views
+COPY --from=build --chown=node:node /app/build ./build
+COPY --from=build --chown=node:node /app/config ./config
+
+USER node
+EXPOSE 3300
+ENTRYPOINT ["/tini", "--", "node", "bin/run"]
+CMD ["/game"]

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -131,6 +131,53 @@ npm run storybook
 npm run copy:agv
 ```
 
+## Docker での起動
+
+以下コマンドで Docker コンテナを起動できます。
+
+```sh
+docker run \
+  -p 3300:3300 \
+  --name serve \
+  --rm \
+  -it \
+  --mount type=bind,src=/path/to/game,dst=/game,readonly akashic-cli-serve
+```
+
+`--mount` の `src` にコンテンツの絶対パス (`game.json` が存在するディレクトリ) を指定してください。
+`akashic-cli-serve` への引数を省略すると、 Docker コンテナ内部の `/game` をデフォルトのコンテンツのパスとして実行します。
+
+カレントディレクトリに `game.json` が存在する場合、Linux では以下のように実行できます。
+
+```sh
+docker run \
+  -p 3300:3300 \
+  --name serve \
+  --rm \
+  -it \
+  --mount type=bind,src=$(pwd),dst=/game,readonly akashic-cli-serve 
+```
+
+任意のオプション引数を `akashic-cli-serve` へ与える場合、`akashic-cli-serve` に対してコンテンツのパスを引数として明示的に指定してください。
+以下は `akashic-cli-serve` へ `--verbose` オプションを与えて実行する例です。
+Docker コンテナ内の `/game` をコンテンツのパスとして末尾で指定している点に注意してください。
+
+```sh
+docker run \
+  -p 3300:3300 \
+  --name serve \
+  --rm \
+  -it \
+  --mount type=bind,src=/path/to/game,dst=/game,readonly akashic-cli-serve \
+  --verbose /game
+```
+
+Windows 環境においては
+[バインドマウントの利用](https://matsuand.github.io/docs.docker.jp.onthefly/storage/bind-mounts/#start-a-container-with-a-bind-mount)
+および
+[Windows におけるパス変換](https://matsuand.github.io/docs.docker.jp.onthefly/desktop/windows/troubleshoot/#path-conversion-on-windows)
+を参考に適宜コンテンツのパスを変換してください。
+
 ## ライセンス
 
 本リポジトリは MIT License の元で公開されています。

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -133,12 +133,18 @@ npm run copy:agv
 
 ## Docker での起動
 
-以下コマンドで Docker コンテナを起動できます。
+以下コマンドで Docker イメージを作成します。
+
+```sh
+docker build -t akashic-cli-serve .
+```
+
+その後 Docker コンテナを起動してください。
 
 ```sh
 docker run \
   -p 3300:3300 \
-  --name serve \
+  --name akashic-cli-serve \
   --rm \
   -it \
   --mount type=bind,src=/path/to/game,dst=/game,readonly akashic-cli-serve
@@ -152,10 +158,10 @@ docker run \
 ```sh
 docker run \
   -p 3300:3300 \
-  --name serve \
+  --name akashic-cli-serve \
   --rm \
   -it \
-  --mount type=bind,src=$(pwd),dst=/game,readonly akashic-cli-serve 
+  --mount type=bind,src=$(pwd),dst=/game,readonly akashic-cli-serve
 ```
 
 任意のオプション引数を `akashic-cli-serve` へ与える場合、`akashic-cli-serve` に対してコンテンツのパスを引数として明示的に指定してください。

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -179,9 +179,9 @@ docker run \
 ```
 
 Windows 環境においては
-[バインドマウントの利用](https://matsuand.github.io/docs.docker.jp.onthefly/storage/bind-mounts/#start-a-container-with-a-bind-mount)
+[バインドマウントの利用](https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount)
 および
-[Windows におけるパス変換](https://matsuand.github.io/docs.docker.jp.onthefly/desktop/windows/troubleshoot/#path-conversion-on-windows)
+[Windows におけるパス変換](https://docs.docker.com/desktop/troubleshoot/topics/#path-conversion-on-windows)
 を参考に適宜コンテンツのパスを変換してください。
 
 ## ライセンス

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -184,6 +184,20 @@ Windows 環境においては
 [Windows におけるパス変換](https://docs.docker.com/desktop/troubleshoot/topics/#path-conversion-on-windows)
 を参考に適宜コンテンツのパスを変換してください。
 
+Mac の Apple Silicon (M1/M2) 環境において正常にビルドできない場合は Docker のベースイメージのアーキテクチャを `linux/amd64` に指定してください。
+
+```Dockerfile
+FROM --platform=linux/amd64 node:***
+```
+
+また、起動時に `--platform=linux/amd64` をオプションに加えてください。
+
+```sh
+docker run \
+  --platform linux/x86_64 \
+  ...
+```
+
 ## ライセンス
 
 本リポジトリは MIT License の元で公開されています。


### PR DESCRIPTION
# このPullRequestが解決する内容
akashic-cli-serve の Dockerfile を追加します。
Dockerfile 自体をテストするワークフローの追加は別で対応します。

最終的なイメージサイズは約 320 MB です。

```sh
$ docker image ls akashic-cli-serve 
REPOSITORY          TAG       IMAGE ID       CREATED          SIZE
akashic-cli-serve   latest    19e737cc4742   15 seconds ago   321MB
```