### PR TITLE
fix(sandbox): fix crash when installed sandbox only, caused by a lacking dependency

### DIFF
--- a/.changeset/swift-geese-develop.md
+++ b/.changeset/swift-geese-develop.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-sandbox": patch
+---
+
+Fix crash when installed sandbox only, caused by a lacking dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -19609,11 +19609,11 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.0-next.0",
+      "version": "3.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0-next.0",
-        "@akashic/akashic-cli-export": "2.0.0-next.0",
+        "@akashic/akashic-cli-export": "2.0.0-next.1",
         "@akashic/akashic-cli-extra": "2.0.0-next.0",
         "@akashic/akashic-cli-init": "2.0.0-next.0",
         "@akashic/akashic-cli-lib-manage": "2.0.0-next.0",
@@ -19818,7 +19818,7 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0-next.0",
@@ -20211,6 +20211,7 @@
       "version": "2.0.0-next.0",
       "license": "MIT",
       "dependencies": {
+        "@akashic/akashic-cli-commons": "1.0.0-next.0",
         "@akashic/game-configuration": "^2.0.0",
         "@akashic/headless-driver": "2.15.12",
         "commander": "^11.0.0",

--- a/packages/akashic-cli-sandbox/package.json
+++ b/packages/akashic-cli-sandbox/package.json
@@ -38,6 +38,7 @@
     "@akashic:registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
+    "@akashic/akashic-cli-commons": "1.0.0-next.0",
     "@akashic/game-configuration": "^2.0.0",
     "@akashic/headless-driver": "2.15.12",
     "commander": "^11.0.0",


### PR DESCRIPTION
掲題どおり。

index.js から参照されている commons が dependencies になく、単体で akashic-cli-sandbox だけ導入するとエラーになっていました。

自明につきセルフマージします。
