### PR TITLE
chore(serve): add build test for Dockerfile

### DIFF
--- a/.github/workflows/serve_dockerfile_build_test.yml
+++ b/.github/workflows/serve_dockerfile_build_test.yml
@@ -1,0 +1,34 @@
+name: Build Test for serve Dockerfile
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "packages/akashic-cli-serve/**"
+
+env:
+  WORKING_DIR: packages/akashic-cli-serve
+  TEST_TAG: akashic/akashic-cli-serve:test
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Install
+        run: npm ci
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ env.WORKING_DIR }}
+          load: true
+          tags: ${{ env.TEST_TAG }}
+      - name: Test
+        run: |
+          docker run --rm ${{ env.TEST_TAG }} --version


### PR DESCRIPTION
# このPullRequestが解決する内容

#1265 の Dockerfile をテストするワークフローを追加します。

参考: https://docs.docker.com/build/ci/github-actions/test-before-push/