### PR TITLE
feat(stat): Support for "vector-image" and "binary" assets

### DIFF
--- a/packages/akashic-cli-extra/src/stat/stat.ts
+++ b/packages/akashic-cli-extra/src/stat/stat.ts
@@ -18,6 +18,7 @@ class SizeResult {
 	aacAudioSize: number;
 	m4aAudioSize: number;
 	scriptSize: number;
+	binarySize: number;
 	otherSize: number;
 	otherDetail: {[key: string]: number};
 
@@ -30,28 +31,29 @@ class SizeResult {
 		this.aacAudioSize = 0;
 		this.m4aAudioSize = 0;
 		this.scriptSize = 0;
+		this.binarySize = 0;
 		this.otherSize = 0;
 		this.otherDetail = { };
 	}
 
 	totalSizeOgg(): number {
 		return this.imageSize + this.vectorImageSize + this.textSize +
-			this.oggAudioSize + this.scriptSize + this.otherSize;
+			this.oggAudioSize + this.scriptSize + this.binarySize + this.otherSize;
 	}
 
 	totalSizeAac(): number {
 		return this.imageSize + this.vectorImageSize + this.textSize +
-			this.aacAudioSize + this.scriptSize + this.otherSize;
+			this.aacAudioSize + this.scriptSize + this.binarySize + this.otherSize;
 	}
 
 	totalSizeMp4(): number {
 		return this.imageSize + this.vectorImageSize + this.textSize +
-			this.mp4AudioSize + this.scriptSize + this.otherSize;
+			this.mp4AudioSize + this.scriptSize + this.binarySize + this.otherSize;
 	}
 
 	totalSizeM4a(): number {
 		return this.imageSize + this.vectorImageSize + this.textSize +
-			this.m4aAudioSize + this.scriptSize + this.otherSize;
+			this.m4aAudioSize + this.scriptSize + this.binarySize + this.otherSize;
 	}
 
 	sumOfTable(): number {
@@ -139,6 +141,7 @@ function showSize(param: StatSizeParameterObject, sizeResult: SizeResult): void 
 		}
 
 		param.logger.print(formatSize("script", sizeResult.scriptSize));
+		param.logger.print(formatSize("binary", sizeResult.binarySize));
 		param.logger.print(formatSize("other", sizeResult.otherSize));
 
 		Object.keys(sizeResult.otherDetail).forEach(key =>
@@ -244,6 +247,11 @@ function sizeOfAssets(param: StatSizeParameterObject, sizeResult: SizeResult): P
 				return fileSize(path.join(param.basepath, asset.path))
 					.then(size => {
 						sizeResult.scriptSize += size;
+					});
+			case "binary":
+				return fileSize(path.join(param.basepath, asset.path))
+					.then(size => {
+						sizeResult.binarySize += size;
 					});
 			case "audio":
 				let m4aExist = false;

--- a/packages/akashic-cli-extra/src/stat/stat.ts
+++ b/packages/akashic-cli-extra/src/stat/stat.ts
@@ -11,6 +11,7 @@ enum FileType {
 
 class SizeResult {
 	imageSize: number;
+	vectorImageSize: number;
 	textSize: number;
 	oggAudioSize: number;
 	mp4AudioSize: number;
@@ -22,6 +23,7 @@ class SizeResult {
 
 	constructor() {
 		this.imageSize = 0;
+		this.vectorImageSize = 0;
 		this.textSize = 0;
 		this.oggAudioSize = 0;
 		this.mp4AudioSize = 0;
@@ -33,22 +35,22 @@ class SizeResult {
 	}
 
 	totalSizeOgg(): number {
-		return this.imageSize + this.textSize +
+		return this.imageSize + this.vectorImageSize + this.textSize +
 			this.oggAudioSize + this.scriptSize + this.otherSize;
 	}
 
 	totalSizeAac(): number {
-		return this.imageSize + this.textSize +
+		return this.imageSize + this.vectorImageSize + this.textSize +
 			this.aacAudioSize + this.scriptSize + this.otherSize;
 	}
 
 	totalSizeMp4(): number {
-		return this.imageSize + this.textSize +
+		return this.imageSize + this.vectorImageSize + this.textSize +
 			this.mp4AudioSize + this.scriptSize + this.otherSize;
 	}
 
 	totalSizeM4a(): number {
-		return this.imageSize + this.textSize +
+		return this.imageSize + this.vectorImageSize + this.textSize +
 			this.m4aAudioSize + this.scriptSize + this.otherSize;
 	}
 
@@ -104,6 +106,7 @@ function showSize(param: StatSizeParameterObject, sizeResult: SizeResult): void 
 		const persent = (value: number): string => (value / totalSize * 100).toFixed(0);
 		const formatSize = (name: string, size: number): string => `${name}: ${sizeToString(size)} (${persent(size)}%)`;
 		param.logger.print(formatSize("image", sizeResult.imageSize));
+		param.logger.print(formatSize("vector-image", sizeResult.vectorImageSize));
 		param.logger.print(formatSize("text", sizeResult.textSize));
 
 		switch (largestFileType) {
@@ -226,6 +229,11 @@ function sizeOfAssets(param: StatSizeParameterObject, sizeResult: SizeResult): P
 				return fileSize(path.join(param.basepath, asset.path))
 					.then(size => {
 						sizeResult.imageSize += size;
+					});
+			case "vector-image":
+				return fileSize(path.join(param.basepath, asset.path))
+					.then(size => {
+						sizeResult.vectorImageSize += size;
 					});
 			case "text":
 				return fileSize(path.join(param.basepath, asset.path))


### PR DESCRIPTION
# このPullRequestが解決する内容
#1358 の対応です。

`akashic stat size` において typeが "vector-image" と "binary" のアセットに対応しました。