### PR TITLE
chore: add extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34494,13 +34494,13 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "2.17.21",
+      "version": "2.17.22",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-export": "1.9.17",
-        "@akashic/akashic-cli-extra": "1.7.7",
-        "@akashic/akashic-cli-init": "1.15.8",
+        "@akashic/akashic-cli-export": "1.9.18",
+        "@akashic/akashic-cli-extra": "1.7.8",
+        "@akashic/akashic-cli-init": "1.15.9",
         "@akashic/akashic-cli-lib-manage": "1.9.6",
         "@akashic/akashic-cli-sandbox": "1.1.9",
         "@akashic/akashic-cli-scan": "0.17.7",
@@ -34608,11 +34608,11 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "1.9.17",
+      "version": "1.9.18",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.7",
+        "@akashic/akashic-cli-extra": "1.7.8",
         "@akashic/game-configuration": "2.3.0",
         "@akashic/headless-driver": "2.15.8",
         "@babel/core": "7.25.2",
@@ -34829,7 +34829,7 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "1.7.7",
+      "version": "1.7.8",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
@@ -34904,11 +34904,11 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "1.15.8",
+      "version": "1.15.9",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.7",
+        "@akashic/akashic-cli-extra": "1.7.8",
         "commander": "12.1.0",
         "fs-extra": "11.2.0",
         "glob": "11.0.0",
@@ -35780,9 +35780,9 @@
       "version": "file:packages/akashic-cli",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-export": "1.9.17",
-        "@akashic/akashic-cli-extra": "1.7.7",
-        "@akashic/akashic-cli-init": "1.15.8",
+        "@akashic/akashic-cli-export": "1.9.18",
+        "@akashic/akashic-cli-extra": "1.7.8",
+        "@akashic/akashic-cli-init": "1.15.9",
         "@akashic/akashic-cli-lib-manage": "1.9.6",
         "@akashic/akashic-cli-sandbox": "1.1.9",
         "@akashic/akashic-cli-scan": "0.17.7",
@@ -35892,7 +35892,7 @@
       "version": "file:packages/akashic-cli-export",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.7",
+        "@akashic/akashic-cli-extra": "1.7.8",
         "@akashic/akashic-engine": "~2.6.7",
         "@akashic/eslint-config": "2.1.0",
         "@akashic/game-configuration": "2.3.0",
@@ -36118,7 +36118,7 @@
       "version": "file:packages/akashic-cli-init",
       "requires": {
         "@akashic/akashic-cli-commons": "0.15.3",
-        "@akashic/akashic-cli-extra": "1.7.7",
+        "@akashic/akashic-cli-extra": "1.7.8",
         "@akashic/eslint-config": "2.1.0",
         "@types/commander": "2.12.2",
         "@types/express": "4.17.21",

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -3,8 +3,8 @@ import * as path from "path";
 import type { CliConfigExportHtml} from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import type { ExportHTMLParameterObject } from "./exportHTML";
-import { promiseExportHTML } from "./exportHTML";
+import type { ExportHTMLParameterObject } from "./exportHTML.js";
+import { promiseExportHTML } from "./exportHTML.js";
 
 const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8")).version;
 

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -3,9 +3,9 @@ import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import * as fsx from "fs-extra";
-import { validateGameJson } from "../utils";
+import { validateGameJson } from "../utils.js";
 import type {
-	ConvertTemplateParameterObject} from "./convertUtil";
+	ConvertTemplateParameterObject} from "./convertUtil.js";
 import {
 	copyAssetFilesStrip,
 	copyAssetFiles,
@@ -18,7 +18,7 @@ import {
 	validateEs5Code,
 	validateSandboxConfigJs,
 	readSandboxConfigJs
-} from "./convertUtil";
+} from "./convertUtil.js";
 
 interface InnerHTMLAssetData {
 	name: string;

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -3,9 +3,9 @@ import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import * as fsx from "fs-extra";
-import { validateGameJson } from "../utils";
+import { validateGameJson } from "../utils.js";
 import type {
-	ConvertTemplateParameterObject} from "./convertUtil";
+	ConvertTemplateParameterObject} from "./convertUtil.js";
 import {
 	copyAssetFilesStrip,
 	copyAssetFiles,
@@ -18,7 +18,7 @@ import {
 	validateEngineFilesName,
 	resolveEngineFilesPath,
 	validateSandboxConfigJs
-} from "./convertUtil";
+} from "./convertUtil.js";
 
 export async function promiseConvertNoBundle(options: ConvertTemplateParameterObject): Promise<void> {
 	const content = await cmn.ConfigurationFile.read(path.join(options.source, "game.json"), options.logger);

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -6,10 +6,10 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import archiver = require("archiver");
 import * as fsx from "fs-extra";
 import readdir = require("fs-readdir-recursive");
-import { promiseConvertBundle } from "./convertBundle";
-import { promiseConvertNoBundle } from "./convertNoBundle";
-import type { ConvertTemplateParameterObject } from "./convertUtil";
-import * as Utils from "./Utils";
+import { promiseConvertBundle } from "./convertBundle.js";
+import { promiseConvertNoBundle } from "./convertNoBundle.js";
+import type { ConvertTemplateParameterObject } from "./convertUtil.js";
+import * as Utils from "./Utils.js";
 
 export interface ExportHTMLParameterObject extends ConvertTemplateParameterObject {
 	quiet?: boolean;

--- a/packages/akashic-cli-export/src/html/index.ts
+++ b/packages/akashic-cli-export/src/html/index.ts
@@ -1,2 +1,2 @@
-import { run } from "./cli";
+import { run } from "./cli.js";
 export { run };

--- a/packages/akashic-cli-export/src/pdi/storage/GameExternalStorage.ts
+++ b/packages/akashic-cli-export/src/pdi/storage/GameExternalStorage.ts
@@ -1,5 +1,5 @@
-import * as types from "./content-storage-types";
-import type { KVSLike } from "./KVSLike";
+import * as types from "./content-storage-types/index.js";
+import type { KVSLike } from "./KVSLike.js";
 
 export interface GameExternalStorageParameterObject {
 	kvs: KVSLike;

--- a/packages/akashic-cli-export/src/pdi/storage/content-storage-types/GameExternalStorageLike.ts
+++ b/packages/akashic-cli-export/src/pdi/storage/content-storage-types/GameExternalStorageLike.ts
@@ -7,7 +7,7 @@ import type {
 	StorageWriteType,
 	StorageData,
 	StorageWriteFailureType
-} from "./types";
+} from "./types.js";
 
 /**
  * GameExternalStorageReadRequest.limitのデフォルト値

--- a/packages/akashic-cli-export/src/pdi/storage/content-storage-types/index.ts
+++ b/packages/akashic-cli-export/src/pdi/storage/content-storage-types/index.ts
@@ -1,4 +1,4 @@
 // TODO: このファイルは将来的には外部から参照するようにする
 
-export * from "./types";
-export * from "./GameExternalStorageLike";
+export * from "./types.js";
+export * from "./GameExternalStorageLike.js";

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { CliConfigExportZip} from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile, SERVICE_TYPES } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import { promiseExportZip } from "./exportZip";
+import { promiseExportZip } from "./exportZip.js";
 
 const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8")).version;
 

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -13,12 +13,12 @@ import readdir = require("fs-readdir-recursive");
 import type { OutputChunk, RollupBuild } from "rollup";
 import { rollup } from "rollup";
 import * as UglifyJS from "uglify-js";
-import * as utils from "../utils";
-import { validateGameJson } from "../utils";
-import { getFromHttps } from "./apiUtil";
-import { NICOLIVE_SIZE_LIMIT_GAME_JSON, NICOLIVE_SIZE_LIMIT_TOTAL_FILE } from "./constants";
-import * as gcu from "./GameConfigurationUtil";
-import { transformPackSmallImages } from "./transformPackImages";
+import * as utils from "../utils.js";
+import { validateGameJson } from "../utils.js";
+import { getFromHttps } from "./apiUtil.js";
+import { NICOLIVE_SIZE_LIMIT_GAME_JSON, NICOLIVE_SIZE_LIMIT_TOTAL_FILE } from "./constants.js";
+import * as gcu from "./GameConfigurationUtil.js";
+import { transformPackSmallImages } from "./transformPackImages.js";
 
 export interface ConvertGameParameterObject {
 	bundle?: boolean;

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -5,7 +5,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import { size as statSize } from "@akashic/akashic-cli-extra/lib/stat";
 import archiver = require("archiver");
 import readdir = require("fs-readdir-recursive");
-import { convertGame } from "./convert";
+import { convertGame } from "./convert.js";
 
 export interface ExportZipParameterObject {
 	bundle?: boolean;

--- a/packages/akashic-cli-export/src/zip/index.ts
+++ b/packages/akashic-cli-export/src/zip/index.ts
@@ -1,1 +1,1 @@
-export { cli, run } from "./cli";
+export { cli, run } from "./cli.js";

--- a/packages/akashic-cli-export/src/zip/transformPackImages.ts
+++ b/packages/akashic-cli-export/src/zip/transformPackImages.ts
@@ -5,9 +5,9 @@ import type { GameConfiguration } from "@akashic/akashic-cli-commons/lib/GameCon
 import { mkdirpSync } from "@akashic/akashic-cli-commons/lib/Util";
 import type { AssetConfiguration, ImageAssetConfigurationBase } from "@akashic/game-configuration";
 import type { PNG } from "pngjs";
-import { makeUniqueAssetPath } from "./GameConfigurationUtil";
-import type { PackResult, PackTarget } from "./packRects";
-import { packSmallRects } from "./packRects";
+import { makeUniqueAssetPath } from "./GameConfigurationUtil.js";
+import type { PackResult, PackTarget } from "./packRects.js";
+import { packSmallRects } from "./packRects.js";
 
 /**
  * コンテンツ内の小さい画像 (PNG ファイル) を、一定サイズに収まる限りでパッキングして一つにまとめる。

--- a/packages/akashic-cli-extra/src/config/cli.ts
+++ b/packages/akashic-cli-extra/src/config/cli.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import * as config from "./config";
+import * as config from "./config.js";
 
 /**
  * akashic cli configを実行する

--- a/packages/akashic-cli-extra/src/config/index.ts
+++ b/packages/akashic-cli-extra/src/config/index.ts
@@ -1,4 +1,4 @@
-import { run } from "./cli";
+import { run } from "./cli.js";
 export { run };
 export {
 	StringMap,
@@ -6,4 +6,4 @@ export {
 	getConfigItem,
 	setConfigItem,
 	deleteConfigItem
-} from "./config";
+} from "./config.js";

--- a/packages/akashic-cli-extra/src/modify/cli.ts
+++ b/packages/akashic-cli-extra/src/modify/cli.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { CliConfigModify } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import { promiseModifyBasicParameter } from "./modify";
+import { promiseModifyBasicParameter } from "./modify.js";
 
 const commander = new Command();
 

--- a/packages/akashic-cli-extra/src/modify/index.ts
+++ b/packages/akashic-cli-extra/src/modify/index.ts
@@ -1,2 +1,2 @@
-import { run } from "./cli";
+import { run } from "./cli.js";
 export { run };

--- a/packages/akashic-cli-extra/src/stat/cli.ts
+++ b/packages/akashic-cli-extra/src/stat/cli.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { Logger, CliConfigStat } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, ConfigurationFile, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import * as stat from "./stat";
+import * as stat from "./stat.js";
 
 function statSize(logger: Logger, param: CliConfigStat): void {
 	const basepath = param.cwd || process.cwd();

--- a/packages/akashic-cli-extra/src/stat/index.ts
+++ b/packages/akashic-cli-extra/src/stat/index.ts
@@ -1,4 +1,4 @@
-import { run } from "./cli";
+import { run } from "./cli.js";
 export { run };
-import { StatSizeParameterObject, size } from "./stat";
+import { StatSizeParameterObject, size } from "./stat.js";
 export { StatSizeParameterObject, size };

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -4,8 +4,8 @@ import type { CliConfigInit } from "@akashic/akashic-cli-commons/lib/CliConfig/C
 import { CliConfigurationFile } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigurationFile";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger";
 import { Command } from "commander";
-import { promiseInit } from "./init/init";
-import { listTemplates } from "./list/listTemplates";
+import { promiseInit } from "./init/init.js";
+import { listTemplates } from "./list/listTemplates.js";
 
 async function cli(param: CliConfigInit): Promise<void> {
 	const logger = new ConsoleLogger({ quiet: param.quiet });

--- a/packages/akashic-cli-init/src/index.ts
+++ b/packages/akashic-cli-init/src/index.ts
@@ -1,3 +1,3 @@
-export { promiseInit, init } from "./init/init";
-export { listTemplates } from "./list/listTemplates";
-export { run } from "./cli";
+export { promiseInit, init } from "./init/init.js";
+export { listTemplates } from "./list/listTemplates.js";
+export { run } from "./cli.js";

--- a/packages/akashic-cli-init/src/init/InitParameterObject.ts
+++ b/packages/akashic-cli-init/src/init/InitParameterObject.ts
@@ -1,6 +1,6 @@
-import type { InitCommonOptions} from "../common/InitCommonOptions";
-import { completeInitCommonOptions, confirmAccessToUrl } from "../common/InitCommonOptions";
-import { createGitUri, parseCloneTargetInfo } from "./cloneTemplate";
+import type { InitCommonOptions} from "../common/InitCommonOptions.js";
+import { completeInitCommonOptions, confirmAccessToUrl } from "../common/InitCommonOptions.js";
+import { createGitUri, parseCloneTargetInfo } from "./cloneTemplate.js";
 
 export type GitProtocol = "https" | "ssh";
 

--- a/packages/akashic-cli-init/src/init/cloneTemplate.ts
+++ b/packages/akashic-cli-init/src/init/cloneTemplate.ts
@@ -2,7 +2,7 @@ import * as childProcess from "child_process";
 import * as fs from "fs/promises";
 import * as path from "path";
 import * as util from "util";
-import type { GitProtocol, InitParameterObject } from "./InitParameterObject";
+import type { GitProtocol, InitParameterObject } from "./InitParameterObject.js";
 const exec = util.promisify(childProcess.exec);
 
 interface GitCloneParameterObject {

--- a/packages/akashic-cli-init/src/init/init.ts
+++ b/packages/akashic-cli-init/src/init/init.ts
@@ -8,13 +8,13 @@ import {
 	digestOfTemplateMetadata,
 	fetchRemoteTemplatesMetadata,
 	fetchTemplate
-} from "../common/TemplateMetadata";
-import { updateConfigurationFile } from "./BasicParameters";
-import { cloneTemplate, parseCloneTargetInfo } from "./cloneTemplate";
-import type { InitParameterObject} from "./InitParameterObject";
-import { completeInitParameterObject } from "./InitParameterObject";
-import type { TemplateConfig, NormalizedTemplateConfig } from "./TemplateConfig";
-import { completeTemplateConfig } from "./TemplateConfig";
+} from "../common/TemplateMetadata.js";
+import { updateConfigurationFile } from "./BasicParameters.js";
+import { cloneTemplate, parseCloneTargetInfo } from "./cloneTemplate.js";
+import type { InitParameterObject} from "./InitParameterObject.js";
+import { completeInitParameterObject } from "./InitParameterObject.js";
+import type { TemplateConfig, NormalizedTemplateConfig } from "./TemplateConfig.js";
+import { completeTemplateConfig } from "./TemplateConfig.js";
 
 export async function promiseInit(p: InitParameterObject): Promise<void> {
 	const param = await completeInitParameterObject(p);

--- a/packages/akashic-cli-init/src/list/ListTemplatesParameterObject.ts
+++ b/packages/akashic-cli-init/src/list/ListTemplatesParameterObject.ts
@@ -1,5 +1,5 @@
-import type { InitCommonOptions } from "../common/InitCommonOptions";
-import { completeInitCommonOptions } from "../common/InitCommonOptions";
+import type { InitCommonOptions } from "../common/InitCommonOptions.js";
+import { completeInitCommonOptions } from "../common/InitCommonOptions.js";
 
 export interface ListTemplatesParameterObject extends InitCommonOptions {
 	// add nothing.

--- a/packages/akashic-cli-init/src/list/listTemplates.ts
+++ b/packages/akashic-cli-init/src/list/listTemplates.ts
@@ -1,6 +1,6 @@
-import { collectLocalTemplatesMetadata, fetchRemoteTemplatesMetadata } from "../common/TemplateMetadata";
-import type { ListTemplatesParameterObject} from "./ListTemplatesParameterObject";
-import { completeListTemplatesParamterObject } from "./ListTemplatesParameterObject";
+import { collectLocalTemplatesMetadata, fetchRemoteTemplatesMetadata } from "../common/TemplateMetadata.js";
+import type { ListTemplatesParameterObject} from "./ListTemplatesParameterObject.js";
+import { completeListTemplatesParamterObject } from "./ListTemplatesParameterObject.js";
 
 export async function listTemplates(p: ListTemplatesParameterObject): Promise<void> {
 	const param = await completeListTemplatesParamterObject(p);

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -3,8 +3,8 @@ import * as path from "path";
 import type { CliConfigInstall } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import type { InstallParameterObject} from "./install";
-import { promiseInstall } from "./install";
+import type { InstallParameterObject} from "./install.js";
+import { promiseInstall } from "./install.js";
 
 function cli(param: CliConfigInstall): void {
 	const logger = new ConsoleLogger({ quiet: param.quiet });

--- a/packages/akashic-cli-lib-manage/src/install/index.ts
+++ b/packages/akashic-cli-lib-manage/src/install/index.ts
@@ -1,2 +1,2 @@
-export { run } from "./cli";
-export { install, promiseInstall } from "./install";
+export { run } from "./cli.js";
+export { install, promiseInstall } from "./install.js";

--- a/packages/akashic-cli-lib-manage/src/install/install.ts
+++ b/packages/akashic-cli-lib-manage/src/install/install.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as tar from "tar";
-import { Configuration } from "./Configuration";
+import { Configuration } from "./Configuration.js";
 
 export interface InstallParameterObject {
 	/**

--- a/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { CliConfigUninstall } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import { promiseUninstall } from "./uninstall";
+import { promiseUninstall } from "./uninstall.js";
 
 function cli(param: CliConfigUninstall): void {
 	const logger = new ConsoleLogger({ quiet: param.quiet });

--- a/packages/akashic-cli-lib-manage/src/uninstall/index.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/index.ts
@@ -1,2 +1,2 @@
-export { run } from "./cli";
-export { uninstall, promiseUninstall } from "./uninstall";
+export { run } from "./cli.js";
+export { uninstall, promiseUninstall } from "./uninstall.js";

--- a/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/uninstall.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
-import { Configuration } from "./Configuration";
+import { Configuration } from "./Configuration.js";
 
 export interface UninstallParameterObject {
 	/**

--- a/packages/akashic-cli-lib-manage/src/update/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/update/cli.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import type { CliConfigUpdate } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, CliConfigurationFile } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
-import { promiseUpdate } from "./update";
+import { promiseUpdate } from "./update.js";
 
 const ver = JSON.parse(fs.readFileSync(path.resolve(__dirname, "..", "..", "package.json"), "utf8")).version;
 

--- a/packages/akashic-cli-lib-manage/src/update/index.ts
+++ b/packages/akashic-cli-lib-manage/src/update/index.ts
@@ -1,5 +1,5 @@
 export {
 	update, promiseUpdate
-} from "./update";
-import { run } from "./cli";
+} from "./update.js";
+import { run } from "./cli.js";
 export { run };


### PR DESCRIPTION
# このPullRequestが解決する内容
akashic-cli の以下のモジュール (serve, sandbox, scan は除外)の TypeScript コードの import 先に拡張子 `.js` を付与します。
プロダクトコードに変更はありません。
各モジュールの `--version` コマンドが機能することまでを確認しています。

- akashic-cli-export
- akashic-cli-extra
- akashic-cli-init
- akashic-cli-lib-manage

rel. #1392 