### PR TITLE
Fix bug with export-html hash option

### DIFF
--- a/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
+++ b/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
@@ -55,8 +55,7 @@ describe("Renamer", function () {
 							},
 							bar_plugin: {
 								"type": "script",
-								"path": "node_modules/foo/bar/barPlugin.js",
-								"global": true
+								"path": "node_modules/foo/bar/barPlugin.js"
 							}
 						},
 						globalScripts: [
@@ -137,7 +136,7 @@ describe("Renamer", function () {
 				expect(gamejson.assets["bar_plugin"]).toEqual({
 					type: 'script',
 					path: 'files/a57a44b454ed3a456b27.js',
-					global: true,
+					global: true,  // 元定義にはないが、globalScripts に存在するため true に書き換えられる
 					virtualPath: 'node_modules/foo/bar/barPlugin.js'
 				});
 				// moduleMainScripts はvirtualPathで扱うのでリネームされていてはならない

--- a/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
+++ b/packages/akashic-cli-commons/spec/src/RenamerSpec.ts
@@ -52,13 +52,20 @@ describe("Renamer", function () {
 								type: "audio",
 								path: "audio/foo",
 								global: true
+							},
+							bar_plugin: {
+								"type": "script",
+								"path": "node_modules/foo/bar/barPlugin.js",
+								"global": true
 							}
 						},
 						globalScripts: [
-							"node_modules/foo/bar/index.js"
+							"node_modules/foo/bar/index.js",
+							"node_modules/foo/bar/barPlugin.js"
 						],
 						moduleMainScripts: {
-							foo: "node_modules/foo/bar/index.js"
+							foo: "node_modules/foo/bar/index.js",
+							bar_plugin:"node_modules/foo/bar/barPlugin.js"
 						}
 					}),
 					script: {
@@ -75,7 +82,8 @@ describe("Renamer", function () {
 					node_modules: {
 						foo: {
 							bar: {
-								"index.js": "console.log('foo');"
+								"index.js": "console.log('foo');",
+								"barPlugin.js": "console.log('barPlugin.js');",
 							}
 						}
 					}
@@ -124,6 +132,13 @@ describe("Renamer", function () {
 					path: "files/825a514c9ba0f7565c0b.js",
 					virtualPath: "node_modules/foo/bar/index.js",
 					global: true
+				});
+				// asset と globalScripts で同じパスの場合は globalScripts の処理でリネームしない
+				expect(gamejson.assets["bar_plugin"]).toEqual({
+					type: 'script',
+					path: 'files/a57a44b454ed3a456b27.js',
+					global: true,
+					virtualPath: 'node_modules/foo/bar/barPlugin.js'
 				});
 				// moduleMainScripts はvirtualPathで扱うのでリネームされていてはならない
 				expect(gamejson.moduleMainScripts["foo"]).toBe("node_modules/foo/bar/index.js");

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -87,11 +87,13 @@ function _renameAssets(content: GameConfiguration, basedir: string, maxHashLengt
 }
 
 function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: Set<string>, basedir: string, maxHashLength: number): void {
+	const assetsValues = Object.values(content.assets);
 	if (content.globalScripts) {
 		content.globalScripts.forEach((name: string, idx: number) => {
 			const assetname = "a_e_z_" + idx;
 			const hashedFilePath = hashFilepath(name, maxHashLength);
 			const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
+			if ( assetsValues.find(v => v.path === hashedFilePath) ) return; // asset にハッシュ化済みの同パスがある場合はスキップ
 
 			content.assets[assetname] = {
 				type: /\.json$/i.test(name) ? "text" : "script",

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -94,7 +94,7 @@ function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: S
 			const assetname = "a_e_z_" + idx;
 			const hashedFilePath = hashFilepath(name, maxHashLength);
 			const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
-			if (pathSet.has(hashedFilePath)) return; // ハッシュ化済みの同パスがある場合はスキップ
+			if (pathSet.has(hashedFilePath)) return; // asset にハッシュ化済みの同パスがある場合はスキップ
 
 			content.assets[assetname] = {
 				type: /\.json$/i.test(name) ? "text" : "script",

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -89,7 +89,8 @@ function _renameAssets(content: GameConfiguration, basedir: string, maxHashLengt
 function _renameGlobalScripts(
 	content: GameConfiguration,
 	processedAssetPaths: Map<string, string>,
-	basedir: string, maxHashLength: number
+	basedir: string, 
+	maxHashLength: number
 ): void {
 	if (content.globalScripts) {
 		content.globalScripts.forEach((name: string, idx: number) => {
@@ -112,7 +113,7 @@ function _renameGlobalScripts(
 				path: hashedFilePath,
 				global: true
 			};
-			processedAssetPaths.set(hashedFilePath, name);
+			processedAssetPaths.set(hashedFilePath, assetname);
 			_renameFilename(basedir, name, hashedFilePath);
 		});
 

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -88,12 +88,13 @@ function _renameAssets(content: GameConfiguration, basedir: string, maxHashLengt
 
 function _renameGlobalScripts(content: GameConfiguration, processedAssetPaths: Set<string>, basedir: string, maxHashLength: number): void {
 	const assetsValues = Object.values(content.assets);
+	const pathSet = new Set(assetsValues.map(item => item.path));
 	if (content.globalScripts) {
 		content.globalScripts.forEach((name: string, idx: number) => {
 			const assetname = "a_e_z_" + idx;
 			const hashedFilePath = hashFilepath(name, maxHashLength);
 			const isRenamedAsset = processedAssetPaths.has(hashedFilePath);
-			if ( assetsValues.find(v => v.path === hashedFilePath) ) return; // asset にハッシュ化済みの同パスがある場合はスキップ
+			if (pathSet.has(hashedFilePath)) return; // ハッシュ化済みの同パスがある場合はスキップ
 
 			content.assets[assetname] = {
 				type: /\.json$/i.test(name) ? "text" : "script",


### PR DESCRIPTION
## 概要

game.json の asset と globalScripts に同じパスの定義があった場合に、export-html の hash 化オプション(-H) を実行した場合にコンテンツが起動しなくなる不具合を修正。
キーとなる名前が globalScripts のリネーム処理で `a_e_z_*` と変更されるので、game.json の asset で定義された名前で参照できなくなっていた。

**動作確認**
動作確認用コンテンツの game.json でプラグインの同パスとなる定義を、assets 側だけ、globalScripts 側だけ、assets と globalScriptsの両方に入れ、export-html -H を実行してコンテンツが動作する事を確認。
