### PR TITLE
feat(serve): support custom fonts

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -1,4 +1,5 @@
 import type { ServiceType } from "../ServiceType.js";
+import type { CliConfigFontDeclaration } from "./common.js";
 
 export interface CliConfigServe {
 	hostname?: string;
@@ -21,4 +22,5 @@ export interface CliConfigServe {
 	sslCert?: string;
 	sslKey?: string;
 	corsAllowOrigin?: string;
+	fonts?: CliConfigFontDeclaration[];
 }

--- a/packages/akashic-cli-commons/src/CliConfig/common.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/common.ts
@@ -1,0 +1,8 @@
+export type CliConfigFontDescriptors = {
+	"font-family": string; // NOTE: font-family は必須
+} & Record<string, string>;
+
+export interface CliConfigFontDeclaration {
+	path: string;
+	descriptors: CliConfigFontDescriptors;
+}

--- a/packages/akashic-cli-commons/src/Util.ts
+++ b/packages/akashic-cli-commons/src/Util.ts
@@ -124,3 +124,22 @@ export function readdirRecursive(dir: string, baseDir: string = dir): string[] {
 export function requireResolve(id: string, opts?: { paths?: string[] | undefined; basedir?: string }): string {
 	return resolve.sync(id, { ...opts, preserveSymlinks: true });
 }
+
+/**
+ * フォントファイルの拡張子からフォント形式を取得する。
+ * @param filePath パス
+ */
+export function getFontFormat(filePath: string): string | null {
+	const extension = path.extname(filePath);
+	switch (extension) {
+		case ".ttf":
+		case ".otf":
+			return "truetype";
+		case ".woff":
+			return "woff";
+		case ".woff2":
+			return "woff2";
+	}
+
+	return null;
+};

--- a/packages/akashic-cli-commons/src/Util.ts
+++ b/packages/akashic-cli-commons/src/Util.ts
@@ -133,8 +133,9 @@ export function getFontFormat(filePath: string): string | null {
 	const extension = path.extname(filePath);
 	switch (extension) {
 		case ".ttf":
-		case ".otf":
 			return "truetype";
+		case ".otf":
+			return "opentype";
 		case ".woff":
 			return "woff";
 		case ".woff2":

--- a/packages/akashic-cli-serve/src/client/bootstrap.tsx
+++ b/packages/akashic-cli-serve/src/client/bootstrap.tsx
@@ -21,11 +21,12 @@ const pluginFuncs = {};
 
 window.addEventListener("load", async () => {
 	try {
+		await operator.assertInitialized();
+
 		for (const fontFamily of store.appOptions.fontFamilies) {
 			await document.fonts.load(`16px '${fontFamily}'`);
 		}
 
-		await operator.assertInitialized();
 		ReactDOM.render(
 			<App store={store} operator={operator} gameViewManager={gameViewManager} />,
 			document.getElementById("container")

--- a/packages/akashic-cli-serve/src/client/bootstrap.tsx
+++ b/packages/akashic-cli-serve/src/client/bootstrap.tsx
@@ -21,6 +21,10 @@ const pluginFuncs = {};
 
 window.addEventListener("load", async () => {
 	try {
+		for (const fontFamily of store.appOptions.fontFamilies) {
+			await document.fonts.load(`16px '${fontFamily}'`);
+		}
+
 		await operator.assertInitialized();
 		ReactDOM.render(
 			<App store={store} operator={operator} gameViewManager={gameViewManager} />,
@@ -34,10 +38,6 @@ window.addEventListener("load", async () => {
 			}
 			// 保存数,順序を保つため、指定数 window を開いたら localStorage に対象のデータが残っていてもクリアする。
 			localStorage.removeItem("win_" + store.contentStore.defaultContent().gameLocationKey);
-		}
-
-		for (const fontFamily of store.appOptions.fontFamilies) {
-			await document.fonts.load(`16px '${fontFamily}'`);
 		}
 	} catch (e) {
 		console.error(e);

--- a/packages/akashic-cli-serve/src/client/bootstrap.tsx
+++ b/packages/akashic-cli-serve/src/client/bootstrap.tsx
@@ -35,6 +35,10 @@ window.addEventListener("load", async () => {
 			// 保存数,順序を保つため、指定数 window を開いたら localStorage に対象のデータが残っていてもクリアする。
 			localStorage.removeItem("win_" + store.contentStore.defaultContent().gameLocationKey);
 		}
+
+		for (const fontFamily of store.appOptions.fontFamilies) {
+			await document.fonts.load(`16px '${fontFamily}'`);
+		}
 	} catch (e) {
 		console.error(e);
 	}

--- a/packages/akashic-cli-serve/src/client/index.html
+++ b/packages/akashic-cli-serve/src/client/index.html
@@ -6,6 +6,7 @@
     <title>Akashic Serve</title>
     <link rel="shortcut icon" type="image/x-icon" href="./static/favicon.ico" />
     <link href="./static/thirdparty/material-icons/material-icons.css" rel="stylesheet" type="text/css">
+    <link href="/public/external/fonts/fonts.css" rel="stylesheet" type="text/css">
 </head>
 <body>
     <div id="container"></div>

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -1,3 +1,4 @@
+import { asHumanReadable } from "@akashic/akashic-cli-commons/lib/asHumanReadable.js";
 import type {ServiceType} from "@akashic/akashic-cli-commons/lib/ServiceType";
 import {observable, action, autorun} from "mobx";
 import { isServiceTypeNicoliveLike } from "../../common/targetServiceUtil";
@@ -22,22 +23,6 @@ import {ProfilerStore} from "./ProfilerStore";
 import {StartupScreenUiStore} from "./StartupScreenUiStore";
 import {storage} from "./storage";
 import {ToolBarUiStore} from "./ToolBarUiStore";
-
-// FIXME: serve の ESM 移行後に commons のものを利用するように修正
-export function asHumanReadable(byteLength: number, fractionDigits?: number): string {
-	if (byteLength < 1024) {
-		return `${byteLength} Bytes`;
-	}
-	// 1024 * 1024
-	if (byteLength < 1048576) {
-		return `${(byteLength / 1024).toFixed(fractionDigits)} KiB`;
-	}
-	// 1024 * 1024 * 1024
-	if (byteLength < 1073741824) {
-		return `${(byteLength / 1048576).toFixed(fractionDigits)} MiB`;
-	}
-	return `${(byteLength / 1073741824).toFixed(fractionDigits)} GiB`;
-}
 
 export interface StoreParameterObject {
 	gameViewManager: GameViewManager;

--- a/packages/akashic-cli-serve/src/common/types/AppOptions.ts
+++ b/packages/akashic-cli-serve/src/common/types/AppOptions.ts
@@ -10,4 +10,5 @@ export interface AppOptions {
 	runInIframe: boolean;
 	experimentalOpen: number | null;
 	disableFeatCheck: boolean;
+	fontFamilies: string[];
 }

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -17,6 +17,7 @@ export interface ServerGlobalConfig {
 	experimentalOpen: number | null;
 	protocol: string;
 	disableFeatCheck: boolean;
+	fontFamilies: string[];
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -38,5 +39,6 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	preserveDisconnected: false,
 	experimentalOpen: null,
 	protocol: "http",
-	disableFeatCheck: false
+	disableFeatCheck: false,
+	fontFamilies: [],
 };

--- a/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/StartupOptionsController.ts
@@ -14,7 +14,8 @@ export const handleToGetStartupOptions = (_req: express.Request, res: express.Re
 			pauseActive: serverGlobalConfig.pauseActive,
 			preserveDisconnected: serverGlobalConfig.preserveDisconnected,
 			experimentalOpen: serverGlobalConfig.experimentalOpen,
-			disableFeatCheck: serverGlobalConfig.disableFeatCheck
+			disableFeatCheck: serverGlobalConfig.disableFeatCheck,
+			fontFamilies: serverGlobalConfig.fontFamilies,
 		});
 	} catch (e) {
 		next(e);

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -354,7 +354,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 				}
 				responseBody += [
 					"@font-face {",
-					Object.entries(font.descriptors).map(([key, value]) => `${key}: '${value}';`).join("\n"),
+					Object.entries(font.descriptors).map(([key, value]) => `${key}: ${value}`).join("\n"),
 					`src: url('${path.join("/public/external/fonts", path.basename(font.path))}') format('${fontFormat}');`,
 					"}",
 				].join("\n");

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -357,7 +357,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 					"@font-face {",
 					Object.entries(font.descriptors).map(([key, value]) => `${key}: ${value};`).join("\n"),
 					`src: url('${path.join("/public/external/fonts", fontFilename)}') format('${fontFormat}');`,
-					"}",
+					"}\n",
 				].join("\n");
 
 				app.get(path.join("/public/external/fonts", fontFilename), (_, res) => res.send(fs.readFileSync(fontPath)));


### PR DESCRIPTION
# このPullRequestが解決する内容
akashic serve にて任意のフォントを CSS として利用できる機能を追加します。

## akashic.config.js の設定例

```js
export default {
  commandOptions: {
    serve: {
      fonts: [
        {
          path: "./foo.ttf",
          descriptors: {
            "font-family": "CustomFont1", // font-family 指定は必須
          },
        },
        {
          path: "/path/to/bar.ttf",
          descriptors: {
            "font-family": "CustomFont2",
          },
        },
      ],
    },
  },
};
```