### PR TITLE
Fix exporthtml to copy sandboxconfigjs

### DIFF
--- a/packages/akashic-cli-export/spec/fixtures/sample_game/sandbox.config.js
+++ b/packages/akashic-cli-export/spec/fixtures/sample_game/sandbox.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+    "autoSendEventName": "sessionParameter",
+    events: {
+        "sessionParameter": [
+        [
+            32,
+            0,
+            ":akashic",
+            {
+                "type":"start",
+                "parameters":{
+                    "mode": "ranking",
+                    "totalTimeLimit": 75 
+                }
+            }
+        ]
+    ]}
+};

--- a/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/spec/src/html/exportHTMLSpec.ts
@@ -194,4 +194,32 @@ describe("exportHTML", function () {
 			})
 			.then(done, done.fail);
 	});
+
+	it("promiseExportHTML - copy sandbox.config.js to TempDir", (done) => {
+		Promise.resolve()
+			.then(function () {
+				const param: exp.ExportHTMLParameterObject = {
+					logger: undefined,
+					cwd: path.join(__dirname, "..", "..", "fixtures", "sample_game"),
+					source: ".",
+					output: undefined,
+					force: true,
+					strip: true,
+					minify: true,
+					magnify: false,
+					unbundleText: false,
+					hashLength: 20,
+					autoSendEventName: "sessionParameter"
+				};
+				return exp.promiseExportHTML(param);
+			})
+			.then((dest) => {
+				const html = fsx.readFileSync(path.join(dest, "index.html")).toString("utf-8");
+				expect(html.indexOf("autoSendEventName") !== -1).toBeTruthy();
+				expect(html.indexOf("sessionParameter") !== -1).toBeTruthy();
+				fsx.removeSync(dest);
+			})
+			.then(done, done.fail);
+	});
+
 });

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -142,6 +142,9 @@ export function exportHTML(param: ExportHTMLParameterObject, cb: (err?: any) => 
 
 function createRenamedGame(sourcePath: string, hashLength: number, logger: cmn.Logger): Promise<string> {
 	const destDirPath = path.resolve(fs.mkdtempSync(path.join(os.tmpdir(), "akashic-export-html-")));
+	if (fs.existsSync(path.resolve(sourcePath, "sandbox.config.js"))) {
+		fs.copyFileSync(path.resolve(sourcePath, "sandbox.config.js"), path.resolve(destDirPath, "sandbox.config.js"));
+	}
 	Utils.copyContentFiles(sourcePath, destDirPath);
 	return Promise.resolve()
 		.then(() => cmn.ConfigurationFile.read(path.join(destDirPath, "game.json"), logger))


### PR DESCRIPTION
## 概要

export-html にて `-H` オプションで実行時に、sandbox.config.js が一時ディレクトリにコピーされない問題を修正。