### PR TITLE
fix: fix to resolve the engine-files aliases

### DIFF
--- a/.changeset/smooth-hairs-pump.md
+++ b/.changeset/smooth-hairs-pump.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-sandbox": patch
+"@akashic/akashic-cli-export": patch
+---
+
+fix to resolve the engine-files aliases

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,16 +125,16 @@
       "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
     },
     "node_modules/@akashic/headless-driver": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.15.2.tgz",
-      "integrity": "sha512-4EazoRZ4D+F84J8AVFT0/LzPW5ljevVFiDwOCBLOLyKirFLNBDsbPOq0rEihsqgAawwyY5DtUWAFFXAbH7K9CA==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.15.4.tgz",
+      "integrity": "sha512-uQQsZgA2cnTsc+NzT3a3FvIxkx7eOEHvgoYVHtx1jAg5m8oOkQCyjqWhu4BnwkUhPC/fZ/GfGpzlxfTBjgsSUg==",
       "dependencies": {
         "@akashic/amflow": "^3.2.0",
         "@akashic/playlog": "^3.2.0",
         "@akashic/trigger": "^2.0.0",
         "engine-files-v1": "npm:@akashic/engine-files@1.4.0",
         "engine-files-v2": "npm:@akashic/engine-files@2.4.0",
-        "engine-files-v3": "npm:@akashic/engine-files@3.8.2",
+        "engine-files-v3": "npm:@akashic/engine-files@3.8.4",
         "js-sha256": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "node-fetch": "^2.6.7"
@@ -15219,16 +15219,16 @@
     },
     "node_modules/engine-files-v3": {
       "name": "@akashic/engine-files",
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.8.2.tgz",
-      "integrity": "sha512-N3Cx0WX7/+9DSJTfPzlK6Ubry86MM4dyE1gwZ9HzrjAmI4xjHQi5vThAXvem1pI2JX/nTBP484R1RNOFuCV6TQ==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.8.4.tgz",
+      "integrity": "sha512-Bjxzt9L6xr9fB7vlJ4Fz/oOwQUxHfnvtnVEVNh3rI04WOd41Lw091BQqF2lN7zJNd64JZiG9gl0/UkxwPtYJdg==",
       "dependencies": {
         "@akashic/akashic-engine": "3.18.0",
         "@akashic/amflow": "3.3.0",
         "@akashic/amflow-util": "1.4.0",
         "@akashic/game-configuration": "2.3.0",
         "@akashic/game-driver": "2.21.0",
-        "@akashic/pdi-browser": "2.10.0",
+        "@akashic/pdi-browser": "2.10.2",
         "@akashic/pdi-common-impl": "1.4.0",
         "@akashic/pdi-types": "1.14.0",
         "@akashic/playlog": "3.3.0",
@@ -15273,9 +15273,9 @@
       }
     },
     "node_modules/engine-files-v3/node_modules/@akashic/pdi-browser": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.10.0.tgz",
-      "integrity": "sha512-HYQ2ZX/YzMVRcO1rDNCi0zC8f6Duwi7uonSPYOB8RIuMBlQxrqsH4f9GmRclgEvfS5vxIhsy7F7PtwH2jczwaw==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.10.2.tgz",
+      "integrity": "sha512-Duwz97p8dWHfMGXFc5ntGF0psU/yg0UR48R/iCL9JwjFqxMR+AyhojPnPmiAxC9qs8LZIoytE0M0h8JxQP6AjA==",
       "dependencies": {
         "@akashic/trigger": "^2.0.1"
       }
@@ -30867,16 +30867,16 @@
       }
     },
     "node_modules/socket.io": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
-      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.2.tgz",
+      "integrity": "sha512-Vp+lSks5k0dewYTfwgPT9UeGGd+ht7sCpB7p0e83VgO4X/AHYWhXITMrNk/pg8syY2bpx23ptClCQuHhqi2BgQ==",
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.4.1",
+        "engine.io": "~6.4.2",
         "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.1"
+        "socket.io-parser": "~4.2.4"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -30947,6 +30947,18 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
       "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -35708,17 +35720,17 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "2.17.3",
+      "version": "2.17.7",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-export": "1.9.3",
-        "@akashic/akashic-cli-extra": "1.7.2",
-        "@akashic/akashic-cli-init": "1.15.2",
-        "@akashic/akashic-cli-lib-manage": "1.9.2",
-        "@akashic/akashic-cli-sandbox": "1.1.2",
-        "@akashic/akashic-cli-scan": "0.17.2",
-        "@akashic/akashic-cli-serve": "1.16.3",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-export": "1.9.7",
+        "@akashic/akashic-cli-extra": "1.7.4",
+        "@akashic/akashic-cli-init": "1.15.4",
+        "@akashic/akashic-cli-lib-manage": "1.9.3",
+        "@akashic/akashic-cli-sandbox": "1.1.4",
+        "@akashic/akashic-cli-scan": "0.17.3",
+        "@akashic/akashic-cli-serve": "1.16.6",
         "commander": "^8.3.0"
       },
       "bin": {
@@ -35737,7 +35749,7 @@
     },
     "packages/akashic-cli-commons": {
       "name": "@akashic/akashic-cli-commons",
-      "version": "0.15.2",
+      "version": "0.15.3",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "2.3.0",
@@ -36802,13 +36814,13 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "1.9.3",
+      "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-extra": "1.7.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-extra": "1.7.4",
         "@akashic/game-configuration": "2.3.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "@babel/core": "7.20.2",
         "@babel/preset-env": "7.20.2",
         "archiver": "5.3.1",
@@ -39483,10 +39495,10 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "1.7.2",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "commander": "8.3.0",
         "ini": "4.1.1",
         "lodash.get": "4.4.2",
@@ -41492,11 +41504,11 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "1.15.2",
+      "version": "1.15.4",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-extra": "1.7.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-extra": "1.7.4",
         "commander": "8.3.0",
         "fs-extra": "11.2.0",
         "glob": "10.2.3",
@@ -42548,10 +42560,10 @@
     },
     "packages/akashic-cli-lib-manage": {
       "name": "@akashic/akashic-cli-lib-manage",
-      "version": "1.9.2",
+      "version": "1.9.3",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "commander": "8.3.0",
         "minipass": "3.3.5",
         "tar": "6.2.1"
@@ -43492,11 +43504,11 @@
     },
     "packages/akashic-cli-sandbox": {
       "name": "@akashic/akashic-cli-sandbox",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "^2.0.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "commander": "^11.0.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.8",
@@ -44395,10 +44407,10 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "aac-duration": "0.0.1",
         "chokidar": "^3.5.1",
         "commander": "^8.0.0",
@@ -45308,14 +45320,14 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "1.16.3",
+      "version": "1.16.6",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-scan": "0.17.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-scan": "0.17.3",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "@akashic/sandbox-configuration": "^2.3.0",
         "@akashic/trigger": "2.1.0",
         "@msgpack/msgpack": "2.8.0",
@@ -45330,7 +45342,7 @@
         "open": "8.4.0",
         "query-string": "6.14.1",
         "rxjs": "7.5.6",
-        "socket.io": "4.6.1",
+        "socket.io": "4.6.2",
         "socket.io-parser": "4.2.3"
       },
       "bin": {
@@ -47299,14 +47311,14 @@
     "@akashic/akashic-cli": {
       "version": "file:packages/akashic-cli",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-export": "1.9.3",
-        "@akashic/akashic-cli-extra": "1.7.2",
-        "@akashic/akashic-cli-init": "1.15.2",
-        "@akashic/akashic-cli-lib-manage": "1.9.2",
-        "@akashic/akashic-cli-sandbox": "1.1.2",
-        "@akashic/akashic-cli-scan": "0.17.2",
-        "@akashic/akashic-cli-serve": "1.16.3",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-export": "1.9.7",
+        "@akashic/akashic-cli-extra": "1.7.4",
+        "@akashic/akashic-cli-init": "1.15.4",
+        "@akashic/akashic-cli-lib-manage": "1.9.3",
+        "@akashic/akashic-cli-sandbox": "1.1.4",
+        "@akashic/akashic-cli-scan": "0.17.3",
+        "@akashic/akashic-cli-serve": "1.16.6",
         "@akashic/eslint-config": "1.1.0",
         "@types/node": "^14.18.30",
         "@typescript-eslint/eslint-plugin": "5.43.0",
@@ -48612,12 +48624,12 @@
     "@akashic/akashic-cli-export": {
       "version": "file:packages/akashic-cli-export",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-extra": "1.7.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-extra": "1.7.4",
         "@akashic/akashic-engine": "~2.6.7",
         "@akashic/eslint-config": "1.1.0",
         "@akashic/game-configuration": "2.3.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "@babel/core": "7.20.2",
         "@babel/preset-env": "7.20.2",
         "@types/archiver": "5.3.2",
@@ -50584,7 +50596,7 @@
     "@akashic/akashic-cli-extra": {
       "version": "file:packages/akashic-cli-extra",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "@akashic/eslint-config": "1.1.1",
         "@types/commander": "2.12.0",
         "@types/ini": "1.3.31",
@@ -52052,8 +52064,8 @@
     "@akashic/akashic-cli-init": {
       "version": "file:packages/akashic-cli-init",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-extra": "1.7.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-extra": "1.7.4",
         "@akashic/eslint-config": "1.1.1",
         "@types/commander": "2.12.0",
         "@types/express": "4.17.14",
@@ -52742,7 +52754,7 @@
     "@akashic/akashic-cli-lib-manage": {
       "version": "file:packages/akashic-cli-lib-manage",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "@akashic/eslint-config": "1.1.1",
         "@akashic/game-configuration": "2.3.0",
         "@types/commander": "2.12.2",
@@ -53362,7 +53374,7 @@
         "@akashic/akashic-engine": "~2.6.6",
         "@akashic/eslint-config": "^2.0.0",
         "@akashic/game-configuration": "^2.0.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "@akashic/sandbox-configuration": "^2.3.0",
         "@deboxsoft/cpx": "^1.5.0",
         "@types/ejs": "^3.1.1",
@@ -53950,7 +53962,7 @@
     "@akashic/akashic-cli-scan": {
       "version": "file:packages/akashic-cli-scan",
       "requires": {
-        "@akashic/akashic-cli-commons": "0.15.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
         "@akashic/eslint-config": "1.1.1",
         "@akashic/game-configuration": "2.3.0",
         "@types/image-size": "0.7.0",
@@ -54542,13 +54554,13 @@
       "version": "file:packages/akashic-cli-serve",
       "requires": {
         "@akashic/agvw": "^1.0.4",
-        "@akashic/akashic-cli-commons": "0.15.2",
-        "@akashic/akashic-cli-scan": "0.17.2",
+        "@akashic/akashic-cli-commons": "0.15.3",
+        "@akashic/akashic-cli-scan": "0.17.3",
         "@akashic/amflow": "~3.3.0",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/eslint-config": "1.1.1",
         "@akashic/game-configuration": "^2.1.0",
-        "@akashic/headless-driver": "2.15.2",
+        "@akashic/headless-driver": "2.15.4",
         "@akashic/pdi-types": "~1.14.0",
         "@akashic/playlog": "~3.3.0",
         "@akashic/sandbox-configuration": "^2.3.0",
@@ -54597,7 +54609,7 @@
         "rxjs": "7.5.6",
         "scroll-into-view-if-needed": "2.2.29",
         "shx": "0.3.4",
-        "socket.io": "4.6.1",
+        "socket.io": "4.6.2",
         "socket.io-client": "3.1.3",
         "socket.io-parser": "4.2.3",
         "storybook-addon-jsx": "7.3.14",
@@ -55359,16 +55371,16 @@
       }
     },
     "@akashic/headless-driver": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.15.2.tgz",
-      "integrity": "sha512-4EazoRZ4D+F84J8AVFT0/LzPW5ljevVFiDwOCBLOLyKirFLNBDsbPOq0rEihsqgAawwyY5DtUWAFFXAbH7K9CA==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@akashic/headless-driver/-/headless-driver-2.15.4.tgz",
+      "integrity": "sha512-uQQsZgA2cnTsc+NzT3a3FvIxkx7eOEHvgoYVHtx1jAg5m8oOkQCyjqWhu4BnwkUhPC/fZ/GfGpzlxfTBjgsSUg==",
       "requires": {
         "@akashic/amflow": "^3.2.0",
         "@akashic/playlog": "^3.2.0",
         "@akashic/trigger": "^2.0.0",
         "engine-files-v1": "npm:@akashic/engine-files@1.4.0",
         "engine-files-v2": "npm:@akashic/engine-files@2.4.0",
-        "engine-files-v3": "npm:@akashic/engine-files@3.8.2",
+        "engine-files-v3": "npm:@akashic/engine-files@3.8.4",
         "js-sha256": "^0.11.0",
         "lodash.clonedeep": "^4.5.0",
         "node-fetch": "^2.6.7"
@@ -67167,16 +67179,16 @@
       }
     },
     "engine-files-v3": {
-      "version": "npm:@akashic/engine-files@3.8.2",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.8.2.tgz",
-      "integrity": "sha512-N3Cx0WX7/+9DSJTfPzlK6Ubry86MM4dyE1gwZ9HzrjAmI4xjHQi5vThAXvem1pI2JX/nTBP484R1RNOFuCV6TQ==",
+      "version": "npm:@akashic/engine-files@3.8.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.8.4.tgz",
+      "integrity": "sha512-Bjxzt9L6xr9fB7vlJ4Fz/oOwQUxHfnvtnVEVNh3rI04WOd41Lw091BQqF2lN7zJNd64JZiG9gl0/UkxwPtYJdg==",
       "requires": {
         "@akashic/akashic-engine": "3.18.0",
         "@akashic/amflow": "3.3.0",
         "@akashic/amflow-util": "1.4.0",
         "@akashic/game-configuration": "2.3.0",
         "@akashic/game-driver": "2.21.0",
-        "@akashic/pdi-browser": "2.10.0",
+        "@akashic/pdi-browser": "2.10.2",
         "@akashic/pdi-common-impl": "1.4.0",
         "@akashic/pdi-types": "1.14.0",
         "@akashic/playlog": "3.3.0",
@@ -67225,9 +67237,9 @@
           }
         },
         "@akashic/pdi-browser": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.10.0.tgz",
-          "integrity": "sha512-HYQ2ZX/YzMVRcO1rDNCi0zC8f6Duwi7uonSPYOB8RIuMBlQxrqsH4f9GmRclgEvfS5vxIhsy7F7PtwH2jczwaw==",
+          "version": "2.10.2",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.10.2.tgz",
+          "integrity": "sha512-Duwz97p8dWHfMGXFc5ntGF0psU/yg0UR48R/iCL9JwjFqxMR+AyhojPnPmiAxC9qs8LZIoytE0M0h8JxQP6AjA==",
           "requires": {
             "@akashic/trigger": "^2.0.1"
           }
@@ -79124,16 +79136,27 @@
       }
     },
     "socket.io": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
-      "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.2.tgz",
+      "integrity": "sha512-Vp+lSks5k0dewYTfwgPT9UeGGd+ht7sCpB7p0e83VgO4X/AHYWhXITMrNk/pg8syY2bpx23ptClCQuHhqi2BgQ==",
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
         "debug": "~4.3.2",
-        "engine.io": "~6.4.1",
+        "engine.io": "~6.4.2",
         "socket.io-adapter": "~2.5.2",
-        "socket.io-parser": "~4.2.1"
+        "socket.io-parser": "~4.2.4"
+      },
+      "dependencies": {
+        "socket.io-parser": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+          "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+          "requires": {
+            "@socket.io/component-emitter": "~3.1.0",
+            "debug": "~4.3.1"
+          }
+        }
       }
     },
     "socket.io-adapter": {

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -225,7 +225,8 @@ export function validateEngineFilesName(filename: string, expectedMajorVersion: 
 
 export function resolveEngineFilesPath(version: string): string {
 	// @akashic/headless-driver が依存している engine-files-v* を直接参照
-	const engineFilesPackageDir = path.dirname(require.resolve(`engine-files-v${version}`));
+	const headlessDriverPath = require.resolve("@akashic/headless-driver");
+	const engineFilesPackageDir = path.dirname(require.resolve(`engine-files-v${version}`, {paths: [headlessDriverPath]}));
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-var-requires
 	const engineFilesPackageJson = require(`${engineFilesPackageDir}/package.json`);
 	const engineFilesName = `engineFilesV${engineFilesPackageJson.version.replace(/[\.-]/g, "_")}.js`;

--- a/packages/akashic-cli-sandbox/src/server/utils.ts
+++ b/packages/akashic-cli-sandbox/src/server/utils.ts
@@ -22,7 +22,8 @@ export function resolveEngineFilesPath(version: SandboxRuntimeVersion): string {
 	} else {
 		const engineFilesName = resolveEngineFilesVariable(version);
 		const libName = `engine-files-v${version}`;
-		engineFilesPath = path.join(path.dirname(require.resolve(libName)), `dist/raw/debug/full/${engineFilesName}.js`);
+		const engineFilesPackagePath = path.dirname(require.resolve(libName, { paths: [require.resolve("@akashic/headless-driver")] }));
+		engineFilesPath = path.join(engineFilesPackagePath, `dist/raw/debug/full/${engineFilesName}.js`);
 	}
 	return engineFilesPath;
 }


### PR DESCRIPTION
# このPullRequestが解決する内容
`engine-files-v*` のエイリアスを headless-driver のパスを基準に `require()` するように修正します。
akashic-cli-sandbox, akashic-cli-export html が手元で問題なく動作することを確認しています。