### PR TITLE
fix(ci): fetch all history

### DIFF
--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # lerna-changelog の実行に tags の情報が必要なため明示的にすべての履歴を取得
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # lerna-changelog の実行に tags の情報が必要なため明示的にすべての履歴を取得
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
# このPullRequestが解決する内容
[lerna-changelog は内部的に `git describe` コマンドを実行している](https://github.com/lerna/lerna-changelog/blob/3138e8590ff1704d8fe076445c96e641fcc9fbd4/src/git.ts#L24) ため、shallow copy をすると lerna-chagelog の実行に失敗します。一方 [actions/checkout@v4](https://github.com/actions/checkout/tree/v4/) はデフォルトで `--fetch-depth: 1` を与えているため、明示的に `--fetch-depth: 0` を追加することで正常に動作するように修正します。