### PR TITLE
chore(ci): enable concurrency in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: test
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+
+concurrency:
+  group: ${{ startsWith(github.head_ref, 'renovate/') && 'renovate' || format('{0}-{1}', github.workflow, github.ref) }}
+  cancel-in-progress: ${{ !startsWith(github.head_ref, 'renovate/') }}
 
 jobs:
   build:
@@ -21,9 +28,5 @@ jobs:
           cache: npm
       - name: Run test
         run: |
-          # npm において package-lock.json の optional dependencies を欠落するバグがあるらしく、削除した後に再インストールをする
-          # @see https://nx.dev/troubleshooting/troubleshoot-nx-install-issues#native-modules
-          # @see https://github.com/npm/cli/issues/4828
-          rm package-lock.json
-          npm install
+          npm ci
           npm test


### PR DESCRIPTION
# このPullRequestが解決する内容
test.yml で [concurrency ](https://docs.github.com/ja/actions/writing-workflows/choosing-what-your-workflow-does/using-concurrency)を有効にします。

- 同一 PullRequest (branch) 内での複数の CI の実行を停止
  - 新しいコミットが push されたら前に実行されていた CI をキャンセルするように
- renovate が作成する PullRequest/Commit に対しては `renovate` という concurrency でグループ化
  - この PullRequest については常にキャンセルしないように