### PR TITLE
feat(install): enable --use-mms option

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigInstall.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigInstall.ts
@@ -6,5 +6,5 @@ export interface CliConfigInstall {
 	plugin?: number;
 	omitPackagejson?: boolean;
 	useMmp?: boolean;
-	// useMms?: boolean;
+	useMms?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
@@ -18,5 +18,5 @@ export interface CliConfigScanGlobalScripts {
 	fromEntryPoint?: boolean;
 	omitPackagejson?: boolean;
 	useMmp?: boolean;
-	// useMms?: boolean;
+	useMms?: boolean;
 }

--- a/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
@@ -217,7 +217,7 @@ describe("install()", function () {
 
 				let content: any;
 
-				// 1. sandbox-runtime が 3 ではない場合は useMmp は無視される
+				// 1-1. sandbox-runtime が 3 ではない場合は useMmp は無視される
 				content = defaultConfig({
 					moduleMainPaths: {},
 					environment: { "sandbox-runtime": "2" },
@@ -227,7 +227,7 @@ describe("install()", function () {
 				content = await readConfig();
 				expect(content.moduleMainScripts).toEqual({ "dummy": "node_modules/dummy/index2.js" });
 
-				// 2. sandbox-runtime 3 にて moduleMainPaths のみ存在した場合は moduleMainPaths に追加
+				// 1-2. sandbox-runtime 3 にて moduleMainPaths のみ存在した場合は moduleMainPaths に追加
 				content = defaultConfig({
 					moduleMainPaths: {},
 					environment: { "sandbox-runtime": "3" },
@@ -238,7 +238,7 @@ describe("install()", function () {
 				expect(content.moduleMainScripts).toBeUndefined();
 				expect(content.moduleMainPaths).toEqual({ "node_modules/dummy/package.json": "node_modules/dummy/index2.js" });
 
-				// 3. sandbox-runtime 3 にて moduleMainScripts のみ存在した場合は moduleMainScripts に追加
+				// 1-3. sandbox-runtime 3 にて moduleMainScripts のみ存在した場合は moduleMainScripts に追加
 				content = defaultConfig({
 					moduleMainScripts: {},
 					environment: { "sandbox-runtime": "3" },
@@ -249,7 +249,7 @@ describe("install()", function () {
 				expect(content.moduleMainScripts).toEqual({ "dummy": "node_modules/dummy/index2.js" });
 				expect(content.moduleMainPaths).toBeUndefined();
 
-				// 4. sandbox-runtime 3 にて useMmp が有効なことを確認
+				// 1-4. sandbox-runtime 3 にて useMmp が有効なことを確認
 				content = defaultConfig({
 					environment: { "sandbox-runtime": "3" },
 				});
@@ -259,7 +259,7 @@ describe("install()", function () {
 				expect(content.moduleMainScripts).toBeUndefined();
 				expect(content.moduleMainPaths).toEqual({ "node_modules/dummy/package.json": "node_modules/dummy/index2.js" });
 
-				// 5. sandbox-runtime 3 にて useMms が有効なことを確認
+				// 1-5. sandbox-runtime 3 にて useMms が有効なことを確認
 				content = defaultConfig({
 					environment: { "sandbox-runtime": "3" },
 				});

--- a/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/install/installSpec.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as mockfs from "mock-fs";
 import * as cmn from "@akashic/akashic-cli-commons";
-import { promiseInstall } from "../../../lib/install/install";
+import { InstallParameterObject, promiseInstall } from "../../../lib/install/install";
 import { workaroundMockFsExistsSync } from "../testUtils"; 
 
 describe("install()", function () {
@@ -49,21 +49,7 @@ describe("install()", function () {
 	});
 
 	it("installs modules and update globalScripts", function (done) {
-		let warnLogs: string[] = [];
-		const logger: cmn.Logger = {
-			warn: function(message) {
-				warnLogs.push(message);
-			},
-			info: function(_message) {
-				// do nothing
-			},
-			print: function(_message) {
-				// do nothing
-			},
-			error: function(_message) {
-				// do nothing
-			},
-		};
+		const logger = new cmn.ConsoleLogger({ quiet: true, debugLogMethod: () => {/* do nothing */} });
 
 		let mockModules: any = {
 			"dummy": {
@@ -143,13 +129,7 @@ describe("install()", function () {
 					"dummy": "node_modules/dummy/main.js",
 					"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js"
 				});
-				expect(warnLogs.length).toBe(1);
-				expect(warnLogs[0]).toBe(
-					"Newly added the moduleMainScripts property to game.json." +
-					"This property, introduced by akashic-cli@>=1.12.2, is NOT supported by older versions of Akashic Engine." +
-					"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
-				);
-				warnLogs = []; // 初期化
+				expect(content.moduleMainPaths).toBeUndefined();
 			})
 			.then(() => promiseInstall({ moduleNames: ["dummy2@1.0.1"], cwd: "./somedir", plugin: 12, logger: logger, debugNpm: dummyNpm }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
@@ -173,14 +153,12 @@ describe("install()", function () {
 					"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js"
 				});
 				expect(content.moduleMainPaths).toBeUndefined();
-				warnLogs = []; // 初期化
 			})
-			.then(() => promiseInstall({ moduleNames: ["noOmitPackagejson@0.0.0"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, noOmitPackagejson: true, useMmp: true }))
+			.then(() => promiseInstall({ moduleNames: ["noOmitPackagejson@0.0.0"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, noOmitPackagejson: true }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
 			.then((content) => {
 				const globalScripts = content.globalScripts;
 
-				expect(warnLogs.length).toBe(0);
 				expect(globalScripts.indexOf("node_modules/noOmitPackagejson/main.js")).not.toBe(-1);
 				expect(globalScripts.indexOf("node_modules/noOmitPackagejson/package.json")).not.toBe(-1);
 				const moduleMainScripts = content.moduleMainScripts;
@@ -189,11 +167,7 @@ describe("install()", function () {
 					"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js",
 					"noOmitPackagejson": "node_modules/noOmitPackagejson/main.js"
 				});
-				const moduleMainPaths = content.moduleMainPaths;
-				expect(moduleMainPaths).toEqual({
-					"node_modules/noOmitPackagejson/package.json": "node_modules/noOmitPackagejson/main.js"
-				});
-				warnLogs = []; // 初期化
+				expect(content.moduleMainPaths).toBeUndefined();
 			})
 			.then(() => {
 				// dummyモジュールの定義を書き換えて反映されるか確認する
@@ -217,12 +191,10 @@ describe("install()", function () {
 				globalScripts.push("node_modules/foo/foo.js");
 				cmn.ConfigurationFile.write(content, "./somedir/game.json", logger);
 			})
-			.then(() => promiseInstall({ moduleNames: ["dummy@1.0.1"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, useMmp: true }))
+			.then(() => promiseInstall({ moduleNames: ["dummy@1.0.1"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm }))
 			.then(() => cmn.ConfigurationFile.read("./somedir/game.json", logger))
 			.then((content) => {
 				const globalScripts = content.globalScripts;
-
-				expect(warnLogs.length).toBe(0);
 				expect(globalScripts.indexOf("node_modules/dummy/main.js")).toBe(-1);
 				expect(globalScripts.indexOf("node_modules/dummy/foo.js")).toBe(-1);
 				expect(globalScripts.indexOf("node_modules/dummy/node_modules/dummyChild/main.js")).toBe(-1);
@@ -235,12 +207,92 @@ describe("install()", function () {
 					"dummyChild": "node_modules/dummy/node_modules/dummyChild/main.js",
 					"noOmitPackagejson": "node_modules/noOmitPackagejson/main.js"
 				});
-				const moduleMainPaths = content.moduleMainPaths;
-				expect(moduleMainPaths).toEqual({
-					"node_modules/noOmitPackagejson/package.json": "node_modules/noOmitPackagejson/main.js",
-					"node_modules/dummy/package.json": "node_modules/dummy/index2.js"
-				});
+			})
+			.then(async () => {
+				// moduleMainPaths の動作確認
+				const install = (param?: InstallParameterObject) => promiseInstall({ moduleNames: ["dummy@1.0.1"], cwd: "./somedir", logger: logger, debugNpm: dummyNpm, ...param });
+				const readConfig = () => cmn.ConfigurationFile.read("./somedir/game.json", logger);
+				const writeConfig = () => cmn.ConfigurationFile.write(content, "./somedir/game.json", logger);
+				const defaultConfig = (config?: any) => ({...config});
 
+				let content: any;
+
+				// 1. sandbox-runtime が 3 ではない場合は useMmp は無視される
+				content = defaultConfig({
+					moduleMainPaths: {},
+					environment: { "sandbox-runtime": "2" },
+				});
+				await writeConfig();
+				await install({ useMmp: true });
+				content = await readConfig();
+				expect(content.moduleMainScripts).toEqual({ "dummy": "node_modules/dummy/index2.js" });
+
+				// 2. sandbox-runtime 3 にて moduleMainPaths のみ存在した場合は moduleMainPaths に追加
+				content = defaultConfig({
+					moduleMainPaths: {},
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await install();
+				content = await readConfig();
+				expect(content.moduleMainScripts).toBeUndefined();
+				expect(content.moduleMainPaths).toEqual({ "node_modules/dummy/package.json": "node_modules/dummy/index2.js" });
+
+				// 3. sandbox-runtime 3 にて moduleMainScripts のみ存在した場合は moduleMainScripts に追加
+				content = defaultConfig({
+					moduleMainScripts: {},
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await install();
+				content = await readConfig();
+				expect(content.moduleMainScripts).toEqual({ "dummy": "node_modules/dummy/index2.js" });
+				expect(content.moduleMainPaths).toBeUndefined();
+
+				// 4. sandbox-runtime 3 にて useMmp が有効なことを確認
+				content = defaultConfig({
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await install({ useMmp: true });
+				content = await readConfig();
+				expect(content.moduleMainScripts).toBeUndefined();
+				expect(content.moduleMainPaths).toEqual({ "node_modules/dummy/package.json": "node_modules/dummy/index2.js" });
+
+				// 5. sandbox-runtime 3 にて useMms が有効なことを確認
+				content = defaultConfig({
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await install({ useMms: true });
+				content = await readConfig();
+				expect(content.moduleMainScripts).toEqual({ "dummy": "node_modules/dummy/index2.js" });
+				expect(content.moduleMainPaths).toBeUndefined();
+
+				// 2-1. sandbox-runtime 3 にて moduleMainPaths と moduleMainScripts が両方とも存在した場合はエラー
+				content = defaultConfig({
+					moduleMainScripts: {},
+					moduleMainPaths: {},
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await expect(install()).rejects.toThrow();
+
+				// 2-2. sandbox-runtime 3 にて moduleMainScripts が存在する場合に useMmp を有効にするとエラー
+				content = defaultConfig({
+					moduleMainScripts: {},
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await expect(install({ useMmp: true })).rejects.toThrow();
+
+				// 2-3. sandbox-runtime 3 にて moduleMainPaths が存在する場合に useMms を有効にするとエラー
+				content = defaultConfig({
+					moduleMainPaths: {},
+					environment: { "sandbox-runtime": "3" },
+				});
+				await writeConfig();
+				await expect(install({ useMms: true })).rejects.toThrow();
 			})
 			.then(done, done.fail);
 	});

--- a/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
@@ -168,8 +168,8 @@ describe("uninstall()", function () {
 				const globalScripts = content.globalScripts;
 				expect(globalScripts).toEqual([]);
 				const moduleMainScripts = content.moduleMainScripts;
-				expect(moduleMainScripts).toBeUndefined();
-				expect(content.moduleMainPaths).toBeUndefined();
+				expect(moduleMainScripts).toEqual({});
+				expect(content.moduleMainPaths).toEqual({});
 			})
 			.then(done, done.fail);
 	});

--- a/packages/akashic-cli-lib-manage/src/install/Configuration.ts
+++ b/packages/akashic-cli-lib-manage/src/install/Configuration.ts
@@ -30,32 +30,18 @@ export class Configuration extends cmn.Configuration {
 		}
 	}
 
-	addToModuleMainScripts(packageJsonFiles: string[], sandboxRuntime: string): void {
+	addToModuleMainScripts(packageJsonFiles: string[]): void {
 		this._logger.info("Adding file paths to moduleMainScripts...");
 		const moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsonFiles);
 		if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
-			if (! this._content.moduleMainScripts && (sandboxRuntime === "1" || sandboxRuntime === "2")) {
-				this._logger.warn(
-					"Newly added the moduleMainScripts property to game.json." +
-					"This property, introduced by akashic-cli@>=1.12.2, is NOT supported by older versions of Akashic Engine." +
-					"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
-				);
-			}
 			this._content.moduleMainScripts = Object.assign(this._content.moduleMainScripts || {}, moduleMainScripts);
 		}
 	}
 
-	addModuleMainPaths(packageJsonFiles: string[], sandboxRuntime: string): void {
+	addModuleMainPaths(packageJsonFiles: string[]): void {
 		this._logger.info("Adding file paths to moduleMainPaths...");
 		const moduleMainPaths = cmn.NodeModules.listModuleMainPaths(packageJsonFiles);
 		if (moduleMainPaths && Object.keys(moduleMainPaths).length > 0) {
-			if (! this._content.moduleMainScripts && (sandboxRuntime === "1" || sandboxRuntime === "2")) {
-				this._logger.warn(
-					"Newly added the moduleMainScripts property to game.json." +
-					"This property, introduced by akashic-cli@>=1.12.2, is NOT supported by older versions of Akashic Engine." +
-					"Please ensure that you are using akashic-engine@>=2.0.2, >=1.12.7."
-				);
-			}
 			this._content.moduleMainPaths = Object.assign(this._content.moduleMainPaths || {}, moduleMainPaths);
 		}
 	}

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -16,7 +16,7 @@ function cli(param: CliConfigInstall): void {
 		link: param.link,
 		noOmitPackagejson: !param.omitPackagejson,
 		useMmp: param.useMmp,
-		// useMms: param.useMms,
+		useMms: param.useMms,
 	};
 	Promise.resolve()
 		.then(() => promiseInstall(installParam))
@@ -41,7 +41,6 @@ commander
 	.option("-p, --plugin <code>", "Also add to operationPlugins with the code", (x: string) => parseInt(x, 10))
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
 	.option("--use-mmp", "Use moduleMainPaths in game.json")
-	// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)");
 
 export function run(argv: string[]): void {
@@ -62,7 +61,7 @@ export function run(argv: string[]): void {
 			plugin: options.plugin ?? conf.plugin,
 			omitPackagejson: options.omitPackagejson ?? conf.omitPackagejson,
 			useMmp: options.useMmp ?? conf.useMmp,
-			// useMms: options.useMms ?? conf.useMms,
+			useMms: options.useMms ?? conf.useMms,
 		});
 	});
 }

--- a/packages/akashic-cli-lib-manage/src/install/install.ts
+++ b/packages/akashic-cli-lib-manage/src/install/install.ts
@@ -113,8 +113,10 @@ export function promiseInstall(param: InstallParameterObject): Promise<void> {
 
 			if (normalizedParam.useMmp && conf._content.moduleMainScripts != null)
 				throw new Error(
-					"To enable the `--use-mmp` option, remove the `moduleMainScripts` property. " +
-					"This issue may be resolved by running the following command: \n" +
+					"An old property `moduleMainScripts` found in game.json and rejected by `--use-mmp` " +
+					"option that forces to use `moduleMainPaths` instead. If you need `moduleMainScripts` " +
+					"(e.g. to support older Akashic Engine), remove `--use-mmp`. Otherwise run the " +
+					"following command to migrate to `moduleMainPaths`: \n" +
 					"> akashic scan globalScripts --use-mmp"
 				);
 			if (normalizedParam.useMms && conf._content.moduleMainPaths != null)

--- a/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
@@ -94,11 +94,14 @@ export function promiseUninstall(param: UninstallParameterObject): Promise<void>
 					conf.vacuumGlobalScripts();
 					const globalScripts = conf._content.globalScripts ?? [];
 					const packageJsons = cmn.NodeModules.listPackageJsonsFromScriptsPath(".", globalScripts);
-					const moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsons);
-					if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
-						conf._content.moduleMainScripts = moduleMainScripts;
-					} else {
-						delete conf._content.moduleMainScripts;
+
+					if (conf._content.moduleMainScripts) {
+						const moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsons);
+						if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
+							conf._content.moduleMainScripts = moduleMainScripts;
+						} else {
+							conf._content.moduleMainScripts = {};
+						}
 					}
 
 					if (conf._content.moduleMainPaths) {
@@ -106,7 +109,7 @@ export function promiseUninstall(param: UninstallParameterObject): Promise<void>
 						if (moduleMainPaths && Object.keys(moduleMainPaths).length > 0) {
 							conf._content.moduleMainPaths = moduleMainPaths;
 						} else {
-							delete conf._content.moduleMainPaths;
+							conf._content.moduleMainPaths = {};
 						}
 					}
 				})

--- a/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
+++ b/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
@@ -107,8 +107,6 @@ describe("scanNodeModules", () => {
 			});
 		};
 
-		afterEach(mockfs.restore);
-
 		test.each(["1", "2", undefined])("should be used `moduleMainScripts` if `sandbox-runtime` is `%s`", async sandboxRuntime => {
 			prepareMock({ environment: { "sandbox-runtime": sandboxRuntime } });
 			await scan({ useMmp: true });

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -96,7 +96,6 @@ commander
 	.option("-q, --quiet", "Suppress output")
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
 	.option("--use-mmp", "Use moduleMainPaths in game.json")
-	// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)")
 	.action((opts: CliConfigScanGlobalScripts = {}) => {
 		const logger = new ConsoleLogger({ quiet: opts.quiet });
@@ -106,7 +105,7 @@ commander
 			fromEntryPoint: opts.fromEntryPoint,
 			noOmitPackagejson: !opts.omitPackagejson,
 			useMmp: opts.useMmp,
-			// useMms: opts.useMms,
+			useMms: opts.useMms,
 		})
 			.catch((err: Error) => {
 				logger.error(err.message);

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -63,14 +63,14 @@ export interface ScanNodeModulesParameterObject {
 	/**
 	 * game.json の moduleMainPaths を優先して利用するかどうか。
 	 * `useMms` の指定よりも優先される。
-	 * 本値が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
+	 * 本値と `useMms` が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
 	 * 省略された場合、 `false` 。
 	 */
 	useMmp?: boolean;
 
 	/**
 	 * game.json の moduleMainScripts を優先して利用するかどうか。
-	 * 本値が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
+	 * 本値と `useMmp` が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
 	 * 省略された場合、 `false` 。
 	 */
 	useMms?: boolean;

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -114,10 +114,8 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 				useMmp = true;
 			} else if (param.useMms) {
 				useMmp = false;
-			} else if (content.moduleMainPaths != null) {
-				useMmp = true;
 			} else {
-				useMmp = false;
+				useMmp = content.moduleMainPaths != null;
 			}
 		} else {
 			useMmp = false;

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -109,7 +109,7 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 		let entryPaths: string | string[];
 		let useMmp: boolean = false;
 
-		if (sandboxRuntime === "3") {
+		if (sandboxRuntime !== "1" && sandboxRuntime !== "2") {
 			if (param.useMmp) {
 				useMmp = true;
 			} else if (param.useMms) {

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -137,7 +137,8 @@ try{
 	if (packageJson["dependencies"]) {
 		assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
 	}
-	assertNotContains(Object.keys(gameJson), "moduleMainScripts");
+	assertContains(Object.keys(gameJson), "moduleMainScripts");
+	assert.deepEqual(gameJson.moduleMainScripts, {});
 	assertNotContains(gameJson["globalScripts"], "node_modules/@akashic-extension/akashic-label/lib/index.js");
 
 	console.log("Completed!");


### PR DESCRIPTION
# このPullRequestが解決する内容
- akashic install において `--use-mms` をサポートします。
- akashic install の挙動を game.json に応じて変更します。
  - `environment."sandbox-runtime"` が 1, 2 の場合
    - 常に `moduleMainScirpts` が使用されます。
  - `environment."sandbox-runtime"` が 3 の場合
    - `moduleMainScirpts` が存在する場合はそちらが使用されます。
    - `moduleMainPaths` が存在する場合はそちらが使用されます。
    - `moduleMainScirpts` が存在する場合に `--use-mmp` を使用するとエラーとなります。
    - `moduleMainPaths` が存在する場合に `--use-mms` を使用するとエラーとなります。
    - `moduleMainScripts` と `moduleMainPaths` の両方が存在した場合はエラーとなります。