### PR TITLE
refactor(export): minify JS on-the-fly

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -9,7 +9,7 @@ export interface CliConfigExportHtml {
 	hashFilename?: number | boolean;
 	minify?: boolean;
 	/**
-	 * terser による minify の際のオプション。minifyJs が true の時のみ参照される。
+	 * terser による minify の際のオプション。minify プロパティが true の時のみ参照される。
 	 * 指定可能な値は https://terser.org/docs/api-reference/#minify-options を参照。
 	 */
 	terser?: object;

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -8,7 +8,11 @@ export interface CliConfigExportHtml {
 	strip?: boolean;
 	hashFilename?: number | boolean;
 	minify?: boolean;
-	terser?: unknown;
+	/**
+	 * terser による minify の際のオプション。minifyJs が true の時のみ参照される。
+	 * 指定可能な値は https://terser.org/docs/api-reference/#minify-options を参照。
+	 */
+	terser?: object;
 	bundle?: boolean;
 	magnify?: boolean;
 	injects?: string[];

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -9,7 +9,11 @@ export interface CliConfigExportZip {
 	minify?: boolean;
 	minifyJs?: boolean;
 	minifyJson?: boolean;
-	terser?: unknown;
+	/**
+	 * terser による minify の際のオプション。minifyJs が true の時のみ参照される。
+	 * 指定可能な値は https://terser.org/docs/api-reference/#minify-options を参照。
+	 */
+	terser?: object;
 	packImage?: boolean;
 	bundle?: boolean;
 	babel?: boolean;

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -10,7 +10,7 @@ export interface CliConfigExportZip {
 	minifyJs?: boolean;
 	minifyJson?: boolean;
 	/**
-	 * terser による minify の際のオプション。minifyJs が true の時のみ参照される。
+	 * terser による minify の際のオプション。minifyJs (または minify) プロパティが true の時のみ参照される。
 	 * 指定可能な値は https://terser.org/docs/api-reference/#minify-options を参照。
 	 */
 	terser?: object;

--- a/packages/akashic-cli-export/bin/akashic-cli-export-html
+++ b/packages/akashic-cli-export/bin/akashic-cli-export-html
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-import { run } from "../lib/html";
+import { run } from "../lib/html/index.js";
 run(process.argv);

--- a/packages/akashic-cli-export/bin/akashic-cli-export-zip
+++ b/packages/akashic-cli-export/bin/akashic-cli-export-zip
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 
-import { run } from "../lib/zip";
+import { run } from "../lib/zip/index.js";
 run(process.argv);

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import fsx from "fs-extra";
+import type { MinifyOptions } from "terser";
 import { validateGameJson } from "../utils.js";
 import type {
 	ConvertTemplateParameterObject} from "./convertUtil.js";
@@ -55,10 +56,11 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		validateSandboxConfigJs(sandboxConfig, options.autoSendEventName, options.autoGivenArgsName);
 	}
 
+	const terser = options.minify ? options.terser ?? {} : undefined;
 	const nonBinaryAssetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
 	const errorMessages: string[] = [];
 	const nonBinaryAssetPaths = await Promise.all(nonBinaryAssetNames.map((assetName: string) => {
-		return convertAssetAndOutput(assetName, conf, options.source, options.output, options.minify, errorMessages);
+		return convertAssetAndOutput(assetName, conf, options.source, options.output, terser, errorMessages);
 	}));
 	assetPaths = assetPaths.concat(nonBinaryAssetPaths);
 	if (conf._content.globalScripts) {
@@ -67,7 +69,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 				scriptName,
 				options.source,
 				options.output,
-				options.minify,
+				terser,
 				errorMessages);
 		}));
 		assetPaths = assetPaths.concat(globalScriptPaths);
@@ -82,7 +84,8 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 async function convertAssetAndOutput(
 	assetName: string, conf: cmn.Configuration,
 	inputPath: string, outputPath: string,
-	minify?: boolean, errors?: string[]): Promise<string> {
+	terser: MinifyOptions | undefined,
+	errors?: string[]): Promise<string> {
 	const assets = conf._content.assets;
 	const asset = assets[assetName];
 	const isScript = asset.type === "script";
@@ -93,7 +96,7 @@ async function convertAssetAndOutput(
 		errors.push.apply(errors, await validateEs5Code(assetPath, assetString)); // ES5構文に反する箇所があるかのチェック
 	}
 
-	const code = (isScript ? wrapScript(assetString, assetName, minify, exports) : wrapText(assetString, assetName));
+	const code = (isScript ? wrapScript(assetString, assetName, terser, exports) : wrapText(assetString, assetName));
 	const relativePath = "./js/assets/" + path.dirname(assetPath) + "/" +
 		path.basename(assetPath, path.extname(assetPath)) + (isScript ? ".js" : ".json.js");
 	const filePath = path.resolve(outputPath, relativePath);
@@ -104,14 +107,14 @@ async function convertAssetAndOutput(
 
 async function convertGlobalScriptAndOutput(
 	scriptName: string, inputPath: string, outputPath: string,
-	minify?: boolean, errors?: string[]): Promise<string> {
+	terser: MinifyOptions | undefined, errors?: string[]): Promise<string> {
 	const scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	const isScript = /\.js$/i.test(scriptName);
 	if (isScript) {
 		errors.push.apply(errors, await validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
 	}
 
-	const code = isScript ? wrapScript(scriptString, scriptName, minify) : wrapText(scriptString, scriptName);
+	const code = isScript ? wrapScript(scriptString, scriptName, terser) : wrapText(scriptString, scriptName);
 	const relativePath = "./globalScripts/" + scriptName + (isScript ? "" : ".js");
 	const filePath = path.resolve(outputPath, relativePath);
 
@@ -201,7 +204,7 @@ window.optionProps.magnify = ${!!options.magnify};
 	fs.writeFileSync(path.resolve(outputPath, "./js/option.js"), script);
 }
 
-function wrapScript(code: string, name: string, terser?: unknown, exports: string[] = []): string {
+function wrapScript(code: string, name: string, terser?: MinifyOptions, exports: string[] = []): string {
 	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, exports) + "}";
 }
 

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -6,6 +6,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import type { AssetConfigurationMap, ImageAssetConfigurationBase } from "@akashic/game-configuration";
 import type { SandboxConfiguration } from "@akashic/sandbox-configuration";
 import fsx from "fs-extra";
+import type { MinifyOptions } from "terser";
 import { minify_sync } from "terser";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -17,7 +18,7 @@ export interface ConvertTemplateParameterObject {
 	logger: cmn.Logger;
 	strip: boolean;
 	minify: boolean;
-	terser: unknown;
+	terser: MinifyOptions;
 	magnify: boolean;
 	force: boolean;
 	source: string;
@@ -101,7 +102,7 @@ export function encodeText(text: string): string {
 	return text.replace(/[\u2028\u2029'"\\\b\f\n\r\t\v%]/g, encodeURIComponent);
 }
 
-export function wrap(code: string, terser?: unknown, exports: string[] = []): string {
+export function wrap(code: string, terser?: MinifyOptions, exports: string[] = []): string {
 	const preScript = "(function(exports, require, module, __filename, __dirname) {";
 	let postScript: string = "";
 	for (const key of exports) {

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -275,14 +275,12 @@ describe("convert", () => {
 						"		y: foo()",
 						"	};",
 						"}",
-						""
 					].join("\n"));
 					const foo = fs.readFileSync(path.join(destDir, "script/foo.js"), { encoding: "utf-8" }).toString();
 					expect(foo.replace(/\r?\n/g, "\n")).toBe([
 						"module.exports = function () {",
 						"	return \"このスクリプトファイルは Shift-JIS です。\";",
 						"};",
-						""
 					].join("\n"));
 					const eucjp = fs.readFileSync(path.join(destDir, "assets/euc-jp.txt"), { encoding: "utf-8" }).toString();
 					expect(eucjp).toBe("このテキストファイルは EUC-JP です");

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -9,6 +9,7 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import * as fsx from "fs-extra";
 import type { OutputChunk, RollupBuild } from "rollup";
 import { rollup } from "rollup";
+import type { MinifyOptions } from "terser";
 import { minify_sync } from "terser";
 import * as utils from "../utils.js";
 import { validateGameJson } from "../utils.js";
@@ -29,7 +30,7 @@ export interface ConvertGameParameterObject {
 	minify?: boolean;
 	minifyJs?: boolean;
 	minifyJson?: boolean;
-	terser?: unknown;
+	terser?: MinifyOptions;
 	packImage?: boolean;
 	strip?: boolean;
 	source?: string;

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import * as cmn from "@akashic/akashic-cli-commons";
 import { size as statSize } from "@akashic/akashic-cli-extra/lib/stat/stat.js";
 import archiver = require("archiver");
+import type { MinifyOptions } from "terser";
 import { convertGame } from "./convert.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -16,7 +17,7 @@ export interface ExportZipParameterObject {
 	minify?: boolean;
 	minifyJs?: boolean;
 	minifyJson?: boolean;
-	terser?: unknown;
+	terser?: MinifyOptions;
 	packImage?: boolean;
 	strip?: boolean;
 	source?: string;


### PR DESCRIPTION
掲題どおり。

- terser による minify の実行タイミングを見直し
   - ファイルに書き出した後に行うのではなく、(babel による変換同様) コピー時に on-the-fly で行います。
   - 元々は babel に先駆けて minify を行おうとした修正ですが、実際には babel が出力を整形してくるためこれはできませんでした (せっかくつぶした空白が戻る) 。結果的に処理の無駄を省いただけの変更になっています。
- ついでに: akashic-cli-export-html, -zip の拡張子がない import でエラーになるのを修正
