### PR TITLE
chore: add tsconfig.test.json

### DIFF
--- a/packages/akashic-cli-commons/src/tsconfig.json
+++ b/packages/akashic-cli-commons/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-commons/tsconfig.test.json
+++ b/packages/akashic-cli-commons/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-export/src/tsconfig.json
+++ b/packages/akashic-cli-export/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-export/tsconfig.test.json
+++ b/packages/akashic-cli-export/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-extra/src/tsconfig.json
+++ b/packages/akashic-cli-extra/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-extra/tsconfig.test.json
+++ b/packages/akashic-cli-extra/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-init/src/tsconfig.json
+++ b/packages/akashic-cli-init/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-init/tsconfig.test.json
+++ b/packages/akashic-cli-init/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-lib-manage/src/tsconfig.json
+++ b/packages/akashic-cli-lib-manage/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-lib-manage/tsconfig.test.json
+++ b/packages/akashic-cli-lib-manage/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-sandbox/src/tsconfig.json
+++ b/packages/akashic-cli-sandbox/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-sandbox/tsconfig.test.json
+++ b/packages/akashic-cli-sandbox/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli-scan/src/tsconfig.json
+++ b/packages/akashic-cli-scan/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli-scan/tsconfig.test.json
+++ b/packages/akashic-cli-scan/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}

--- a/packages/akashic-cli/src/tsconfig.json
+++ b/packages/akashic-cli/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.test.json"
+}

--- a/packages/akashic-cli/tsconfig.test.json
+++ b/packages/akashic-cli/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
# このPullRequestが解決する内容
各 src ファイル内に `tsconfig.test.json` を継承した `tsconfig.json` を配置することで、vitest の型定義を IDE で解決できるようにします。

<img width="1725" alt="スクリーンショット 2024-10-07 14 45 12" src="https://github.com/user-attachments/assets/278da6f5-e868-4f88-a3bf-7bc0fedab807">


