### PR TITLE
Change node-fetch in akashic-init to fetch

### DIFF
--- a/.changeset/sweet-eels-lay.md
+++ b/.changeset/sweet-eels-lay.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-init": patch
+---
+
+Change node-fetch in akashic-init to fetch

--- a/package-lock.json
+++ b/package-lock.json
@@ -9216,9 +9216,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.7.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.8.tgz",
-      "integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag=="
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -26027,11 +26030,11 @@
       }
     },
     "node_modules/pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=14.19.0"
       }
     },
     "node_modules/pnp-webpack-plugin": {
@@ -31829,8 +31832,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
@@ -34057,7 +34059,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -34231,17 +34234,17 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "2.17.10",
+      "version": "2.17.11",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-export": "1.9.10",
-        "@akashic/akashic-cli-extra": "1.7.5",
-        "@akashic/akashic-cli-init": "1.15.5",
-        "@akashic/akashic-cli-lib-manage": "1.9.4",
+        "@akashic/akashic-cli-export": "1.9.11",
+        "@akashic/akashic-cli-extra": "1.7.6",
+        "@akashic/akashic-cli-init": "1.15.6",
+        "@akashic/akashic-cli-lib-manage": "1.9.5",
         "@akashic/akashic-cli-sandbox": "1.1.6",
-        "@akashic/akashic-cli-scan": "0.17.4",
-        "@akashic/akashic-cli-serve": "1.16.8",
+        "@akashic/akashic-cli-scan": "0.17.5",
+        "@akashic/akashic-cli-serve": "1.16.9",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -35325,11 +35328,11 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "1.9.10",
+      "version": "1.9.11",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.5",
+        "@akashic/akashic-cli-extra": "1.7.6",
         "@akashic/game-configuration": "2.3.0",
         "@akashic/headless-driver": "2.15.5",
         "@babel/core": "7.20.2",
@@ -35344,7 +35347,7 @@
         "glob": "11.0.0",
         "https": "1.0.0",
         "maxrects-packer": "2.7.3",
-        "pngjs": "6.0.0",
+        "pngjs": "7.0.0",
         "uglify-js": "3.17.1"
       },
       "bin": {
@@ -36630,7 +36633,7 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "1.7.5",
+      "version": "1.7.6",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
@@ -37573,16 +37576,15 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "1.15.5",
+      "version": "1.15.6",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.5",
+        "@akashic/akashic-cli-extra": "1.7.6",
         "commander": "12.1.0",
         "fs-extra": "11.2.0",
         "glob": "11.0.0",
         "ignore": "5.2.4",
-        "node-fetch": "2.6.7",
         "prompt": "1.3.0",
         "unzipper": "0.10.11"
       },
@@ -37597,8 +37599,7 @@
         "@types/fs-extra": "9.0.13",
         "@types/jest": "29.5.12",
         "@types/mock-fs": "4.13.4",
-        "@types/node": "18.15.11",
-        "@types/node-fetch": "2.6.2",
+        "@types/node": "20.14.14",
         "@types/unzipper": "0.10.5",
         "@typescript-eslint/eslint-plugin": "5.43.0",
         "eslint": "8.27.0",
@@ -37694,12 +37695,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "packages/akashic-cli-init/node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-      "dev": true
     },
     "packages/akashic-cli-init/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.43.0",
@@ -38653,12 +38648,12 @@
     },
     "packages/akashic-cli-lib-manage": {
       "name": "@akashic/akashic-cli-lib-manage",
-      "version": "1.9.4",
+      "version": "1.9.5",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
         "commander": "12.1.0",
-        "minipass": "3.3.5",
+        "minipass": "7.1.2",
         "tar": "7.4.3"
       },
       "bin": {
@@ -39500,14 +39495,11 @@
       }
     },
     "packages/akashic-cli-lib-manage/node_modules/minipass": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.5.tgz",
-      "integrity": "sha512-rQ/p+KfKBkeNwo04U15i+hOwoVBVmekmm/HcfTkTN2t9pbQKCMm4eN5gFeqgrrSp/kH/7BYYhTIHOxGqzbBPaA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/akashic-cli-lib-manage/node_modules/minizlib": {
@@ -39553,14 +39545,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "packages/akashic-cli-lib-manage/node_modules/minizlib/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/akashic-cli-lib-manage/node_modules/minizlib/node_modules/rimraf": {
@@ -39715,14 +39699,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/akashic-cli-lib-manage/node_modules/tar/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "packages/akashic-cli-lib-manage/node_modules/tar/node_modules/yallist": {
@@ -39887,15 +39863,6 @@
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.4.tgz",
       "integrity": "sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==",
       "dev": true
-    },
-    "packages/akashic-cli-sandbox/node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
     },
     "packages/akashic-cli-sandbox/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -40664,7 +40631,7 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "0.17.4",
+      "version": "0.17.5",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
@@ -41577,11 +41544,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "1.16.8",
+      "version": "1.16.9",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-scan": "0.17.4",
+        "@akashic/akashic-cli-scan": "0.17.5",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.15.5",
@@ -43580,13 +43547,13 @@
       "version": "file:packages/akashic-cli",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-export": "1.9.10",
-        "@akashic/akashic-cli-extra": "1.7.5",
-        "@akashic/akashic-cli-init": "1.15.5",
-        "@akashic/akashic-cli-lib-manage": "1.9.4",
+        "@akashic/akashic-cli-export": "1.9.11",
+        "@akashic/akashic-cli-extra": "1.7.6",
+        "@akashic/akashic-cli-init": "1.15.6",
+        "@akashic/akashic-cli-lib-manage": "1.9.5",
         "@akashic/akashic-cli-sandbox": "1.1.6",
-        "@akashic/akashic-cli-scan": "0.17.4",
-        "@akashic/akashic-cli-serve": "1.16.8",
+        "@akashic/akashic-cli-scan": "0.17.5",
+        "@akashic/akashic-cli-serve": "1.16.9",
         "@akashic/eslint-config": "1.1.0",
         "@types/node": "^14.18.30",
         "@typescript-eslint/eslint-plugin": "5.43.0",
@@ -44893,7 +44860,7 @@
       "version": "file:packages/akashic-cli-export",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.5",
+        "@akashic/akashic-cli-extra": "1.7.6",
         "@akashic/akashic-engine": "~2.6.7",
         "@akashic/eslint-config": "1.1.0",
         "@akashic/game-configuration": "2.3.0",
@@ -44931,7 +44898,7 @@
         "minimatch": "5.1.6",
         "mock-fs": "5.2.0",
         "node-fetch": "2.6.7",
-        "pngjs": "6.0.0",
+        "pngjs": "7.0.0",
         "shx": "0.3.4",
         "typescript": "4.8.3",
         "uglify-js": "3.17.1",
@@ -46382,7 +46349,7 @@
       "version": "file:packages/akashic-cli-init",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.5",
+        "@akashic/akashic-cli-extra": "1.7.6",
         "@akashic/eslint-config": "1.1.1",
         "@types/commander": "2.12.0",
         "@types/express": "4.17.14",
@@ -46390,8 +46357,7 @@
         "@types/fs-extra": "9.0.13",
         "@types/jest": "29.5.12",
         "@types/mock-fs": "4.13.4",
-        "@types/node": "18.15.11",
-        "@types/node-fetch": "2.6.2",
+        "@types/node": "20.14.14",
         "@types/unzipper": "0.10.5",
         "@typescript-eslint/eslint-plugin": "5.43.0",
         "commander": "12.1.0",
@@ -46405,7 +46371,6 @@
         "ignore": "5.2.4",
         "jest": "29.7.0",
         "mock-fs": "5.2.0",
-        "node-fetch": "2.6.7",
         "prompt": "1.3.0",
         "rimraf": "3.0.2",
         "ts-jest": "29.1.2",
@@ -46474,12 +46439,6 @@
           "requires": {
             "@types/node": "*"
           }
-        },
-        "@types/node": {
-          "version": "18.15.11",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-          "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
-          "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
           "version": "5.43.0",
@@ -47102,7 +47061,7 @@
         "eslint-plugin-import": "2.26.0",
         "eslint-plugin-jest": "26.9.0",
         "jest": "29.7.0",
-        "minipass": "3.3.5",
+        "minipass": "7.1.2",
         "mock-fs": "5.2.0",
         "rimraf": "3.0.2",
         "tar": "7.4.3",
@@ -47637,12 +47596,9 @@
           }
         },
         "minipass": {
-          "version": "3.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.5.tgz",
-          "integrity": "sha512-rQ/p+KfKBkeNwo04U15i+hOwoVBVmekmm/HcfTkTN2t9pbQKCMm4eN5gFeqgrrSp/kH/7BYYhTIHOxGqzbBPaA==",
-          "requires": {
-            "yallist": "^4.0.0"
-          }
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
         },
         "minizlib": {
           "version": "3.0.1",
@@ -47673,11 +47629,6 @@
               "requires": {
                 "brace-expansion": "^2.0.1"
               }
-            },
-            "minipass": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-              "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
             },
             "rimraf": {
               "version": "5.0.10",
@@ -47778,11 +47729,6 @@
             "yallist": "^5.0.0"
           },
           "dependencies": {
-            "minipass": {
-              "version": "7.1.2",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-              "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
-            },
             "yallist": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -47910,15 +47856,6 @@
           "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-5.1.4.tgz",
           "integrity": "sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==",
           "dev": true
-        },
-        "@types/node": {
-          "version": "20.12.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-          "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
-          "dev": true,
-          "requires": {
-            "undici-types": "~5.26.4"
-          }
         },
         "@typescript-eslint/eslint-plugin": {
           "version": "6.21.0",
@@ -48993,7 +48930,7 @@
       "requires": {
         "@akashic/agvw": "^1.0.4",
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-scan": "0.17.4",
+        "@akashic/akashic-cli-scan": "0.17.5",
         "@akashic/amflow": "~3.3.0",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/eslint-config": "1.1.1",
@@ -56863,9 +56800,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.8.tgz",
-      "integrity": "sha512-/YP55EMK2341JkODUb8DM9O0x1SIz2aBvyF33Uf1c76St3VpsMXEIW0nxuKkq/5cxnbz0RD9cfwNZHEAZQD3ag=="
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -69543,9 +69483,9 @@
       }
     },
     "pngjs": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
-      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="
     },
     "pnp-webpack-plugin": {
       "version": "1.6.4",
@@ -74154,8 +74094,7 @@
     "undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "unfetch": {
       "version": "4.2.0",
@@ -75894,7 +75833,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -31,8 +31,7 @@
     "@types/fs-extra": "9.0.13",
     "@types/jest": "29.5.12",
     "@types/mock-fs": "4.13.4",
-    "@types/node": "18.15.11",
-    "@types/node-fetch": "2.6.2",
+    "@types/node": "20.14.14",
     "@types/unzipper": "0.10.5",
     "@typescript-eslint/eslint-plugin": "5.43.0",
     "eslint": "8.27.0",
@@ -54,7 +53,6 @@
     "fs-extra": "11.2.0",
     "glob": "11.0.0",
     "ignore": "5.2.4",
-    "node-fetch": "2.6.7",
     "prompt": "1.3.0",
     "unzipper": "0.10.11"
   },

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { readdir } from "@akashic/akashic-cli-commons/lib/FileSystem";
-import fetch from "node-fetch";
 import * as unzipper from "unzipper";
 
 // TODO: 適切な場所に移動
@@ -94,7 +93,9 @@ export async function fetchTemplate(metadata: TemplateMetadata): Promise<string>
 		}
 		case "remote": {
 			const { name, url } = metadata;
-			const zip = await (await fetch(url)).buffer();
+			const res = await fetch(url);
+			const arrayBuffer = await res.arrayBuffer();
+			const zip = Buffer.from(arrayBuffer);
 			const dest = fs.mkdtempSync(path.join(os.tmpdir(), name + "-"));
 			await _extractZip(zip, dest);
 			const templateRoot = await _findTemplateRoot(dest);

--- a/packages/akashic-cli-init/tsconfig.json
+++ b/packages/akashic-cli-init/tsconfig.json
@@ -6,7 +6,7 @@
     "outDir": "./lib",
     "declaration": true,
     "sourceMap": true,
-    "types" : ["commander", "fs-extra", "node", "node-fetch"],
+    "types" : ["commander", "fs-extra", "node"],
     "strict": true,
     "useUnknownInCatchVariables": false
   },


### PR DESCRIPTION
## 概要

akashic-init の `node-fetch` を node.js の `fetch` に置き換えます。
#915 で renovate の PR が出ていますが、`node-fetch` 自体の不具合で 2年前から issue も open 状態のため `fetch` を利用します。

**動作確認**
修正後の init を使用して、fetch で [template-list.json](https://akashic-contents.github.io/templates/template-list.json) を取得でき、init コマンドでテンプレートが利用できる事を確認。