### PR TITLE
fix(ci): `GITHUB_AUTH` -> `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -38,4 +38,4 @@ jobs:
           npm run publish:${{ env.PUBLISH_VERSION }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -38,4 +38,4 @@ jobs:
           npm run publish:${{ env.PUBLISH_VERSION }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
           version: npm run version-packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# このPullRequestが解決する内容

`GITHUB_AUTH` となっているのを `GITHUB_TOKEN` に修正します。
(なぜ `GITHUB_AUTH` と指定していたかの記憶が定かではありません..)

c.f. https://github.com/changesets/action?tab=readme-ov-file#with-publishing