### PR TITLE
Fix ES5 warning to ES7 on export

### DIFF
--- a/packages/akashic-cli-commons/src/LintUtil.ts
+++ b/packages/akashic-cli-commons/src/LintUtil.ts
@@ -9,7 +9,7 @@ export async function validateEsCode(code: string): Promise<LintErrorInfo[]> {
 	const eslint = await import("eslint");
 	const errors = (new eslint.Linter()).verify(code, {
 		parserOptions: {
-			ecmaVersion: 2016
+			ecmaVersion: 2015
 		}
 	});
 	return errors.map(error => {

--- a/packages/akashic-cli-commons/src/LintUtil.ts
+++ b/packages/akashic-cli-commons/src/LintUtil.ts
@@ -5,11 +5,11 @@ export interface LintErrorInfo {
 	message: string;
 }
 
-export async function validateEs5Code(code: string): Promise<LintErrorInfo[]> {
+export async function validateEsCode(code: string): Promise<LintErrorInfo[]> {
 	const eslint = await import("eslint");
 	const errors = (new eslint.Linter()).verify(code, {
 		parserOptions: {
-			ecmaVersion: 5
+			ecmaVersion: 2016
 		}
 	});
 	return errors.map(error => {

--- a/packages/akashic-cli-export/src/__tests__/fixtures/simple_game_es6/script/main.js
+++ b/packages/akashic-cli-export/src/__tests__/fixtures/simple_game_es6/script/main.js
@@ -1,13 +1,7 @@
 const foo = require("./foo");
 
 const main = () => {
-	const array = [1, 2];
-	array.includes(1);
-
-	const obj1 = {a: 1, b: 2};
-	const obj2 = {c: 10, d: 20};
-	const obj3 = {...obj1, ...obj2};				
-
+	const x = 3 ** 2;
 	return {
 		x: foo()
 	};

--- a/packages/akashic-cli-export/src/__tests__/fixtures/simple_game_es6/script/main.js
+++ b/packages/akashic-cli-export/src/__tests__/fixtures/simple_game_es6/script/main.js
@@ -1,6 +1,13 @@
 const foo = require("./foo");
 
 const main = () => {
+	const array = [1, 2];
+	array.includes(1);
+
+	const obj1 = {a: 1, b: 2};
+	const obj2 = {c: 10, d: 20};
+	const obj3 = {...obj1, ...obj2};				
+
 	return {
 		x: foo()
 	};

--- a/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
@@ -37,32 +37,29 @@ describe("convertUtil", function () {
 		});
 	});
 	describe("validateEsCode", function () {
-		it("If the code is written in ES7 or lower syntax, no errors.", async function () {
-			const es7orLessCode = `
+		it("If the code is written in ES2015 or lower syntax, no errors.", async function () {
+			const es6orLessCode = `
 				"use strict";
-				var fn = function () {
+				var fn = () => {
 					return 1;
 				};
 				var array = [1, 2];
 				const a = array[0];
 				const b = array[1];
-				array.includes(1);
 			`;
-			expect((await convert.validateEsCode("es7.js", es7orLessCode)).length).toBe(0);
+			expect((await convert.validateEsCode("es6.js", es6orLessCode)).length).toBe(0);
 		});
-		it("If the code is written in ES8 syntax, an error.", async function () {
-			const es8Code = `
+		it("If the code is written in ES2016 syntax, an error.", async function () {
+			const es7Code = `
 				"use strict";
 				const fn = () => {
 					return 1;
 				}
-				const obj1 = {a: 1, b: 2};
-				const obj2 = {c: 10, d: 20};
-				const obj3 = {...obj1, ...obj2};				
+				const x = 3 ** 2;
 			`;
-			const result = await convert.validateEsCode("es8.js", es8Code);
+			const result = await convert.validateEsCode("es7.js", es7Code);
 			expect(result.length).toBe(1);
-			expect(result[0]).toBe("es8.js(8:19): Parsing error: Unexpected token ...");
+			expect(result[0]).toBe("es7.js(6:18): Parsing error: Unexpected token *");
 		});
 	});
 	describe("encodeText", function () {

--- a/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
@@ -36,31 +36,33 @@ describe("convertUtil", function () {
 			expect(existFileContents[1]).toBe(sampleScriptContent);
 		});
 	});
-	describe("validateEs5Code", function () {
-		it("return empty array if code is written with ES5 syntax", async function () {
-			const es5Code = `
+	describe("validateEsCode", function () {
+		it("If the code is written in ES7 or lower syntax, no errors.", async function () {
+			const es7orLessCode = `
 				"use strict";
 				var fn = function () {
 					return 1;
 				};
 				var array = [1, 2];
-				var a = array[0];
-				var b = array[1];
+				const a = array[0];
+				const b = array[1];
+				array.includes(1);
 			`;
-			expect((await convert.validateEs5Code("es5.js", es5Code)).length).toBe(0);
+			expect((await convert.validateEsCode("es7.js", es7orLessCode)).length).toBe(0);
 		});
-		it("return error messages if code is not written with ES5 syntax", async function () {
-			const es6Code = `
+		it("If the code is written in ES8 syntax, an error.", async function () {
+			const es8Code = `
 				"use strict";
 				const fn = () => {
 					return 1;
 				}
-				const array = [1, 3];
-				const [a, b] = array;
+				const obj1 = {a: 1, b: 2};
+				const obj2 = {c: 10, d: 20};
+				const obj3 = {...obj1, ...obj2};				
 			`;
-			const result = await convert.validateEs5Code("es6.js", es6Code);
+			const result = await convert.validateEsCode("es8.js", es8Code);
 			expect(result.length).toBe(1);
-			expect(result[0]).toBe("es6.js(3:5): Parsing error: The keyword \'const\' is reserved");
+			expect(result[0]).toBe("es8.js(8:19): Parsing error: Unexpected token ...");
 		});
 	});
 	describe("encodeText", function () {

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -82,7 +82,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	}
 
 	if (errorMessages.length > 0) {
-		options.logger.warn("The following ES7 syntax errors exist.\n" + errorMessages.join("\n"));
+		options.logger.warn("The following ES2015 syntax errors exist.\n" + errorMessages.join("\n"));
 	}
 
 	let templatePath: string;

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -18,7 +18,7 @@ import {
 	getDefaultBundleStyle,
 	extractAssetDefinitions,
 	getInjectedContents,
-	validateEs5Code,
+	validateEsCode,
 	validateSandboxConfigJs,
 	readSandboxConfigJs
 } from "./convertUtil.js";
@@ -82,7 +82,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	}
 
 	if (errorMessages.length > 0) {
-		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));
+		options.logger.warn("The following ES7 syntax errors exist.\n" + errorMessages.join("\n"));
 	}
 
 	let templatePath: string;
@@ -112,7 +112,7 @@ async function convertAssetToInnerHTMLObj(
 	const exports = (asset.type === "script" && asset.exports) ?? [];
 	const assetString = fs.readFileSync(path.join(inputPath, asset.path), "utf8").replace(/\r\n|\r/g, "\n");
 	if (isScript) {
-		errors.push.apply(errors, await validateEs5Code(asset.path, assetString));
+		errors.push.apply(errors, await validateEsCode(asset.path, assetString));
 	}
 	return {
 		name: assetName,
@@ -132,7 +132,7 @@ async function convertScriptNameToInnerHTMLObj(
 		scriptString = encodeText(scriptString);
 	}
 	if (isScript) {
-		errors.push.apply(errors, await validateEs5Code(scriptName, scriptString));
+		errors.push.apply(errors, await validateEsCode(scriptName, scriptString));
 	}
 	return {
 		name: scriptName,

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -16,7 +16,7 @@ import {
 	wrap,
 	extractAssetDefinitions,
 	getInjectedContents,
-	validateEs5Code,
+	validateEsCode,
 	readSandboxConfigJs,
 	validateEngineFilesName,
 	resolveEngineFilesPath,
@@ -75,7 +75,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		assetPaths = assetPaths.concat(globalScriptPaths);
 	}
 	if (errorMessages.length > 0) {
-		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));
+		options.logger.warn("The following ES7 syntax errors exist.\n" + errorMessages.join("\n"));
 	}
 	await writeHtmlFile(assetPaths, options.output, conf, options);
 	writeOptionScript(options.output, options);
@@ -93,7 +93,7 @@ async function convertAssetAndOutput(
 	const assetString = fs.readFileSync(path.join(inputPath, asset.path), "utf8").replace(/\r\n|\r/g, "\n");
 	const assetPath = asset.path;
 	if (isScript) {
-		errors.push.apply(errors, await validateEs5Code(assetPath, assetString)); // ES5構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEsCode(assetPath, assetString)); // ES7以下の構文に反する箇所があるかのチェック
 	}
 
 	const code = (isScript ? wrapScript(assetString, assetName, terser, exports) : wrapText(assetString, assetName));
@@ -111,7 +111,7 @@ async function convertGlobalScriptAndOutput(
 	const scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	const isScript = /\.js$/i.test(scriptName);
 	if (isScript) {
-		errors.push.apply(errors, await validateEs5Code(scriptName, scriptString)); // ES5構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEsCode(scriptName, scriptString)); // ES7以下の構文に反する箇所があるかのチェック
 	}
 
 	const code = isScript ? wrapScript(scriptString, scriptName, terser) : wrapText(scriptString, scriptName);

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -75,7 +75,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		assetPaths = assetPaths.concat(globalScriptPaths);
 	}
 	if (errorMessages.length > 0) {
-		options.logger.warn("The following ES7 syntax errors exist.\n" + errorMessages.join("\n"));
+		options.logger.warn("The following ES2015 syntax errors exist.\n" + errorMessages.join("\n"));
 	}
 	await writeHtmlFile(assetPaths, options.output, conf, options);
 	writeOptionScript(options.output, options);
@@ -93,7 +93,7 @@ async function convertAssetAndOutput(
 	const assetString = fs.readFileSync(path.join(inputPath, asset.path), "utf8").replace(/\r\n|\r/g, "\n");
 	const assetPath = asset.path;
 	if (isScript) {
-		errors.push.apply(errors, await validateEsCode(assetPath, assetString)); // ES7以下の構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEsCode(assetPath, assetString)); // (ニコ生ゲームの) サポート下限の ES バージョンにない構文のチェック
 	}
 
 	const code = (isScript ? wrapScript(assetString, assetName, terser, exports) : wrapText(assetString, assetName));
@@ -111,7 +111,7 @@ async function convertGlobalScriptAndOutput(
 	const scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	const isScript = /\.js$/i.test(scriptName);
 	if (isScript) {
-		errors.push.apply(errors, await validateEsCode(scriptName, scriptString)); // ES7以下の構文に反する箇所があるかのチェック
+		errors.push.apply(errors, await validateEsCode(scriptName, scriptString)); // (ニコ生ゲームの) サポート下限の ES バージョンにない構文のチェック
 	}
 
 	const code = isScript ? wrapScript(scriptString, scriptName, terser) : wrapText(scriptString, scriptName);

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -199,8 +199,8 @@ export function getInjectedContents(baseDir: string, injects: string[]): string[
 	return injectedContents;
 }
 
-export async function validateEs5Code(fileName: string, code: string): Promise<string[]> {
-	const errInfo = await cmn.LintUtil.validateEs5Code(code);
+export async function validateEsCode(fileName: string, code: string): Promise<string[]> {
+	const errInfo = await cmn.LintUtil.validateEsCode(code);
 	return errInfo.map(info => `${fileName}(${info.line}:${info.column}): ${info.message}`);
 }
 

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -56,7 +56,7 @@ describe("convert", () => {
 			consoleSpy.mockRestore();
 		});
 
-		it("can not convert game if script that is not written with ES5 syntax", async () => {
+		it("can not convert game if script that is not written with ES7 or less syntax", async () => {
 			let warningMessage = "";
 			const param = {
 				source: path.resolve(fixturesDir, "simple_game_es6"),
@@ -79,9 +79,8 @@ describe("convert", () => {
 			return convertGame(param)
 				.then(() => {
 					expect(fs.existsSync(destDir)).toBe(true);
-					const expected = "Non-ES5 syntax found.\n"
-						+ "script/main.js(1:1): Parsing error: The keyword 'const' is reserved\n"
-						+ "script/foo.js(1:1): Parsing error: The keyword 'const' is reserved";
+					const expected = "Non-ES7 syntax found.\n"
+						+ "script/main.js(9:16): Parsing error: Unexpected token ..."
 					expect(warningMessage).toBe(expected);
 				});
 		});

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -56,7 +56,7 @@ describe("convert", () => {
 			consoleSpy.mockRestore();
 		});
 
-		it("can not convert game if script that is not written with ES7 or less syntax", async () => {
+		it("can not convert game if script that is not written with ES2015 syntax", async () => {
 			let warningMessage = "";
 			const param = {
 				source: path.resolve(fixturesDir, "simple_game_es6"),
@@ -79,8 +79,8 @@ describe("convert", () => {
 			return convertGame(param)
 				.then(() => {
 					expect(fs.existsSync(destDir)).toBe(true);
-					const expected = "Non-ES7 syntax found.\n"
-						+ "script/main.js(9:16): Parsing error: Unexpected token ..."
+					const expected = "Non-ES2015 syntax found.\n"
+						+ "script/main.js(4:15): Parsing error: Unexpected token *"
 					expect(warningMessage).toBe(expected);
 				});
 		});

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -140,7 +140,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					option: param.exportInfo.option
 				};
 			}
-			// 全スクリプトがES7以下の構文になっていることを確認する
+			// 全スクリプトがサポート下限の ES バージョンの構文になっていることを確認する
 			let errorMessages: string[] = [];
 			const filePaths = gcu.extractScriptAssetFilePaths(gamejson);
 			for (const filePath of filePaths) {
@@ -153,7 +153,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 				}
 			}
 			if (errorMessages.length > 0) {
-				param.logger.warn("Non-ES7 syntax found.\n" + errorMessages.join("\n"));
+				param.logger.warn("Non-ES2015 syntax found.\n" + errorMessages.join("\n"));
 			}
 			if (!param.bundle)
 				return null;

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -140,7 +140,7 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					option: param.exportInfo.option
 				};
 			}
-			// 全スクリプトがES5構文になっていることを確認する
+			// 全スクリプトがES7以下の構文になっていることを確認する
 			let errorMessages: string[] = [];
 			const filePaths = gcu.extractScriptAssetFilePaths(gamejson);
 			for (const filePath of filePaths) {

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -146,14 +146,14 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			for (const filePath of filePaths) {
 				const code = fs.readFileSync(path.resolve(param.source, filePath)).toString();
 				if (!param.babel) {
-					const errInfo = await cmn.LintUtil.validateEs5Code(code);
+					const errInfo = await cmn.LintUtil.validateEsCode(code);
 					errorMessages = errorMessages.concat(
 						errInfo.map(info => `${filePath}(${info.line}:${info.column}): ${info.message}`)
 					);
 				}
 			}
 			if (errorMessages.length > 0) {
-				param.logger.warn("Non-ES5 syntax found.\n" + errorMessages.join("\n"));
+				param.logger.warn("Non-ES7 syntax found.\n" + errorMessages.join("\n"));
 			}
 			if (!param.bundle)
 				return null;


### PR DESCRIPTION
## 概要

export zip/html 実行時に ES5 構文のチェックで警告を出力している箇所を、ES2015(ES6) に変更します。