### PR TITLE
fix(serve): fix -w causes reload twice

### DIFF
--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -229,9 +229,9 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 				if (err) {
 					getSystemLogger().error(err.message);
 				}
-				if (modTargetFlag === ModTargetFlags.GameJson) {
-					console.log("Reflect changes of game.json");
-				}
+				const timestamp = (new Date()).toTimeString().split(" ")[0]; // "hh:mm:dd"
+				const modifiedTarget = (modTargetFlag === ModTargetFlags.GameJson) ? "game.json" : "assets";
+				console.log(`[${chalk.gray(timestamp)}] Reflect changes of ${modifiedTarget}`);
 				// コンテンツに変更があったらplayを新規に作り直して再起動
 				const contentId = `${i}`;
 				const targetPlayIds: string[] = [];


### PR DESCRIPTION
掲題どおり。

serve の `--watch` オプションで、game.json 以外のファイル変更を検出すると、再実行が誤って 2 回起きる問題を解消します。

ユニットテストは chokidar の挙動を mock していて、この問題を確認できないので手を入れていません。手元の `akashic init -t typescript` したコンテンツで、 Mac/Windows の Node.js v18 系列で問題を解消することを目視しています。
