### PR TITLE
feat: add `--use-mmp` option

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigInstall.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigInstall.ts
@@ -5,5 +5,6 @@ export interface CliConfigInstall {
 	quiet?: boolean;
 	plugin?: number;
 	omitPackagejson?: boolean;
-	experimentalMmp?: boolean;
+	useMmp?: boolean;
+	// useMms?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
@@ -17,5 +17,6 @@ export interface CliConfigScanGlobalScripts {
 	quiet?: boolean;
 	fromEntryPoint?: boolean;
 	omitPackagejson?: boolean;
-	experimentalMmp?: boolean;
+	useMmp?: boolean;
+	// useMms?: boolean;
 }

--- a/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
@@ -172,7 +172,7 @@ describe("install()", function () {
 				expect(content.moduleMainPaths).toBeUndefined();
 				warnLogs = []; // 初期化
 			})
-			.then(() => promiseInstall({ moduleNames: ["noOmitPackagejson@0.0.0"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, noOmitPackagejson: true, experimentalMmp: true }))
+			.then(() => promiseInstall({ moduleNames: ["noOmitPackagejson@0.0.0"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, noOmitPackagejson: true, useMmp: true }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
 			.then((content) => {
 				const globalScripts = content.globalScripts;
@@ -214,7 +214,7 @@ describe("install()", function () {
 				globalScripts.push("node_modules/foo/foo.js");
 				cmn.ConfigurationFile.write(content, "./somedir/game.json", logger);
 			})
-			.then(() => promiseInstall({ moduleNames: ["dummy@1.0.1"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, experimentalMmp: true }))
+			.then(() => promiseInstall({ moduleNames: ["dummy@1.0.1"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, useMmp: true }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
 			.then((content) => {
 				const globalScripts = content.globalScripts;

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -41,7 +41,7 @@ commander
 	.option("-p, --plugin <code>", "Also add to operationPlugins with the code", (x: string) => parseInt(x, 10))
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
 	.option("--use-mmp", "Use moduleMainPaths in game.json")
-// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
+	// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)");
 
 export function run(argv: string[]): void {

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -3,18 +3,20 @@ import * as path from "path";
 import type { CliConfigInstall } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
+import type { InstallParameterObject} from "./install";
 import { promiseInstall } from "./install";
 
 function cli(param: CliConfigInstall): void {
 	const logger = new ConsoleLogger({ quiet: param.quiet });
-	const installParam = {
+	const installParam: InstallParameterObject = {
 		moduleNames: param.args,
 		cwd: param.cwd,
 		plugin: param.plugin,
 		logger: logger,
 		link: param.link,
 		noOmitPackagejson: !param.omitPackagejson,
-		experimentalMmp: param.experimentalMmp
+		useMmp: param.useMmp,
+		// useMms: param.useMms,
 	};
 	Promise.resolve()
 		.then(() => promiseInstall(installParam))
@@ -38,7 +40,9 @@ commander
 	.option("-q, --quiet", "Suppress output")
 	.option("-p, --plugin <code>", "Also add to operationPlugins with the code", (x: string) => parseInt(x, 10))
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
-	.option("--experimental-mmp", "Supports moduleMainPaths in game.json");
+	.option("--use-mmp", "Use moduleMainPaths in game.json")
+// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
+	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)");
 
 export function run(argv: string[]): void {
 	commander.parse(argv);
@@ -57,7 +61,8 @@ export function run(argv: string[]): void {
 			quiet: options.quiet ?? conf.quiet,
 			plugin: options.plugin ?? conf.plugin,
 			omitPackagejson: options.omitPackagejson ?? conf.omitPackagejson,
-			experimentalMmp: options.experimentalMmp ?? conf.experimentalMmp
+			useMmp: options.useMmp ?? conf.useMmp,
+			// useMms: options.useMms ?? conf.useMms,
 		});
 	});
 }

--- a/packages/akashic-cli-lib-manage/src/install/install.ts
+++ b/packages/akashic-cli-lib-manage/src/install/install.ts
@@ -49,9 +49,16 @@ export interface InstallParameterObject {
 	noOmitPackagejson?: boolean;
 
 	/**
-	 * game.json の moduleMainPaths をサポートするかどうか。
+	 * game.json の moduleMainPaths を利用するかどうか。
+	 * 省略された場合、 `false`
 	 */
-	experimentalMmp?: boolean;
+	useMmp?: boolean;
+
+	/**
+	 * game.json の moduleMainScripts を利用するかどうか。
+	 * この値は将来的に利用される値であり、現バージョンにおいては機能しない。
+	 */
+	// useMms?: boolean;
 }
 
 interface NormalizedInstallParameterObject extends Required<Omit<InstallParameterObject, "plugin" | "debugNpm">> {
@@ -68,7 +75,8 @@ function _normalizeInstallParameterObject(param: InstallParameterObject): Normal
 		logger: param.logger ?? new cmn.ConsoleLogger(),
 		noOmitPackagejson: !!param.noOmitPackagejson,
 		debugNpm: param.debugNpm ?? null,
-		experimentalMmp: !!param.experimentalMmp
+		useMmp: !!param.useMmp,
+		// useMms: !!param.useMms,
 	};
 }
 
@@ -132,8 +140,8 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 							? conf._content.environment["sandbox-runtime"] : "1";
 						conf.addToModuleMainScripts(packageJsonFiles, sandboxRuntime);
 
-						if (param.experimentalMmp) {
-							// TODO: --tmp-mmp を削除しデフォルト動作とする
+						if (param.useMmp) {
+							// TODO: --use-mmp を削除しデフォルト動作とする (その際に --use-mms の真偽値を分岐の条件に変更する)
 							conf.addModuleMainPaths(packageJsonFiles, sandboxRuntime);
 						}
 					}

--- a/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
+++ b/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
@@ -120,7 +120,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -149,9 +149,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js"
 		});
@@ -204,7 +202,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: { "dummy": {}, "dummy2": {}, "@scope/scoped": {} }
 			})
@@ -230,9 +228,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/@scope/scoped/package.json": "node_modules/@scope/scoped/root.js"
@@ -266,7 +262,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -288,9 +284,7 @@ describe("scanNodeModules", () => {
 		];
 		expect(globalScripts.length).toBe(expectedPaths.length);
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/noExtension.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/noExtension.js"
 		});
@@ -304,7 +298,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {}
 			})
@@ -385,7 +379,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -414,10 +408,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js",
-			"dummyChild": "node_modules/dummy/node_modules/dummyChild/index.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/dummy/node_modules/dummyChild/package.json": "node_modules/dummy/node_modules/dummyChild/index.js"
@@ -449,7 +440,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -478,10 +469,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js",
-			"dummyChild": "node_modules/dummyChild/index.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/dummyChild/package.json": "node_modules/dummyChild/index.js"
@@ -508,7 +496,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"invalidDummy": {}
@@ -594,7 +582,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {}, "dummy2": {}, "@scope/scoped": {}
@@ -622,12 +610,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js",
-			"dummyChild": "node_modules/dummy/node_modules/dummyChild/index.js",
-			"dummy2": "node_modules/dummy2/index.js",
-			"@scope/scoped": "node_modules/@scope/scoped/root.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/dummy/node_modules/dummyChild/package.json": "node_modules/dummy/node_modules/dummyChild/index.js",
@@ -695,7 +678,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {}, "dummy2": {}, "@scope/scoped": {}
@@ -728,12 +711,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js",
-			"dummyChild": "node_modules/dummy/node_modules/dummyChild/index.js",
-			"dummy2": "node_modules/dummy2/index.js",
-			"@scope/scoped": "node_modules/@scope/scoped/root.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/dummy/node_modules/dummyChild/package.json": "node_modules/dummy/node_modules/dummyChild/index.js",
@@ -827,7 +805,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -854,9 +832,7 @@ describe("scanNodeModules", () => {
 			expect(globalScripts.indexOf(expectedPath)).not.toBe(-1);
 		}
 
-		expect(moduleMainScripts).toEqual({
-			"dummyChild": "node_modules/dummyChild/main.js"
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummyChild/package.json": "node_modules/dummyChild/main.js"
 		});
@@ -926,7 +902,7 @@ describe("scanNodeModules", () => {
 
 		await scanNodeModules({
 			logger: nullLogger,
-			experimentalMmp: true,
+			useMmp: true,
 			debugNpm: new MockPromisedNpm({
 				expectDependencies: {
 					"dummy": {
@@ -952,10 +928,7 @@ describe("scanNodeModules", () => {
 		];
 		expect(globalScripts).toEqual(expectedPaths);
 
-		expect(moduleMainScripts).toEqual({
-			"dummy": "node_modules/dummy/main.js",
-			"dummyChild": "node_modules/dummy/node_modules/dummyChild/index.js",
-		});
+		expect(moduleMainScripts).toBeUndefined();
 		expect(moduleMainPaths).toEqual({
 			"node_modules/dummy/package.json": "node_modules/dummy/main.js",
 			"node_modules/dummy/node_modules/dummyChild/package.json": "node_modules/dummy/node_modules/dummyChild/index.js",

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -95,7 +95,9 @@ commander
 	.option("-e, --from-entry-point", "Scan from the entry point instead of `npm ls`")
 	.option("-q, --quiet", "Suppress output")
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
-	.option("--experimental-mmp", "Supports moduleMainPaths in game.json")
+	.option("--use-mmp", "Use moduleMainPaths in game.json")
+	// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
+	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)")
 	.action((opts: CliConfigScanGlobalScripts = {}) => {
 		const logger = new ConsoleLogger({ quiet: opts.quiet });
 		scanNodeModules({
@@ -103,7 +105,8 @@ commander
 			logger,
 			fromEntryPoint: opts.fromEntryPoint,
 			noOmitPackagejson: !opts.omitPackagejson,
-			experimentalMmp: opts.experimentalMmp
+			useMmp: opts.useMmp,
+			// useMms: opts.useMms,
 		})
 			.catch((err: Error) => {
 				logger.error(err.message);


### PR DESCRIPTION
# このPullRequestが解決する内容
- `--experimental-mmp` オプションを `--use-mmp` オプションに変更します。
- akashic-cli-scan の `--use-mmp` オプションの挙動を修正します。
  - `--use-mmp` が指定されていない場合は `moduleMainPaths` を削除
  - `--use-mmp` が指定された場合は `moduleMainScripts` を削除
- `--use-mms` オプションを引数としてのみ定義
  - このオプションは現状においては機能しません。
  - `--use-mmp` オプションが将来的にデフォルトとなったときの移行先とする想定です。