### PR TITLE
Fix errorMessage when getImageSize() in akashi-cli-scan

### DIFF
--- a/packages/akashic-cli-scan/src/getImageSize.ts
+++ b/packages/akashic-cli-scan/src/getImageSize.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { extname } from "path";
+import { basename, extname } from "path";
 import { imageSize } from "image-size";
 import { parseSync } from "svgson";
 
@@ -36,5 +36,16 @@ export function getImageSize(path: string): ISize | null {
 		};
 	}
 
-	return imageSize(path);
+	let size: ISize | null = null;
+	try {
+		size = imageSize(path);
+	} catch (e) {
+		// CMYK ベースのカラープロファイル画像の場合、image-size でエラーとなる。エラーメッセージがわかりにくいためメッセージを差し替え。
+		if (e.message === "Corrupt JPG, exceeded buffer limits") {
+			const message = `Failed to get image size of ${basename(path)}. The image may not be in sRGB format.`;
+			throw new Error(message);
+		}
+		throw e;
+	}
+	return size;
 }


### PR DESCRIPTION
## 概要

akashic-cli-scan で CMYKベースのカラープロファイル画像のサイズを取得する時(image-size#imageSize()) に `image-size`がエラーを出力するが、メッセージから原因が解りにくいためエラーメッセージを差し替えて出力します。

**元のエラーメッセージ**
```
ERROR: Corrupt JPG, exceeded buffer limits
```

**修正後のエラーメッセージ**
```
ERROR: Failed to get image size of xxxxx.jpeg. The image may not be in sRGB format.
```
