### PR TITLE
Add warning output to exportzip

### DIFF
--- a/packages/akashic-cli-export/spec/src/utilsSpec.ts
+++ b/packages/akashic-cli-export/spec/src/utilsSpec.ts
@@ -1,6 +1,6 @@
 import * as utils from "../../lib/utils";
 
-describe("checkAudioAssetExtensions", () => {
+describe("warnLackOfAudioFile", () => {
 	const gamejson: any = {
 		assets: {
 			audio1: {
@@ -55,11 +55,11 @@ describe("checkAudioAssetExtensions", () => {
 
 	it("output warning logs", () => {
 		const spy = jest.spyOn(global.console, "warn");
-		utils.checkAudioAssetExtensions(Object.values(gamejson.assets));
+		Object.values(gamejson.assets).forEach((asset: any) => utils.warnLackOfAudioFile(asset));
 
 		/* eslint-disable max-len */
-		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .ogg file in assets/audio/se/audio2.");
-		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .m4a or .aac file in assets/audio/se/audio3.");
+		expect(spy).toHaveBeenCalledWith("No .ogg file found for assets/audio/se/audio2. This asset may not be played on some environments (e.g. Android)");
+		expect(spy).toHaveBeenCalledWith("Neither .m4a nor .aac file found for assets/audio/se/audio3. This asset may not be played on some environments (e.g. iOS)");
 		/* eslint-enable max-len */
 		spy.mockRestore();
 	});

--- a/packages/akashic-cli-export/spec/src/utilsSpec.ts
+++ b/packages/akashic-cli-export/spec/src/utilsSpec.ts
@@ -53,7 +53,7 @@ describe("checkAudioAssetExtensions", () => {
 		}
 	};
 
-	it("Log output when checkAudioAssetExtensions", () => {
+	it("output warning logs", () => {
 		const spy = jest.spyOn(global.console, "warn");
 		utils.checkAudioAssetExtensions(Object.values(gamejson.assets));
 

--- a/packages/akashic-cli-export/spec/src/utilsSpec.ts
+++ b/packages/akashic-cli-export/spec/src/utilsSpec.ts
@@ -1,0 +1,66 @@
+import * as utils from "../../lib/utils";
+
+describe("checkAudioAssetExtensions", () => {
+	const gamejson: any = {
+		assets: {
+			audio1: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				global: true,
+				path: "assets/audio/se/audio1",
+				hint: {
+				  extensions: [".ogg", ".m4a"]
+				}
+			},
+			audio2: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				global: true,
+				path: "assets/audio/se/audio2",
+				hint: {
+				  extensions: [".m4a"]
+				}
+			},
+			audio3: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				global: true,
+				path: "assets/audio/se/audio3",
+				hint: {
+				  extensions: [".ogg"]
+				}
+			},
+			audio4: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				global: true,
+				path: "assets/audio/se/audio4",
+				hint: {
+				  extensions: [".ogg", ".aac"]
+				}
+			},
+			nohint: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				path: "assets/audio/se/nohint",
+				global: true
+			}
+		}
+	};
+
+	it("Log output when checkAudioAssetExtensions", () => {
+		const spy = jest.spyOn(global.console, "warn");
+		utils.checkAudioAssetExtensions(Object.values(gamejson.assets));
+
+		/* eslint-disable max-len */
+		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .ogg file in assets/audio/se/audio2.");
+		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .m4a or .aac file in assets/audio/se/audio3.");
+		/* eslint-enable max-len */
+		spy.mockRestore();
+	});
+});

--- a/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
@@ -430,10 +430,10 @@ describe("convert", () => {
 					expect(gameJson.globalScripts.includes("node_modules/@hoge/testmodule/lib/ModuleC.js")).toBeFalsy();
 					expect(gameJson.globalScripts.includes("node_modules/@hoge/testmodule/lib/index.js")).toBeFalsy();
 					// バンドルに含まれず削除された利用されていない不要なファイルをログ出力
-					expect(consoleSpy).toHaveBeenCalledWith("node_modules/@hoge/testmodule/lib/ModuleB.js was not included in the bundle.");
-					expect(consoleSpy).toHaveBeenCalledWith("node_modules/@hoge/testmodule/lib/ModuleC.js was not included in the bundle.");
-					expect(consoleSpy).toHaveBeenCalledWith("node_modules/@hoge/testmodule/lib/index.js was not included in the bundle.");
-					expect(consoleSpy).toHaveBeenCalledWith("script/bar.js was not included in the bundle.");
+					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/ModuleB.js due to unreachable/unhandled.");
+					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/ModuleC.js due to unreachable/unhandled.");
+					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/index.js due to unreachable/unhandled.");
+					expect(consoleSpy).toHaveBeenCalledWith("excluded script/bar.js due to unreachable/unhandled.");
 					done();
 				}, done.fail);
 		});
@@ -645,6 +645,7 @@ describe("checkAudioAssetExtensions", () => {
 				duration: 456,
 				systemId: "sound",
 				global: true,
+				path: "assets/audio/se/audio1",
 				hint: {
 				  extensions: [".ogg", ".m4a"]
 				}
@@ -654,6 +655,7 @@ describe("checkAudioAssetExtensions", () => {
 				duration: 456,
 				systemId: "sound",
 				global: true,
+				path: "assets/audio/se/audio2",
 				hint: {
 				  extensions: [".m4a"]
 				}
@@ -663,6 +665,7 @@ describe("checkAudioAssetExtensions", () => {
 				duration: 456,
 				systemId: "sound",
 				global: true,
+				path: "assets/audio/se/audio3",
 				hint: {
 				  extensions: [".ogg"]
 				}
@@ -672,11 +675,18 @@ describe("checkAudioAssetExtensions", () => {
 				duration: 456,
 				systemId: "sound",
 				global: true,
+				path: "assets/audio/se/audio4",
 				hint: {
 				  extensions: [".ogg", ".aac"]
 				}
+			},
+			nohint: {
+				type: "audio",
+				duration: 456,
+				systemId: "sound",
+				path: "assets/audio/se/nohint",
+				global: true
 			}
-
 		}
 	};
 
@@ -684,8 +694,8 @@ describe("checkAudioAssetExtensions", () => {
 		const spy = jest.spyOn(global.console, "warn");
 		checkAudioAssetExtensions(gamejson);
 
-		expect(spy).toHaveBeenCalledWith(".ogg is missing from audio2.hint.extensions in game.json");
-		expect(spy).toHaveBeenCalledWith(".m4a or .aac is missing from audio3.hint.extensions in game.json");
+		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .ogg file in assets/audio/se/audio2.");
+		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .m4a or .aac file in assets/audio/se/audio3.");
 		spy.mockRestore();
 	});
 });

--- a/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
+++ b/packages/akashic-cli-export/spec/src/zip/convertSpec.ts
@@ -7,7 +7,6 @@ import {
 	bundleScripts,
 	convertGame,
 	ConvertGameParameterObject,
-	checkAudioAssetExtensions,
 	validateGameJsonForNicolive
 } from "../../../lib/zip/convert";
 
@@ -430,10 +429,12 @@ describe("convert", () => {
 					expect(gameJson.globalScripts.includes("node_modules/@hoge/testmodule/lib/ModuleC.js")).toBeFalsy();
 					expect(gameJson.globalScripts.includes("node_modules/@hoge/testmodule/lib/index.js")).toBeFalsy();
 					// バンドルに含まれず削除された利用されていない不要なファイルをログ出力
+					/* eslint-disable max-len */
 					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/ModuleB.js due to unreachable/unhandled.");
 					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/ModuleC.js due to unreachable/unhandled.");
 					expect(consoleSpy).toHaveBeenCalledWith("excluded node_modules/@hoge/testmodule/lib/index.js due to unreachable/unhandled.");
 					expect(consoleSpy).toHaveBeenCalledWith("excluded script/bar.js due to unreachable/unhandled.");
+					/* eslint-enable max-len */
 					done();
 				}, done.fail);
 		});
@@ -634,68 +635,5 @@ describe("game.json validation with nicolive option", () => {
 	it("nicolive property does not exist", () => {
 		delete gamejson.environment.nicolive;
 		expect(() => validateGameJsonForNicolive(gamejson)).toThrow();
-	});
-});
-
-describe("checkAudioAssetExtensions", () => {
-	const gamejson: any = {
-		assets: {
-			audio1: {
-				type: "audio",
-				duration: 456,
-				systemId: "sound",
-				global: true,
-				path: "assets/audio/se/audio1",
-				hint: {
-				  extensions: [".ogg", ".m4a"]
-				}
-			},
-			audio2: {
-				type: "audio",
-				duration: 456,
-				systemId: "sound",
-				global: true,
-				path: "assets/audio/se/audio2",
-				hint: {
-				  extensions: [".m4a"]
-				}
-			},
-			audio3: {
-				type: "audio",
-				duration: 456,
-				systemId: "sound",
-				global: true,
-				path: "assets/audio/se/audio3",
-				hint: {
-				  extensions: [".ogg"]
-				}
-			},
-			audio4: {
-				type: "audio",
-				duration: 456,
-				systemId: "sound",
-				global: true,
-				path: "assets/audio/se/audio4",
-				hint: {
-				  extensions: [".ogg", ".aac"]
-				}
-			},
-			nohint: {
-				type: "audio",
-				duration: 456,
-				systemId: "sound",
-				path: "assets/audio/se/nohint",
-				global: true
-			}
-		}
-	};
-
-	it("Log output when checkAudioAssetExtensions", () => {
-		const spy = jest.spyOn(global.console, "warn");
-		checkAudioAssetExtensions(gamejson);
-
-		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .ogg file in assets/audio/se/audio2.");
-		expect(spy).toHaveBeenCalledWith("may be no sound depending on the environment because no .m4a or .aac file in assets/audio/se/audio3.");
-		spy.mockRestore();
 	});
 });

--- a/packages/akashic-cli-export/src/utils.ts
+++ b/packages/akashic-cli-export/src/utils.ts
@@ -1,0 +1,25 @@
+import { AssetConfiguration } from "@akashic/game-configuration";
+
+/**
+ * audio アセットの拡張子チェック
+ */
+export function checkAudioAssetExtensions(assets: AssetConfiguration[]): void {
+	assets.forEach(asset => {
+		if (asset.type === "audio") {
+			if (asset.hint && asset.hint.extensions) {
+				let isOggExist = false;
+				let isM4aOrAacExist = false;
+				asset.hint.extensions.forEach(v => {
+					if (v === ".ogg") isOggExist = true;
+					if (v === ".m4a" || v === ".aac") isM4aOrAacExist = true;
+				});
+
+				if (!isOggExist)
+					console.warn(`may be no sound depending on the environment because no .ogg file in ${asset.path}.`);
+
+				if (!isM4aOrAacExist)
+					console.warn(`may be no sound depending on the environment because no .m4a or .aac file in ${asset.path}.`);
+			}
+		}
+	});
+}

--- a/packages/akashic-cli-export/src/utils.ts
+++ b/packages/akashic-cli-export/src/utils.ts
@@ -1,7 +1,7 @@
 import { AssetConfiguration } from "@akashic/game-configuration";
 
 /**
- * audio アセットの拡張子チェック
+ * audio アセットの拡張子をチェックし .ogg, .m4a/.aac が存在しない場合にログ出力する
  */
 export function checkAudioAssetExtensions(assets: AssetConfiguration[]): void {
 	assets.forEach(asset => {

--- a/packages/akashic-cli-export/src/utils.ts
+++ b/packages/akashic-cli-export/src/utils.ts
@@ -3,23 +3,22 @@ import { AssetConfiguration } from "@akashic/game-configuration";
 /**
  * audio アセットの拡張子をチェックし .ogg, .m4a/.aac が存在しない場合にログ出力する
  */
-export function checkAudioAssetExtensions(assets: AssetConfiguration[]): void {
-	assets.forEach(asset => {
-		if (asset.type === "audio") {
-			if (asset.hint && asset.hint.extensions) {
-				let isOggExist = false;
-				let isM4aOrAacExist = false;
-				asset.hint.extensions.forEach(v => {
-					if (v === ".ogg") isOggExist = true;
-					if (v === ".m4a" || v === ".aac") isM4aOrAacExist = true;
-				});
+export function warnLackOfAudioFile(asset: AssetConfiguration): void {
+	if (asset.type !== "audio") return;
 
-				if (!isOggExist)
-					console.warn(`may be no sound depending on the environment because no .ogg file in ${asset.path}.`);
+	if (asset.hint && asset.hint.extensions) {
+		let isOggExist = false;
+		let isM4aOrAacExist = false;
+		asset.hint.extensions.forEach(v => {
+			if (v === ".ogg") isOggExist = true;
+			if (v === ".m4a" || v === ".aac") isM4aOrAacExist = true;
+		});
 
-				if (!isM4aOrAacExist)
-					console.warn(`may be no sound depending on the environment because no .m4a or .aac file in ${asset.path}.`);
-			}
-		}
-	});
+		if (!isOggExist)
+			console.warn(`No .ogg file found for ${asset.path}. This asset may not be played on some environments (e.g. Android)`);
+
+		if (!isM4aOrAacExist)
+			// eslint-disable-next-line max-len
+			console.warn(`Neither .m4a nor .aac file found for ${asset.path}. This asset may not be played on some environments (e.g. iOS)`);
+	}
 }

--- a/packages/akashic-cli-export/src/zip/constants.ts
+++ b/packages/akashic-cli-export/src/zip/constants.ts
@@ -6,4 +6,4 @@ export const NICOLIVE_SIZE_LIMIT_GAME_JSON: number = 102400; // 100 KiB
 /**
  * ニコ生環境におけるゲームファイル全体 (展開後) の推奨サイズ制限
  */
-export const NICOLIVE_SIZE_LIMIT_TOTAL_FILE: number = 10485760; // 10 MiB
+export const NICOLIVE_SIZE_LIMIT_TOTAL_FILE: number = 31457280; // 30 MiB

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -205,7 +205,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 				const noBundledJs: string[] = files.filter(p => p.endsWith(".js") && !bundledFilePaths.includes(p));
 				noBundledJs.forEach(p => {
 					if (!preservingFilePathSet.has(p)) {
-						console.warn(`${p} was not included in the bundle.`);
+						console.warn(`excluded ${p} due to unreachable/unhandled.`);
 					}
 				});
 			}
@@ -404,10 +404,10 @@ export function checkAudioAssetExtensions(gamejson: cmn.GameConfiguration): void
 				});
 
 				if (!isOggExist)
-					console.warn(`.ogg is missing from ${key}.hint.extensions in game.json`);
+					console.warn(`may be no sound depending on the environment because no .ogg file in ${asset.path}.`);
 
 				if (!isM4aOrAacExist)
-					console.warn(`.m4a or .aac is missing from ${key}.hint.extensions in game.json`);
+					console.warn(`may be no sound depending on the environment because no .m4a or .aac file in ${asset.path}.`);
 			}
 		}
 	}

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -201,12 +201,11 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			gcu.removeGlobalScripts(gamejson, (filePath: string) => preservingFilePathSet.has(filePath));
 
 			if (param.bundle) {
-				const noBundledJs: string[] = files.filter(f => f.endsWith(".js")).filter(p => {
-					if (!bundledFilePaths.includes(p)) return p;
-				});
-				noBundledJs.forEach(f => {
-					if (!preservingFilePathSet.has(f)) {
-						console.warn(`${f} was not included in the bundle.`);
+				 // omitUnbundledJs が真の場合 preservingFilePathSet からjsが全て削除されているのでバンドルに含まれないファイルを取得
+				const noBundledJs: string[] = files.filter(p => p.endsWith(".js") && !bundledFilePaths.includes(p));
+				noBundledJs.forEach(p => {
+					if (!preservingFilePathSet.has(p)) {
+						console.warn(`${p} was not included in the bundle.`);
 					}
 				});
 			}

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -88,7 +88,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 		.then(() => cmn.ConfigurationFile.read(path.join(param.source, "game.json"), param.logger))
 		.then(async (result: cmn.GameConfiguration) => {
 			gamejson = result;
-			utils.checkAudioAssetExtensions(Object.values(gamejson.assets));
+			Object.values(gamejson.assets).forEach(asset => utils.warnLackOfAudioFile(asset));
 			if (param.nicolive) {
 				validateGameJsonForNicolive(gamejson);
 			}
@@ -201,8 +201,8 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			gcu.removeScriptAssets(gamejson, (filePath: string) => preservingFilePathSet.has(filePath));
 			gcu.removeGlobalScripts(gamejson, (filePath: string) => preservingFilePathSet.has(filePath));
 
-			if (param.bundle) {
-				 // omitUnbundledJs が真の場合 preservingFilePathSet からjsが全て削除されているのでバンドルに含まれないファイルを取得
+			if (param.bundle && param.omitUnbundledJs) {
+				 // omitUnbundledJs によって js ファイルが全て省かれる場合は警告する
 				const noBundledJs: string[] = files.filter(p => p.endsWith(".js") && !bundledFilePaths.includes(p));
 				noBundledJs.forEach(p => {
 					if (!preservingFilePathSet.has(p)) {


### PR DESCRIPTION
## 概要

- ニコ生ゲームのファイル全体の推奨サイズを 10Mb -> 30Mb へ変更。
- export-zip にて下記の場合に警告ログを出力します。
  - `--bundle` オプションでバンドルに含まれず消えた JS ファイルのログ出力
  - audio の拡張子不足 (.aac|.m4a と .ogg がないケース) のログ出力