### PR TITLE
chore: add 'release' label to PRs created by Renovate

### DIFF
--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -1,0 +1,38 @@
+name: Bump Version and Publish
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+env:
+  PUBLISH_VERSION: patch
+
+jobs:
+  publish:
+    # PullRequest に release ラベルが付与されている場合のみ実行
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Prepare
+        run: |
+          npm ci
+          npm run build
+          npm test
+      - name: Publish and Release
+        run: |
+          git config user.name 'github-actions'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          npm run publish:${{ env.PUBLISH_VERSION }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
           - "from-package"
 
 env:
-  NODE_VERSION: 14
+  NODE_VERSION: 18
 
 jobs:
   release:

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,8 @@
       "matchUpdateTypes": ["patch"],
       "matchPackagePatterns": ["^@akashic/"],
       "schedule": "at any time",
-      "groupName": "akashic patch dependencies"
+      "groupName": "akashic patch dependencies",
+      "labels": ["release"]
     },
     {
       "matchUpdateTypes": ["major"],
@@ -32,7 +33,7 @@
       "draftPR": true
     },
     {
-      "packagePatterns": ["^@storybook/"],
+      "matchPackagePatterns": ["^@storybook/"],
       "enabled": false
     }
   ],


### PR DESCRIPTION
# このPullRequestが解決する内容
- renovate による `@akashic/` のモジュールのパッチ更新の PullRequest に `release` ラベルを付与します。
- `release` ラベルが付与された PullRequest が `master` ブランチにマージされたときに `patch` バージョンを更新する GitHub Actions のワークフローを追加します。