### PR TITLE
Fix consolelog dump for serve

### DIFF
--- a/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
@@ -75,9 +75,10 @@ declare module ae {
 		fillRect(x: number, y: number, width: number, height: number, cssColor: string): void;
 	}
 
-	interface WeakRefKVSLike<T extends object> {
-		get(key: string | number): T | undefined; 
-	}
+	interface WeakRefKVSOrObjectTableLike {
+		get?(id: number): ae.ELike;  // WeakRefKVS 以降後用
+		[id: number]: ae.ELike; // 旧バージョン用
+	  }
 }
 
 declare module agv {
@@ -177,9 +178,9 @@ declare module agv {
 		external: GameExternalPluginsLike;
 
 		// to dump
-		db: ae.WeakRefKVSLike<ae.ELike>;
+		db: ae.WeakRefKVSOrObjectTableLike;
 		renderers: ae.RendererLike[];
-		_localDb: ae.WeakRefKVSLike<ae.ELike>;
+		_localDb: ae.WeakRefKVSOrObjectTableLike;
 		focusingCamera?: ae.CameraLike;
 		vars: any;
 		_modified?: boolean; // AEv3 でのみ存在

--- a/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/AkashicGameViewWeb.d.ts
@@ -74,6 +74,10 @@ declare module ae {
 		transform(mat: number[]): void;
 		fillRect(x: number, y: number, width: number, height: number, cssColor: string): void;
 	}
+
+	interface WeakRefKVSLike<T extends object> {
+		get(key: string | number): T | undefined; 
+	}
 }
 
 declare module agv {
@@ -173,9 +177,9 @@ declare module agv {
 		external: GameExternalPluginsLike;
 
 		// to dump
-		db: { [id: number]: ae.ELike };
+		db: ae.WeakRefKVSLike<ae.ELike>;
 		renderers: ae.RendererLike[];
-		_localDb: { [id: number]: ae.ELike };
+		_localDb: ae.WeakRefKVSLike<ae.ELike>;
 		focusingCamera?: ae.CameraLike;
 		vars: any;
 		_modified?: boolean; // AEv3 でのみ存在

--- a/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
@@ -82,7 +82,7 @@ export class ServeGameContent {
 			const eid = self._highlightedEntityId;
 			if (eid == null)
 				return ret;
-			const e = (eid >= 0) ? game.db.get(eid) : game._localDb.get(eid);
+			const e = (eid >= 0) ? (game.db.get?.(eid) ?? game.db[eid]) : (game._localDb.get?.(eid) ?? game._localDb[eid]);
 			if (!e)
 				return ret;
 			const renderer = game.renderers[0];  // TODO 0番だけで描画するのは暫定。現実的には0しかない。
@@ -159,7 +159,7 @@ export class ServeGameContent {
 	}
 
 	getRawEntity(eid: number): any {
-		return (eid >= 0) ? this._game.db.get(eid) : this._game._localDb.get(eid);
+		return (eid >= 0) ? (this._game.db.get?.(eid) ?? this._game.db[eid]) : (this._game._localDb.get?.(eid) ?? this._game._localDb[eid]);
 	}
 
 	changeHighlightedEntity(eid: number | null): void {

--- a/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/ServeGameContent.ts
@@ -82,7 +82,7 @@ export class ServeGameContent {
 			const eid = self._highlightedEntityId;
 			if (eid == null)
 				return ret;
-			const e = (eid >= 0) ? game.db[eid] : game._localDb[eid];
+			const e = (eid >= 0) ? game.db.get(eid) : game._localDb.get(eid);
 			if (!e)
 				return ret;
 			const renderer = game.renderers[0];  // TODO 0番だけで描画するのは暫定。現実的には0しかない。
@@ -159,7 +159,7 @@ export class ServeGameContent {
 	}
 
 	getRawEntity(eid: number): any {
-		return (eid >= 0) ? this._game.db[eid] : this._game._localDb[eid];
+		return (eid >= 0) ? this._game.db.get(eid) : this._game._localDb.get(eid);
 	}
 
 	changeHighlightedEntity(eid: number | null): void {


### PR DESCRIPTION
## 概要

serve で Devtools-Entitytree タブ内の `console.log()` 機能が undefined しか表示しないバグを修正します。

`g.game.db`, `g.game. _localDb` の型が `WeakRefKVS` に変わったため `g.game.db.get()` で取得するよう修正。

