### PR TITLE
fix(commons): do not detect builtin modules

### DIFF
--- a/packages/akashic-cli-commons/src/NodeModules.ts
+++ b/packages/akashic-cli-commons/src/NodeModules.ts
@@ -111,11 +111,15 @@ export module NodeModules {
 		// これを検知した場合、そのモジュールへの依存はgame.jsonに追記せず、akashicコマンドユーザには警告を表示する。
 		const ignoreModulePaths = ["/akashic-cli-commons/node_modules/"];
 
+		// builtins (コアモジュール) を有効にすると browserify が polyfill したモジュールが b.on("dep", ...) で検出される。
+		// したがってここでは false を指定してコアモジュールの読み込みを禁止する。
+		const builtins = false;
+
 		const b = browserify({
 			entries: new StringStream(rootRequirer, dummyRootPath),
 			basedir: basepath,
 			preserveSymlinks: true, // npm link で node_modules 以下に置かれたモジュールを symlink パスのまま扱う
-			builtins: true  // builtins (コアモジュール) はサポートしていないが、b.on("dep", ...) で検出するためにtrueにする
+			builtins,
 		});
 		b.external("g");
 

--- a/packages/akashic-cli-serve/package-lock.json
+++ b/packages/akashic-cli-serve/package-lock.json
@@ -8883,9 +8883,9 @@
       }
     },
     "node_modules/@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.4.tgz",
+      "integrity": "sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==",
       "dev": true
     },
     "node_modules/@types/minimatch": {

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -95,6 +95,9 @@
     "webpack-cli": "5.0.1",
     "whatwg-fetch": "3.6.2"
   },
+  "overrides": {
+    "@types/mime": "3.0.4"
+  },
   "files": [
     "package.json",
     "README.md",


### PR DESCRIPTION
# このPullRequestが解決する内容

akashic-cli-scan のコアモジュールの検出において [browserify が polyfill しているモジュール](https://github.com/browserify/browserify/blob/e35437af10b9b628885102a6b8e0d1f39cb16c8d/lib/builtins.js) が検出されてしまうケースが存在するため、その機能を停止します。