### PR TITLE
Support es-downpile in export-html

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -20,5 +20,6 @@ export interface CliConfigExportHtml {
 	autoSendEventName?: string | boolean;
 	autoGivenArgsName?: string;
 	omitUnbundledJs?: boolean;
+	babel?: boolean;
 	debugOverrideEngineFiles?: string;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -20,6 +20,6 @@ export interface CliConfigExportHtml {
 	autoSendEventName?: string | boolean;
 	autoGivenArgsName?: string;
 	omitUnbundledJs?: boolean;
-	babel?: boolean;
+	esDownpile?: boolean;
 	debugOverrideEngineFiles?: string;
 }

--- a/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
@@ -129,4 +129,20 @@ describe("convertUtil", function () {
 		});
 	});
 
+	describe("wrap", () => {
+		it("babel arguments enabled/disabled", () => {
+			const code = `
+			test = () => {
+				return x ** 2;
+			};`
+			const downpiled = convert.wrap(code, {}, true);
+			expect(/\(\)\s?=>/.test(downpiled)).toBeTruthy(); // ES2015 のアロー関数はそのまま
+			expect(/\*\*/.test(downpiled)).toBeFalsy(); // ES2016 のべき乗演算子は Math.pow()に変換される
+
+			const noDownpiled = convert.wrap(code, null, false);
+			console.log("*", noDownpiled);
+			expect(/\(\)\s?=>/.test(noDownpiled)).toBeTruthy(); 
+			expect(/\*\*/.test(noDownpiled)).toBeTruthy(); 
+		});
+	})
 });

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -30,6 +30,7 @@ function cli(param: CliConfigExportHtml): void {
 		autoSendEventName: param.autoSendEventName || param.autoSendEvents,
 		autoGivenArgsName: param.autoGivenArgsName,
 		omitUnbundledJs: param.omitUnbundledJs,
+		babel: (param.babel != null) ? param.babel : true,
 		compress: param.output ? path.extname(param.output) === ".zip" : false,
 		debugOverrideEngineFiles: param.debugOverrideEngineFiles,
 		// index.htmlに書き込むためのexport実行時の情報
@@ -84,6 +85,7 @@ commander
 	.option("--auto-given-args-name [argsName]", "argument name that given automatically when game start")
 	.option("-a, --atsumaru", "obsolete  option. Use 'akashic export zip --nicolive' instead")
 	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.")
+	.option("--no-es-downpile", "No convert JavaScript")
 	.option("--debug-override-engine-files <filePath>", "Use the specified engineFiles");
 
 export async function run(argv: string[]): Promise<void> {
@@ -128,6 +130,7 @@ export async function run(argv: string[]): Promise<void> {
 		autoSendEventName: options.autoSendEventName ?? options.autoSendEvents ?? conf.autoSendEventName ?? conf.autoSendEvents,
 		autoGivenArgsName: options.autoGivenArgsName ?? conf.autoGivenArgsName,
 		omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
+		babel: options.esDownpile ?? conf.babel,
 		debugOverrideEngineFiles: options.debugOverrideEngineFiles ?? conf.debugOverrideEngineFiles
 
 	});

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -30,7 +30,7 @@ function cli(param: CliConfigExportHtml): void {
 		autoSendEventName: param.autoSendEventName || param.autoSendEvents,
 		autoGivenArgsName: param.autoGivenArgsName,
 		omitUnbundledJs: param.omitUnbundledJs,
-		babel: (param.babel != null) ? param.babel : true,
+		esDownpile: (param.esDownpile != null) ? param.esDownpile : true,
 		compress: param.output ? path.extname(param.output) === ".zip" : false,
 		debugOverrideEngineFiles: param.debugOverrideEngineFiles,
 		// index.htmlに書き込むためのexport実行時の情報
@@ -130,7 +130,7 @@ export async function run(argv: string[]): Promise<void> {
 		autoSendEventName: options.autoSendEventName ?? options.autoSendEvents ?? conf.autoSendEventName ?? conf.autoSendEvents,
 		autoGivenArgsName: options.autoGivenArgsName ?? conf.autoGivenArgsName,
 		omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
-		babel: options.esDownpile ?? conf.babel,
+		esDownpile: options.esDownpile ?? conf.esDownpile,
 		debugOverrideEngineFiles: options.debugOverrideEngineFiles ?? conf.debugOverrideEngineFiles
 
 	});

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -75,7 +75,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 
 	if (conf._content.globalScripts) {
 		const tempScriptData = await Promise.all(conf._content.globalScripts.map((scriptName: string) => {
-			return convertScriptNameToInnerHTMLObj(scriptName, options.source, terser, errorMessages);
+			return convertScriptNameToInnerHTMLObj(scriptName, options.source, terser);
 		}));
 		innerHTMLAssetArray = innerHTMLAssetArray.concat(tempScriptData);
 	}
@@ -123,7 +123,7 @@ async function convertAssetToInnerHTMLObj(
 
 async function convertScriptNameToInnerHTMLObj(
 	scriptName: string, inputPath: string,
-	terser: MinifyOptions | undefined, errors?: string[]): Promise<InnerHTMLAssetData> {
+	terser: MinifyOptions | undefined): Promise<InnerHTMLAssetData> {
 	let scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	const isScript = /\.js$/i.test(scriptName);
 

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -69,7 +69,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 
 	const terser = options.minify ? options.terser ?? {} : undefined;
 	const tempAssetData = await Promise.all(innerHTMLAssetNames.map((assetName: string) => {
-		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, errorMessages);
+		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, options.babel, errorMessages);
 	}));
 	innerHTMLAssetArray = innerHTMLAssetArray.concat(tempAssetData);
 
@@ -103,8 +103,13 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 }
 
 async function convertAssetToInnerHTMLObj(
-	assetName: string, inputPath: string, conf: cmn.Configuration,
-	terser: MinifyOptions | undefined, errors?: string[]): Promise<InnerHTMLAssetData> {
+	assetName: string, 
+	inputPath: string, 
+	conf: cmn.Configuration,
+	terser: MinifyOptions | undefined, 
+	babel: boolean,
+	_errors?: string[]
+): Promise<InnerHTMLAssetData> {
 	const assets = conf._content.assets;
 	const isScript = assets[assetName].type === "script";
 	const asset = assets[assetName];
@@ -113,7 +118,7 @@ async function convertAssetToInnerHTMLObj(
 	return {
 		name: assetName,
 		type: asset.type,
-		code: isScript ? wrap(assetString, terser, exports) : encodeText(assetString)
+		code: isScript ? wrap(assetString, terser, babel, exports) : encodeText(assetString)
 	};
 }
 
@@ -130,7 +135,7 @@ async function convertScriptNameToInnerHTMLObj(
 	return {
 		name: scriptName,
 		type: isScript ? "script" : "text",
-		code: isScript ? wrap(scriptString, terser) : scriptString
+		code: isScript ? wrap(scriptString, terser, false) : scriptString
 	};
 }
 

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -69,7 +69,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 
 	const terser = options.minify ? options.terser ?? {} : undefined;
 	const tempAssetData = await Promise.all(innerHTMLAssetNames.map((assetName: string) => {
-		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, options.babel, errorMessages);
+		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, options.babel);
 	}));
 	innerHTMLAssetArray = innerHTMLAssetArray.concat(tempAssetData);
 
@@ -107,8 +107,7 @@ async function convertAssetToInnerHTMLObj(
 	inputPath: string, 
 	conf: cmn.Configuration,
 	terser: MinifyOptions | undefined, 
-	babel: boolean,
-	_errors?: string[]
+	babel: boolean
 ): Promise<InnerHTMLAssetData> {
 	const assets = conf._content.assets;
 	const isScript = assets[assetName].type === "script";

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -69,7 +69,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 
 	const terser = options.minify ? options.terser ?? {} : undefined;
 	const tempAssetData = await Promise.all(innerHTMLAssetNames.map((assetName: string) => {
-		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, options.babel);
+		return convertAssetToInnerHTMLObj(assetName, options.source, conf, terser, options.esDownpile);
 	}));
 	innerHTMLAssetArray = innerHTMLAssetArray.concat(tempAssetData);
 
@@ -107,7 +107,7 @@ async function convertAssetToInnerHTMLObj(
 	inputPath: string, 
 	conf: cmn.Configuration,
 	terser: MinifyOptions | undefined, 
-	babel: boolean
+	esDownpile: boolean
 ): Promise<InnerHTMLAssetData> {
 	const assets = conf._content.assets;
 	const isScript = assets[assetName].type === "script";
@@ -117,7 +117,7 @@ async function convertAssetToInnerHTMLObj(
 	return {
 		name: assetName,
 		type: asset.type,
-		code: isScript ? wrap(assetString, terser, babel, exports) : encodeText(assetString)
+		code: isScript ? wrap(assetString, terser, esDownpile, exports) : encodeText(assetString)
 	};
 }
 

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -59,7 +59,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	const nonBinaryAssetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
 	const errorMessages: string[] = [];
 	const nonBinaryAssetPaths = await Promise.all(nonBinaryAssetNames.map((assetName: string) => {
-		return convertAssetAndOutput(assetName, conf, options.source, options.output, terser, options.babel, errorMessages);
+		return convertAssetAndOutput(assetName, conf, options.source, options.output, terser, options.babel);
 	}));
 	assetPaths = assetPaths.concat(nonBinaryAssetPaths);
 	if (conf._content.globalScripts) {
@@ -86,8 +86,7 @@ async function convertAssetAndOutput(
 	inputPath: string,
 	outputPath: string,
 	terser: MinifyOptions | undefined,
-	babel: boolean,
-	_errors?: string[]
+	babel: boolean
 ): Promise<string> {
 	const assets = conf._content.assets;
 	const asset = assets[assetName];
@@ -200,8 +199,8 @@ window.optionProps.magnify = ${!!options.magnify};
 	fs.writeFileSync(path.resolve(outputPath, "./js/option.js"), script);
 }
 
-function wrapScript(code: string, name: string, terser?: MinifyOptions, bable?: boolean, exports: string[] = []): string {
-	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, bable, exports) + "}";
+function wrapScript(code: string, name: string, terser?: MinifyOptions, babel?: boolean, exports: string[] = []): string {
+	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, babel, exports) + "}";
 }
 
 function wrapText(code: string, name: string): string {

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -68,8 +68,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 				scriptName,
 				options.source,
 				options.output,
-				terser,
-				errorMessages);
+				terser);
 		}));
 		assetPaths = assetPaths.concat(globalScriptPaths);
 	}
@@ -106,7 +105,7 @@ async function convertAssetAndOutput(
 
 async function convertGlobalScriptAndOutput(
 	scriptName: string, inputPath: string, outputPath: string,
-	terser: MinifyOptions | undefined, errors?: string[]): Promise<string> {
+	terser: MinifyOptions | undefined): Promise<string> {
 	const scriptString = fs.readFileSync(path.join(inputPath, scriptName), "utf8").replace(/\r\n|\r/g, "\n");
 	const isScript = /\.js$/i.test(scriptName);
 	const code = isScript ? wrapScript(scriptString, scriptName, terser, false) : wrapText(scriptString, scriptName);

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -59,7 +59,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	const nonBinaryAssetNames = extractAssetDefinitions(conf, "script").concat(extractAssetDefinitions(conf, "text"));
 	const errorMessages: string[] = [];
 	const nonBinaryAssetPaths = await Promise.all(nonBinaryAssetNames.map((assetName: string) => {
-		return convertAssetAndOutput(assetName, conf, options.source, options.output, terser, options.babel);
+		return convertAssetAndOutput(assetName, conf, options.source, options.output, terser, options.esDownpile);
 	}));
 	assetPaths = assetPaths.concat(nonBinaryAssetPaths);
 	if (conf._content.globalScripts) {
@@ -85,7 +85,7 @@ async function convertAssetAndOutput(
 	inputPath: string,
 	outputPath: string,
 	terser: MinifyOptions | undefined,
-	babel: boolean
+	esDownpile: boolean
 ): Promise<string> {
 	const assets = conf._content.assets;
 	const asset = assets[assetName];
@@ -94,7 +94,7 @@ async function convertAssetAndOutput(
 	const assetString = fs.readFileSync(path.join(inputPath, asset.path), "utf8").replace(/\r\n|\r/g, "\n");
 	const assetPath = asset.path;
 
-	const code = (isScript ? wrapScript(assetString, assetName, terser, babel, exports) : wrapText(assetString, assetName));
+	const code = (isScript ? wrapScript(assetString, assetName, terser, esDownpile, exports) : wrapText(assetString, assetName));
 	const relativePath = "./js/assets/" + path.dirname(assetPath) + "/" +
 		path.basename(assetPath, path.extname(assetPath)) + (isScript ? ".js" : ".json.js");
 	const filePath = path.resolve(outputPath, relativePath);
@@ -198,8 +198,8 @@ window.optionProps.magnify = ${!!options.magnify};
 	fs.writeFileSync(path.resolve(outputPath, "./js/option.js"), script);
 }
 
-function wrapScript(code: string, name: string, terser?: MinifyOptions, babel?: boolean, exports: string[] = []): string {
-	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, babel, exports) + "}";
+function wrapScript(code: string, name: string, terser?: MinifyOptions, esDownpile?: boolean, exports: string[] = []): string {
+	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, esDownpile, exports) + "}";
 }
 
 function wrapText(code: string, name: string): string {

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -86,7 +86,7 @@ async function convertAssetAndOutput(
 	inputPath: string,
 	outputPath: string,
 	terser: MinifyOptions | undefined,
-	isBable: boolean,
+	babel: boolean,
 	_errors?: string[]
 ): Promise<string> {
 	const assets = conf._content.assets;
@@ -96,7 +96,7 @@ async function convertAssetAndOutput(
 	const assetString = fs.readFileSync(path.join(inputPath, asset.path), "utf8").replace(/\r\n|\r/g, "\n");
 	const assetPath = asset.path;
 
-	const code = (isScript ? wrapScript(assetString, assetName, terser, isBable, exports) : wrapText(assetString, assetName));
+	const code = (isScript ? wrapScript(assetString, assetName, terser, babel, exports) : wrapText(assetString, assetName));
 	const relativePath = "./js/assets/" + path.dirname(assetPath) + "/" +
 		path.basename(assetPath, path.extname(assetPath)) + (isScript ? ".js" : ".json.js");
 	const filePath = path.resolve(outputPath, relativePath);
@@ -200,8 +200,8 @@ window.optionProps.magnify = ${!!options.magnify};
 	fs.writeFileSync(path.resolve(outputPath, "./js/option.js"), script);
 }
 
-function wrapScript(code: string, name: string, terser?: MinifyOptions, downpile?: boolean, exports: string[] = []): string {
-	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, downpile, exports) + "}";
+function wrapScript(code: string, name: string, terser?: MinifyOptions, bable?: boolean, exports: string[] = []): string {
+	return "window.gLocalAssetContainer[\"" + name + "\"] = function(g) { " + wrap(code, terser, bable, exports) + "}";
 }
 
 function wrapText(code: string, name: string): string {

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -117,7 +117,7 @@ const babelOption = {
 	]
 };
 
-export function wrap(code: string, terser?: MinifyOptions, isBabel?: boolean, exports: string[] = []): string {
+export function wrap(code: string, terser?: MinifyOptions, downpile?: boolean, exports: string[] = []): string {
 	const preScript = "(function(exports, require, module, __filename, __dirname) {";
 	let postScript: string = "";
 	for (const key of exports) {
@@ -125,7 +125,7 @@ export function wrap(code: string, terser?: MinifyOptions, isBabel?: boolean, ex
 	}
 	postScript += "})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";
 	// downpile -> minify の順序は入れ替えられない (先に minify すると babel がコードを整形してしまう)
-	const downpiled = isBabel ? babel.transform(code, babelOption).code : code;
+	const downpiled = downpile ? babel.transform(code, babelOption).code : code;
 	const ret = preScript + "\n" + (terser ? minify_sync(downpiled, terser).code : downpiled) + "\n" + postScript + "\n";
 	return ret;
 }

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -35,7 +35,7 @@ export interface ConvertTemplateParameterObject {
 	autoGivenArgsName?: string;
 	sandboxConfigJsCode?: string;
 	omitUnbundledJs?: boolean;
-	babel?: boolean;
+	esDownpile?: boolean;
 	debugOverrideEngineFiles?: string;
 }
 
@@ -117,7 +117,7 @@ const babelOption = {
 	]
 };
 
-export function wrap(code: string, terser?: MinifyOptions, downpile?: boolean, exports: string[] = []): string {
+export function wrap(code: string, terser?: MinifyOptions, esDownpile?: boolean, exports: string[] = []): string {
 	const preScript = "(function(exports, require, module, __filename, __dirname) {";
 	let postScript: string = "";
 	for (const key of exports) {
@@ -125,7 +125,7 @@ export function wrap(code: string, terser?: MinifyOptions, downpile?: boolean, e
 	}
 	postScript += "})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";
 	// downpile -> minify の順序は入れ替えられない (先に minify すると babel がコードを整形してしまう)
-	const downpiled = downpile ? babel.transform(code, babelOption).code : code;
+	const downpiled = esDownpile ? babel.transform(code, babelOption).code : code;
 	const ret = preScript + "\n" + (terser ? minify_sync(downpiled, terser).code : downpiled) + "\n" + postScript + "\n";
 	return ret;
 }

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -8,6 +8,8 @@ import type { SandboxConfiguration } from "@akashic/sandbox-configuration";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
 import { minify_sync } from "terser";
+import * as babel from "@babel/core";
+import presetEnv from "@babel/preset-env";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,6 +35,7 @@ export interface ConvertTemplateParameterObject {
 	autoGivenArgsName?: string;
 	sandboxConfigJsCode?: string;
 	omitUnbundledJs?: boolean;
+	babel?: boolean;
 	debugOverrideEngineFiles?: string;
 }
 
@@ -102,14 +105,28 @@ export function encodeText(text: string): string {
 	return text.replace(/[\u2028\u2029'"\\\b\f\n\r\t\v%]/g, encodeURIComponent);
 }
 
-export function wrap(code: string, terser?: MinifyOptions, exports: string[] = []): string {
+const babelOption = {
+	presets: [
+		babel.createConfigItem([presetEnv, {
+			modules: false,
+			targets: {
+				"chrome": 51
+			}
+		}],
+		{ type: "preset" })
+	]
+};
+
+export function wrap(code: string, terser?: MinifyOptions, isBabel?: boolean, exports: string[] = []): string {
 	const preScript = "(function(exports, require, module, __filename, __dirname) {";
 	let postScript: string = "";
 	for (const key of exports) {
 		postScript += `exports["${key}"] = typeof ${key} !== "undefined" ? ${key} : undefined;\n`;
 	}
 	postScript += "})(g.module.exports, g.module.require, g.module, g.filename, g.dirname);";
-	const ret = preScript + "\n" + (terser ? minify_sync(code, terser).code : code) + "\n" + postScript + "\n";
+	// downpile -> minify の順序は入れ替えられない (先に minify すると babel がコードを整形してしまう)
+	const downpiled = isBabel ? babel.transform(code, babelOption).code : code;
+	const ret = preScript + "\n" + (terser ? minify_sync(downpiled, terser).code : downpiled) + "\n" + postScript + "\n";
 	return ret;
 }
 

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -72,7 +72,7 @@ export function promiseExportHtmlRaw(param: ExportHTMLParameterObject): Promise<
 				logger: param.logger,
 				strip: param.strip,
 				minify: param.minify,
-				babel: param.babel,
+				esDownpile: param.esDownpile,
 				terser: param.terser,
 				magnify: param.magnify,
 				force: param.force,

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -72,6 +72,7 @@ export function promiseExportHtmlRaw(param: ExportHTMLParameterObject): Promise<
 				logger: param.logger,
 				strip: param.strip,
 				minify: param.minify,
+				babel: param.babel,
 				terser: param.terser,
 				magnify: param.magnify,
 				force: param.force,

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -113,7 +113,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "script/bar.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/foo.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 				});
 		});
 
@@ -132,7 +132,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 				});
 		});
 
@@ -152,7 +152,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(false);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 				});
 		});
 
@@ -174,7 +174,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.main).toBe("./script/aez_bundle_main.js");
 					expect(gameJson.assets.aez_bundle_main.path).toBe("script/aez_bundle_main.js");
@@ -201,7 +201,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(outputDirectory, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "package.json"))).toBe(true);
 					expect(fs.existsSync(path.join(outputDirectory, "output"))).toBe(false);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					expect(fs.readFileSync(path.join(outputDirectory, "game.json")).toString())
 						.not.toBe(fs.readFileSync(path.join(param.source, "game.json")).toString());
 				})
@@ -229,7 +229,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(false);
 					expect(fs.readFileSync(path.join(destDir, "game.json")).toString())
 						.not.toBe(fs.readFileSync(path.join(param.source, "game.json")).toString());
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 				});
 		});
 
@@ -251,7 +251,7 @@ describe("convert", () => {
 					const gameJson = fs.readFileSync(path.join(destDir, "game.json")).toString();
 					const gameJsonObj = JSON.parse(gameJson);
 					expect(gameJsonObj.assets.ignore2.global).toBeTruthy();
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 				});
 		});
 
@@ -269,7 +269,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/utf8.txt"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 
 					// UTF8 として読み込めることを確認
 					const main = fs.readFileSync(path.join(destDir, "script/main.js"), { encoding: "utf-8" }).toString();
@@ -312,7 +312,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					expect(fs.readFileSync(path.join(destDir, "game.json")).toString())
 						.not.toBe(fs.readFileSync(path.join(param.source, "game.json")).toString());
 					expect(fs.readFileSync(path.join(destDir, "script/aez_bundle_main.js")).toString())
@@ -340,7 +340,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
 					expect(fs.readFileSync(path.join(destDir, "game.json")).toString())
 						.not.toBe(fs.readFileSync(path.join(param.source, "game.json")).toString());
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 				});
 		});
 
@@ -360,7 +360,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "image/akashic-cli.png"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.assets.aez_bundle_main0.path).toBe("script/aez_bundle_main0.js");
 					expect(gameJson.assets.aez_bundle_main0.type).toBe("script");
@@ -386,7 +386,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "script/mainScene0.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					expect(fs.readFileSync(path.join(destDir, "script/mainScene.js")).toString())
 						.toBe(fs.readFileSync(path.join(param.source, "script/mainScene.js")).toString());
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
@@ -412,7 +412,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.assets.aez_bundle_main.path).toBe("script/aez_bundle_main.js");
@@ -450,7 +450,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "script/bar.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "script/foo.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "text/test.json"))).toBe(false);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy(); // node_modules に LICENSE がないので false
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy(); // node_modules に LICENSE がないので false
 
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.assets.aez_bundle_main.path).toBe("script/aez_bundle_main.js");
@@ -487,7 +487,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "image/akashic-cli.png"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					const imgAsset = gameJson.assets.aez_bundle_main;
 					expect(imgAsset.type).toBe("image");
@@ -521,7 +521,7 @@ describe("convert", () => {
 			return convertGame(param)
 				.then(() => {
 					expect(fs.existsSync(path.join(destDir, "script/aez_bundle_main.js"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy(); // node_modules に LICENSE がないので false
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy(); // node_modules に LICENSE がないので false
 					// bundle済みのファイルは残らない
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBe(false);
 					expect(fs.existsSync(path.join(destDir, "script/foo.js"))).toBe(false);
@@ -553,7 +553,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "script/aez_asset_bundle.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeFalsy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeFalsy();
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.assets.aez_asset_bundle.path).toBe("script/aez_asset_bundle.js");
 					expect(gameJson.assets.aez_asset_bundle.type).toBe("script");
@@ -616,7 +616,7 @@ describe("convert", () => {
 				});
 		});
 
-		it("thirdpary_license.txt by bundle", () => {
+		it("thirdparty_license.txt by bundle", () => {
 			const param = {
 				source: path.resolve(fixturesDir, "simple_game_using_external"),
 				dest: destDir,
@@ -627,14 +627,14 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/index.js"))).toBeFalsy();
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBeTruthy();
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBeFalsy();
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 
 					const mainScript = fs.readFileSync(path.join(destDir, "script/aez_bundle_main.js")).toString().split("\n");
 					expect(mainScript[0]).toBe(LICENSE_TEXT_PREFIX.replace(/\r?\n/g, ""));
 				});
 		});
 
-		it("thirdpary_license.txt by no bundle", () => {
+		it("thirdparty_license.txt by no bundle", () => {
 			const param = {
 				source: path.resolve(fixturesDir, "simple_game_using_external"),
 				dest: destDir,
@@ -644,7 +644,7 @@ describe("convert", () => {
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/index.js"))).toBeTruthy();
 					expect(fs.existsSync(path.join(destDir, "node_modules/external/package.json"))).toBeTruthy();
 					expect(fs.existsSync(path.join(destDir, "script/main.js"))).toBeTruthy();
-					expect(fs.existsSync(path.join(destDir, "thirdpary_license.txt"))).toBeTruthy();
+					expect(fs.existsSync(path.join(destDir, "thirdparty_license.txt"))).toBeTruthy();
 
 					const mainScript = fs.readFileSync(path.join(destDir, "script/main.js")).toString().split("\n");
 					expect(mainScript[0]).toBe(LICENSE_TEXT_PREFIX.replace(/\r?\n/g, ""));

--- a/packages/akashic-cli-export/src/zip/__tests__/licenseUtilSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/licenseUtilSpec.ts
@@ -26,7 +26,7 @@ describe("licenseUtil", () => {
 		expect(consoleSpy).toBeCalledWith(expect.stringMatching(/^\[WARNING\].+hoge.+LGPL-3.0-or-later.+.$/));
 		expect(result).toBeTruthy();
 
-		const license = fsx.readFileSync(path.join(destDir, "thirdpary_license.txt")).toString().split(/\r?\n/g);
+		const license = fsx.readFileSync(path.join(destDir, "thirdparty_license.txt")).toString().split(/\r?\n/g);
 		expect(license).toEqual(
 			[
 				"# external",

--- a/packages/akashic-cli-export/src/zip/licenseUtil.ts
+++ b/packages/akashic-cli-export/src/zip/licenseUtil.ts
@@ -8,10 +8,10 @@ interface LicenseInfo {
     licenseText: string;
 }
 
-export const LICENSE_TEXT_PREFIX  = "// For the library license, see thirdpary_license.txt.\n\n";
+export const LICENSE_TEXT_PREFIX  = "// For the library license, see thirdparty_license.txt.\n\n";
 
 /**
- * ライブラリのライセンスファイルをまとめて thirdpary_license.txt へ書き出す
+ * ライブラリのライセンスファイルをまとめて thirdparty_license.txt へ書き出す
  * 
  * @param source コンテンツの game.json があるディレクトリパス
  * @param dest 出力先
@@ -31,7 +31,7 @@ export async function writeLicenseTextFile(source: string, dest: string, filePat
     const body = textAry.join("\n");
 
     cmn.Util.mkdirpSync(dest);
-    fs.writeFileSync(path.resolve(dest, "thirdpary_license.txt"), body);
+    fs.writeFileSync(path.resolve(dest, "thirdparty_license.txt"), body);
     return true;
 }
 


### PR DESCRIPTION
## 概要

export-html に `--no-es-downpile` オプションを追加します。(export-zip と機能は同じ。)

typo 修正

**動作確認**
コンテンツ で downpile 処理を行いアロー関数はそのまま、べき乗演算子(es2016) は Math.pow() に変換されたファイルが出力される事を確認。