### PR TITLE
Use debug engineFiles in serve

### DIFF
--- a/packages/akashic-cli-serve/build/updateEngineFiles.js
+++ b/packages/akashic-cli-serve/build/updateEngineFiles.js
@@ -29,7 +29,7 @@ try {
 		const rootPath = path.dirname(entryPath); // index.js と package.json が同層にあることが前提
 		const version = require(path.join(rootPath, "package.json")).version;
 		const fileName = `engineFilesV${version.replace(/[\.-]/g, "_")}.js`;
-		const engineFilesPath = path.join(rootPath, `dist/raw/release/full/${fileName}`);
+		const engineFilesPath = path.join(rootPath, `dist/raw/debug/full/${fileName}`);
 
 		versions[key].version = version;
 		versions[key].fileName = fileName;


### PR DESCRIPTION
## 概要

serve 実行時の表示画面で EntityTree にクラス名が正しく表示されなくなった。

原因は engineFiles.js が難読化となったため。serve では debug の engineFiles.js を利用するように修正。

自明のためセルフマージとします。