### PR TITLE
feat(scan): enable --use-mms option

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
@@ -18,5 +18,5 @@ export interface CliConfigScanGlobalScripts {
 	fromEntryPoint?: boolean;
 	omitPackagejson?: boolean;
 	useMmp?: boolean;
-	// useMms?: boolean;
+	useMms?: boolean;
 }

--- a/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
+++ b/packages/akashic-cli-lib-manage/spec/src/uninstall/uninstallSpec.ts
@@ -168,8 +168,8 @@ describe("uninstall()", function () {
 				const globalScripts = content.globalScripts;
 				expect(globalScripts).toEqual([]);
 				const moduleMainScripts = content.moduleMainScripts;
-				expect(moduleMainScripts).toBeUndefined();
-				expect(content.moduleMainPaths).toBeUndefined();
+				expect(moduleMainScripts).toEqual({});
+				expect(content.moduleMainPaths).toEqual({});
 			})
 			.then(done, done.fail);
 	});

--- a/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
@@ -94,11 +94,14 @@ export function promiseUninstall(param: UninstallParameterObject): Promise<void>
 					conf.vacuumGlobalScripts();
 					const globalScripts = conf._content.globalScripts ?? [];
 					const packageJsons = cmn.NodeModules.listPackageJsonsFromScriptsPath(".", globalScripts);
-					const moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsons);
-					if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
-						conf._content.moduleMainScripts = moduleMainScripts;
-					} else {
-						delete conf._content.moduleMainScripts;
+
+					if (conf._content.moduleMainScripts) {
+						const moduleMainScripts = cmn.NodeModules.listModuleMainScripts(packageJsons);
+						if (moduleMainScripts && Object.keys(moduleMainScripts).length > 0) {
+							conf._content.moduleMainScripts = moduleMainScripts;
+						} else {
+							conf._content.moduleMainScripts = {};
+						}
 					}
 
 					if (conf._content.moduleMainPaths) {
@@ -106,7 +109,7 @@ export function promiseUninstall(param: UninstallParameterObject): Promise<void>
 						if (moduleMainPaths && Object.keys(moduleMainPaths).length > 0) {
 							conf._content.moduleMainPaths = moduleMainPaths;
 						} else {
-							delete conf._content.moduleMainPaths;
+							conf._content.moduleMainPaths = {};
 						}
 					}
 				})

--- a/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
+++ b/packages/akashic-cli-scan/src/__tests__/src/scanNodeModulesSpec.ts
@@ -107,8 +107,6 @@ describe("scanNodeModules", () => {
 			});
 		};
 
-		afterEach(mockfs.restore);
-
 		test.each(["1", "2", undefined])("should be used `moduleMainScripts` if `sandbox-runtime` is `%s`", async sandboxRuntime => {
 			prepareMock({ environment: { "sandbox-runtime": sandboxRuntime } });
 			await scan({ useMmp: true });

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -96,7 +96,6 @@ commander
 	.option("-q, --quiet", "Suppress output")
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
 	.option("--use-mmp", "Use moduleMainPaths in game.json")
-	// NOTE: --use-mms は --use-mmp がデフォルトで有効となる場合に機能する値であり、現バージョンにおいては機能しない。
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)")
 	.action((opts: CliConfigScanGlobalScripts = {}) => {
 		const logger = new ConsoleLogger({ quiet: opts.quiet });
@@ -106,7 +105,7 @@ commander
 			fromEntryPoint: opts.fromEntryPoint,
 			noOmitPackagejson: !opts.omitPackagejson,
 			useMmp: opts.useMmp,
-			// useMms: opts.useMms,
+			useMms: opts.useMms,
 		})
 			.catch((err: Error) => {
 				logger.error(err.message);

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -63,14 +63,14 @@ export interface ScanNodeModulesParameterObject {
 	/**
 	 * game.json の moduleMainPaths を優先して利用するかどうか。
 	 * `useMms` の指定よりも優先される。
-	 * 本値が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
+	 * 本値と `useMms` が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
 	 * 省略された場合、 `false` 。
 	 */
 	useMmp?: boolean;
 
 	/**
 	 * game.json の moduleMainScripts を優先して利用するかどうか。
-	 * 本値が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
+	 * 本値と `useMmp` が `false` の場合、 game.json の内容に応じて `moduleMainPaths` と `moduleMainScripts` のどちらを利用するか判断する。
 	 * 省略された場合、 `false` 。
 	 */
 	useMms?: boolean;

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -114,10 +114,8 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 				useMmp = true;
 			} else if (param.useMms) {
 				useMmp = false;
-			} else if (content.moduleMainPaths != null) {
-				useMmp = true;
 			} else {
-				useMmp = false;
+				useMmp = content.moduleMainPaths != null;
 			}
 		} else {
 			useMmp = false;

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -109,7 +109,7 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 		let entryPaths: string | string[];
 		let useMmp: boolean = false;
 
-		if (sandboxRuntime === "3") {
+		if (sandboxRuntime !== "1" && sandboxRuntime !== "2") {
 			if (param.useMmp) {
 				useMmp = true;
 			} else if (param.useMms) {

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -137,7 +137,8 @@ try{
 	if (packageJson["dependencies"]) {
 		assertNotContains(Object.keys(packageJson["dependencies"]), "@akashic-extension/akashic-label");
 	}
-	assertNotContains(Object.keys(gameJson), "moduleMainScripts");
+	assertContains(Object.keys(gameJson), "moduleMainScripts");
+	assert.deepEqual(gameJson.moduleMainScripts, {});
 	assertNotContains(gameJson["globalScripts"], "node_modules/@akashic-extension/akashic-label/lib/index.js");
 
 	console.log("Completed!");


### PR DESCRIPTION
# このPullRequestが解決する内容

#1353 の後続対応です。

- akashic scan において `--use-mms` をサポートします。
- akashic scan の挙動を game.json に応じて変更します。
  - `environment."sandbox-runtime"` が 1, 2 の場合
    - 常に `moduleMainScripts` が使用され、 `moduleMainPaths` は削除されます。
  - `environment."sandbox-runtime"` が 3 の場合
    1 `--use-mmp` を使用すると、 `moduleMainPaths` が使用され `moduleMainScripts` は削除されます。
    2 `--use-mms` を使用すると、 `moduleMainScripts` が使用され `moduleMainPaths` は削除されます。
    3 `moduleMainPaths` が存在する場合はそちらが使用され、 `moduleMainScripts` は削除されます。
      - `moduleMainPaths` と `moduleMainScripts` が同時に存在する場合は `moduleMainPaths` が優先されます。
    4 `moduleMainScripts` のみが存在する場合はそちらが使用されます。
    5 `moduleMainPaths` と `moduleMainScripts` のどちらも存在しない場合は `moduleMainScripts` が使用されます。

- akashic uninstall の挙動を一部修正します。
  - akashic uninstall コマンド実行後に `moduleMainScripts` または `moduleMainPaths` が空になった場合、そのフィールドを削除するのではなく空マップ `{}`を代入します。