### PR TITLE
Fix issue with akashic-init deleting local template

### DIFF
--- a/.changeset/stupid-owls-count.md
+++ b/.changeset/stupid-owls-count.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-init": patch
+---
+
+Fix issue with akashic-init deleting local template

--- a/package-lock.json
+++ b/package-lock.json
@@ -26490,7 +26490,7 @@
         "commander": "^11.0.0",
         "debug": "^4.3.4",
         "ejs": "^3.1.8",
-        "express": "^4.18.2",
+        "express": "^4.20.0",
         "express-session": "^1.17.3"
       },
       "bin": {
@@ -27547,7 +27547,7 @@
         "eslint": "^8.54.0",
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-jest": "^27.6.0",
-        "express": "^4.18.2",
+        "express": "^4.20.0",
         "express-session": "^1.17.3",
         "jasmine": "^5.0.0",
         "supertest": "^6.3.1",

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { readdir } from "@akashic/akashic-cli-commons/lib/FileSystem";
-import * as fsx from "fs-extra";
 import * as unzipper from "unzipper";
 
 // TODO: 適切な場所に移動

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -91,7 +91,7 @@ export async function fetchTemplate(metadata: TemplateMetadata): Promise<string>
 	switch (metadata.sourceType) {
 		case "local": {
 			const destDir = fs.mkdtempSync(path.join(os.tmpdir(), metadata.name + "-"));
-			fsx.copySync(metadata.path, destDir, { recursive: true });
+			fs.cpSync(metadata.path, destDir, { recursive: true });
 			return destDir;
 		}
 		case "remote": {

--- a/packages/akashic-cli-init/src/common/TemplateMetadata.ts
+++ b/packages/akashic-cli-init/src/common/TemplateMetadata.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { readdir } from "@akashic/akashic-cli-commons/lib/FileSystem";
+import * as fsx from "fs-extra";
 import * as unzipper from "unzipper";
 
 // TODO: 適切な場所に移動
@@ -81,7 +82,7 @@ export async function fetchRemoteTemplatesMetadata(templateListJsonUri: string):
 /**
  * テンプレートを取得する。
  *
- * remote ならテンポラリディレクトリにダウンロードし、localなら何もしない。
+ * remote ならテンポラリディレクトリにダウンロードし、local ならテンポラリディレクトリにコピーする。
  *
  * @param metadata 取得するテンプレート
  * @returns 取得したテンプレート(template.jsonがあるディレクトリ)のパス。テンポラリディレクトリでありうる。
@@ -89,7 +90,9 @@ export async function fetchRemoteTemplatesMetadata(templateListJsonUri: string):
 export async function fetchTemplate(metadata: TemplateMetadata): Promise<string> {
 	switch (metadata.sourceType) {
 		case "local": {
-			return metadata.path;
+			const destDir = fs.mkdtempSync(path.join(os.tmpdir(), metadata.name + "-"));
+			fsx.copySync(metadata.path, destDir, { recursive: true });
+			return destDir;
 		}
 		case "remote": {
 			const { name, url } = metadata;


### PR DESCRIPTION
## 概要

issue #1416 の akashic init でローカルテンプレートを指定すると元のテンプレートディレクトリが削除される問題を修正。

ローカルテンプレート指定時に、一時ディレクトリにテンプレートディレクトリのファイルをコピーし利用するように修正。

**動作確認**

ローカルテンプレート指定時に init が指定テンプレートの内容で生成され、元ディレクトリが削除されない事を確認
