### PR TITLE
feat(sandbox): support custom font

### DIFF
--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigSandbox.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigSandbox.ts
@@ -1,0 +1,10 @@
+import { CliConfigFontDeclaration } from "./common.js";
+
+export interface CliConfigSandbox {
+	args?: string[];
+	cwd?: string;
+	port?: number;
+	cascade?: string[];
+	scenario?: string;
+	fonts?: CliConfigFontDeclaration[];
+}

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfiguration.ts
@@ -3,6 +3,7 @@ import type { CliConfigExportZip } from "./CliConfigExportZip.js";
 import type { CliConfigInit } from "./CliConfigInit.js";
 import type { CliConfigInstall } from "./CliConfigInstall.js";
 import type { CliConfigModify } from "./CliConfigModify.js";
+import type { CliConfigSandbox } from "./CliConfigSandbox.js";
 import type { CliConfigScanAsset, CliConfigScanGlobalScripts } from "./CliConfigScan.js";
 import type { CliConfigServe } from "./CliConfigServe.js";
 import type { CliConfigStat } from "./CliConfigStat.js";
@@ -21,6 +22,7 @@ export interface CliConfiguration {
 		init?: Partial<CliConfigInit>;
 		install?: Partial<CliConfigInstall>;
 		modify?: Partial<CliConfigModify>;
+		sandbox?: Partial<CliConfigSandbox>;
 		scan?: {
 			asset?: Partial<CliConfigScanAsset>;
 			globalScripts?: Partial<CliConfigScanGlobalScripts>;

--- a/packages/akashic-cli-commons/src/index.ts
+++ b/packages/akashic-cli-commons/src/index.ts
@@ -3,6 +3,7 @@ export { CliConfigExportZip } from "./CliConfig/CliConfigExportZip.js";
 export { CliConfigInit } from "./CliConfig/CliConfigInit.js";
 export { CliConfigInstall } from "./CliConfig/CliConfigInstall.js";
 export { CliConfigModify } from "./CliConfig/CliConfigModify.js";
+export { CliConfigSandbox } from "./CliConfig/CliConfigSandbox.js";
 export { CliConfigScanAsset, CliConfigScanGlobalScripts } from "./CliConfig/CliConfigScan.js";
 export { CliConfigServe } from "./CliConfig/CliConfigServe.js";
 export { CliConfigStat } from "./CliConfig/CliConfigStat.js";

--- a/packages/akashic-cli-sandbox/engine-src/v1/js/sandbox.js
+++ b/packages/akashic-cli-sandbox/engine-src/v1/js/sandbox.js
@@ -22,7 +22,7 @@ window.addEventListener("load", function() {
 		xhr.send();
 	}
 
-	getGamePath(start);
+	window.loadFonts().then(() => getGamePath(start));
 
 	function fitToWindow(center) {
 		var pf = window.sandboxDeveloperProps.driver._platform;

--- a/packages/akashic-cli-sandbox/engine-src/v2/js/sandbox.js
+++ b/packages/akashic-cli-sandbox/engine-src/v2/js/sandbox.js
@@ -22,7 +22,7 @@ window.addEventListener("load", function() {
 		xhr.send();
 	}
 
-	getGamePath(start);
+	window.loadFonts().then(() => getGamePath(start));
 
 	function fitToWindow(center) {
 		var pf = window.sandboxDeveloperProps.driver._platform;

--- a/packages/akashic-cli-sandbox/engine-src/v3/js/sandbox.js
+++ b/packages/akashic-cli-sandbox/engine-src/v3/js/sandbox.js
@@ -22,7 +22,7 @@ window.addEventListener("load", function() {
 		xhr.send();
 	}
 
-	getGamePath(start);
+	window.loadFonts().then(() => getGamePath(start));
 
 	function fitToWindow(center) {
 		var pf = window.sandboxDeveloperProps.driver._platform;

--- a/packages/akashic-cli-sandbox/src/server/app.ts
+++ b/packages/akashic-cli-sandbox/src/server/app.ts
@@ -1,8 +1,11 @@
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import type { CliConfigSandbox } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigSandbox.js";
+import { hashFilepath } from "@akashic/akashic-cli-commons/lib/Renamer.js";
+import { getFontFormat } from "@akashic/akashic-cli-commons/lib/Util.js";
 import express from "express";
-import session  from "express-session";
+import session from "express-session";
 import gameRoute from "./routes/game.js";
 import jsRoute from "./routes/js.js";
 import sandboxConfigRoute from "./routes/sandboxConfig.js";
@@ -24,6 +27,7 @@ interface AppOptions {
 	cssBase?: string;
 	thirdpartyBase?: string;
 	cascadeBases?: string[];
+	fonts?: CliConfigSandbox["fonts"];
 }
 
 interface ModuleEnvironment {
@@ -50,6 +54,8 @@ export default function (options: AppOptions = {}): AkashicSandbox {
 	const jsBase = options.jsBase ? options.jsBase : path.join(appBase, "js");
 	const cssBase = options.cssBase ? options.cssBase : path.join(appBase, "css");
 	const thridpartyBase = options.thirdpartyBase ? options.thirdpartyBase : path.join(appBase, "thirdparty");
+	const fonts = options.fonts ?? [];
+	const fontFamilies = fonts.map(font => font.descriptors["font-family"]);
 
 	const app: AkashicSandbox = express();
 	const isDev = app.get("env") === "development";
@@ -120,6 +126,62 @@ export default function (options: AppOptions = {}): AkashicSandbox {
 			next();
 		}
 	});
+
+	const serveDefaultFontCSS = (): void => {
+		app.get("/css/fonts/fonts.css", (_, res) => {
+			res.contentType("text/css");
+			res.send("");
+		});
+	};
+
+	if (fonts && fonts.length > 0) {
+		try {
+			let responseBody = "";
+
+			for (const font of fonts) {
+				const fontPath = path.resolve(gameBase, font.path);
+				if (!fs.existsSync(fontPath)) {
+					throw new Error(`${fontPath} not found.`);
+				}
+
+				const fontFormat = getFontFormat(font.path);
+				if (fontFormat == null) {
+					const extension = path.extname(font.path);
+					throw new Error(
+						`The file extension "${extension}" from "${font.path}" is not supported in 'commandOptions.sandbox.fonts'.`
+					);
+				}
+
+				const fontFilename = hashFilepath(fontPath, 16);
+
+				responseBody += [
+					"@font-face {",
+					Object.entries(font.descriptors).map(([key, value]) => `${key}: ${value};`).join("\n"),
+					`src: url('${path.join("/css/fonts", fontFilename)}') format('${fontFormat}');`,
+					"}\n",
+				].join("\n");
+
+				app.get(path.join("/css/fonts", fontFilename), (_, res) => res.send(fs.readFileSync(fontPath)));
+			}
+
+			app.get("/css/fonts/fonts.css", (_, res) => {
+				res.contentType("text/css");
+				res.send(responseBody);
+			});
+
+			app.use((_req, res, next) => {
+				res.locals.fontFamilies = fontFamilies;
+				next();
+			});
+		} catch (error) {
+			console.error(error.message);
+			console.error("Proceeding without applying the 'commandOptions.sandbox.fonts' specification.");
+			serveDefaultFontCSS();
+		}
+	} else {
+		serveDefaultFontCSS();
+	}
+
 	app.use("/js/", express.static(jsBase));
 	app.use("/css/", express.static(cssBase));
 	app.use("/thirdparty/", express.static(thridpartyBase));

--- a/packages/akashic-cli-sandbox/src/server/controller/game.ts
+++ b/packages/akashic-cli-sandbox/src/server/controller/game.ts
@@ -17,7 +17,8 @@ const controller: RequestHandler = (req, res, _next) => {
 		version: version,
 		devMode: devMode,
 		engineFilesVariable: engineFilesVariable,
-		engineFilesPath: `js/v${version}/${engineFilesVariable}.js`
+		engineFilesPath: `js/v${version}/${engineFilesVariable}.js`,
+		fontFamilies: res.locals.fontFamilies ?? [],
 	});
 };
 

--- a/packages/akashic-cli-sandbox/views/game.ejs
+++ b/packages/akashic-cli-sandbox/views/game.ejs
@@ -38,6 +38,13 @@ window.g = engineFiles.akashicEngine;
     import { TimeKeeper } from "/js/TimeKeeper.js";
     window.TimeKeeper = TimeKeeper;
 </script>
+<script type="module">
+    window.loadFonts = async () => {
+        for (const fontFamily of <%- JSON.stringify(fontFamilies) %>) {
+            await document.fonts.load(`16px '${fontFamily}'`);
+        }
+    };
+</script>
 <% if (version === "1") { %>
 <script type="text/javascript" src="/js/v<%= version %>/logger.js"></script>
 <% } %>
@@ -46,6 +53,7 @@ window.g = engineFiles.akashicEngine;
 <link rel="stylesheet" href="/thirdparty/css/pure-min.css">
 <link rel="stylesheet" href="/thirdparty/css/font-awesome.min.css">
 <link rel="stylesheet" href="/css/developer.css">
+<link rel="stylesheet" href="/css/fonts/fonts.css">
 <script src="/thirdparty/js/vue.min.js" type="text/javascript"></script>
 <script src="/thirdparty/js/interact.min.js" type="text/javascript"></script>
 <script src="/js/v<%= version %>/developer.js" type="text/javascript"></script>
@@ -77,7 +85,7 @@ body{
 	</div>
 	<div id="containerRight">
 		<div id="profilerContainer">
-			<canvas id="profilerCanvas" />
+			<canvas id="profilerCanvas"></canvas>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
# このPullRequestが解決する内容
- #1492 の akashic-cli-sandbox 側対応です。
  - `commandOptions.sandbox` が存在しなかったため、読み込めるようにサポートしています

```js
export default {
  commandOptions: {
    sandbox: {
      fonts: [
        {
          path: "./foo.ttf",
          descriptors: {
            "font-family": "CustomFont1", // font-family 指定は必須
          },
        },
        {
          path: "/path/to/bar.ttf",
          descriptors: {
            "font-family": "CustomFont2",
          },
        },
      ],
    },
  },
};
```