### PR TITLE
chore: fix no lint targets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,8 +100,9 @@
     },
     "node_modules/@akashic/eslint-config": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/eslint-config/-/eslint-config-2.1.0.tgz",
+      "integrity": "sha512-1bF3lz5z2vtz9L8lq1lj+JPdqu8JDJDx8OlBvhTgU0vkukX/ofmj/d3VpAsrE/a3gl0Eheiea44vtilxu1fyNA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.7.5",
         "eslint": "^8.51.0",
@@ -4944,8 +4945,9 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
         "@typescript-eslint/scope-manager": "6.21.0",
@@ -19609,7 +19611,7 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.0-next.1",
+      "version": "3.0.0-next.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0-next.0",
@@ -19617,18 +19619,18 @@
         "@akashic/akashic-cli-extra": "2.0.0-next.0",
         "@akashic/akashic-cli-init": "2.0.0-next.0",
         "@akashic/akashic-cli-lib-manage": "2.0.0-next.0",
-        "@akashic/akashic-cli-sandbox": "2.0.0-next.0",
+        "@akashic/akashic-cli-sandbox": "2.0.0-next.1",
         "@akashic/akashic-cli-scan": "1.0.0-next.0",
         "@akashic/akashic-cli-serve": "2.0.0-next.0",
         "commander": "^12.0.0"
       },
       "bin": {
-        "akashic": "bin/akashic"
+        "akashic": "bin/akashic.js"
       },
       "devDependencies": {
-        "@akashic/eslint-config": "^2.1.0",
+        "@akashic/eslint-config": "2.1.0",
         "@types/node": "^20.16.9",
-        "@typescript-eslint/eslint-plugin": "^8.7.0",
+        "@typescript-eslint/eslint-plugin": "6.21.0",
         "eslint": "^8.57.1",
         "eslint-plugin-import": "^2.30.0",
         "rimraf": "^6.0.1",
@@ -19843,10 +19845,10 @@
         "terser": "^5.34.1"
       },
       "bin": {
-        "akashic-cli-export": "bin/run",
-        "akashic-cli-export-html": "bin/akashic-cli-export-html",
-        "akashic-cli-export-zip": "bin/akashic-cli-export-zip",
-        "akashic-cli-zip": "bin/akashic-cli-export-zip"
+        "akashic-cli-export": "bin/run.js",
+        "akashic-cli-export-html": "bin/akashic-cli-export-html.js",
+        "akashic-cli-export-zip": "bin/akashic-cli-export-zip.js",
+        "akashic-cli-zip": "bin/akashic-cli-export-zip.js"
       },
       "devDependencies": {
         "@akashic/akashic-engine": "~2.6.7",
@@ -19870,7 +19872,7 @@
         "typescript": "5.6.2",
         "uglify-save-license": "0.4.1",
         "vinyl-source-stream": "2.0.0",
-        "vitest": "^2.1.9",
+        "vitest": "^2.1.1",
         "zip": "1.2.0"
       }
     },
@@ -20028,9 +20030,9 @@
         "lodash": "4.17.21"
       },
       "bin": {
-        "akashic-cli-config": "bin/akashic-cli-config",
-        "akashic-cli-modify": "bin/akashic-cli-modify",
-        "akashic-cli-stat": "bin/akashic-cli-stat"
+        "akashic-cli-config": "bin/akashic-cli-config.js",
+        "akashic-cli-modify": "bin/akashic-cli-modify.js",
+        "akashic-cli-stat": "bin/akashic-cli-stat.js"
       },
       "devDependencies": {
         "@akashic/eslint-config": "2.1.0",
@@ -20045,7 +20047,7 @@
         "mock-fs": "5.2.0",
         "rimraf": "3.0.2",
         "typescript": "5.5.4",
-        "vitest": "^2.1.9"
+        "vitest": "^2.0.5"
       }
     },
     "packages/akashic-cli-extra/node_modules/@types/commander": {
@@ -20079,7 +20081,7 @@
         "unzipper": "0.12.3"
       },
       "bin": {
-        "akashic-cli-init": "bin/run"
+        "akashic-cli-init": "bin/run.js"
       },
       "devDependencies": {
         "@akashic/eslint-config": "2.1.0",
@@ -20098,7 +20100,7 @@
         "mock-fs": "5.2.0",
         "rimraf": "3.0.2",
         "typescript": "5.5.4",
-        "vitest": "^2.1.9"
+        "vitest": "^2.1.1"
       }
     },
     "packages/akashic-cli-init/node_modules/@types/commander": {
@@ -20143,9 +20145,9 @@
         "tar": "7.4.3"
       },
       "bin": {
-        "akashic-cli-install": "bin/akashic-cli-install",
-        "akashic-cli-uninstall": "bin/akashic-cli-uninstall",
-        "akashic-cli-update": "bin/akashic-cli-update"
+        "akashic-cli-install": "bin/akashic-cli-install.js",
+        "akashic-cli-uninstall": "bin/akashic-cli-uninstall.js",
+        "akashic-cli-update": "bin/akashic-cli-update.js"
       },
       "devDependencies": {
         "@akashic/eslint-config": "2.1.0",
@@ -20162,7 +20164,7 @@
         "mock-fs": "5.2.0",
         "rimraf": "3.0.2",
         "typescript": "5.6.2",
-        "vitest": "^2.1.9"
+        "vitest": "^2.0.5"
       }
     },
     "packages/akashic-cli-lib-manage/node_modules/@akashic/game-configuration": {
@@ -20208,7 +20210,7 @@
     },
     "packages/akashic-cli-sandbox": {
       "name": "@akashic/akashic-cli-sandbox",
-      "version": "2.0.0-next.0",
+      "version": "2.0.0-next.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0-next.0",
@@ -20221,7 +20223,7 @@
         "express-session": "^1.17.3"
       },
       "bin": {
-        "akashic-cli-sandbox": "bin/akashic-cli-sandbox"
+        "akashic-cli-sandbox": "bin/akashic-cli-sandbox.js"
       },
       "devDependencies": {
         "@akashic/akashic-engine": "~2.6.6",
@@ -20240,7 +20242,7 @@
         "eslint-plugin-import": "^2.29.0",
         "supertest": "^6.3.1",
         "typescript": "^5.0.0",
-        "vitest": "^2.1.9"
+        "vitest": "^2.1.0"
       }
     },
     "packages/akashic-cli-sandbox/node_modules/@akashic/game-configuration": {
@@ -20340,7 +20342,7 @@
         "thumbcoil": "~1.2.0"
       },
       "bin": {
-        "akashic-cli-scan": "bin/run"
+        "akashic-cli-scan": "bin/run.js"
       },
       "devDependencies": {
         "@akashic/eslint-config": "2.1.0",
@@ -20354,7 +20356,7 @@
         "mock-fs": "5.2.0",
         "shx": "0.3.4",
         "typescript": "5.5.4",
-        "vitest": "^2.1.9"
+        "vitest": "^2.0.5"
       }
     },
     "packages/akashic-cli-scan/node_modules/@akashic/game-configuration": {
@@ -20466,7 +20468,7 @@
         "socket.io-parser": "4.2.4"
       },
       "bin": {
-        "akashic-cli-serve": "bin/run"
+        "akashic-cli-serve": "bin/run.js"
       },
       "devDependencies": {
         "@akashic/agvw": "^1.0.4",
@@ -20893,192 +20895,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "packages/akashic-cli/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/type-utils": "8.14.0",
-        "@typescript-eslint/utils": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/parser": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/typescript-estree": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.14.0",
-        "@typescript-eslint/utils": "8.14.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/types": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/visitor-keys": "8.14.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.6.3",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/utils": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.14.0",
-        "@typescript-eslint/types": "8.14.0",
-        "@typescript-eslint/typescript-estree": "8.14.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      }
-    },
-    "packages/akashic-cli/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.14.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "packages/akashic-cli/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -21329,20 +21145,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/akashic-cli/node_modules/minimatch": {
-      "version": "9.0.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "packages/akashic-cli/node_modules/p-limit": {

--- a/packages/akashic-cli-commons/.eslintrc.cjs
+++ b/packages/akashic-cli-commons/.eslintrc.cjs
@@ -11,6 +11,6 @@ module.exports = {
 	ignorePatterns: [
 		"**/*.js",
 		"*.cjs",
-		"*.ts",
+		"**/__tests__/**/*",
 	],
 }

--- a/packages/akashic-cli-commons/package.json
+++ b/packages/akashic-cli-commons/package.json
@@ -25,7 +25,7 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint -c .eslintrc.cjs --fix"
+    "test:lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\""
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigSandbox.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigSandbox.ts
@@ -1,4 +1,4 @@
-import { CliConfigFontDeclaration } from "./common.js";
+import type { CliConfigFontDeclaration } from "./common.js";
 
 export interface CliConfigSandbox {
 	args?: string[];

--- a/packages/akashic-cli-commons/src/FileSystem.ts
+++ b/packages/akashic-cli-commons/src/FileSystem.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
-import * as editorconfig from "editorconfig";
-import { join } from "path";
 import { existsSync, statSync } from "fs";
+import { join } from "path";
+import * as editorconfig from "editorconfig";
 import type { CliConfiguration } from "./CliConfig/CliConfiguration.js";
 import { loadModule } from "./loadModule.js";
 

--- a/packages/akashic-cli-commons/src/Util.ts
+++ b/packages/akashic-cli-commons/src/Util.ts
@@ -102,7 +102,7 @@ export async function getTotalFileSize(directoryPath: string): Promise<number> {
  * 指定ディレクトリ以下のすべてのファイルを再帰的に取得する
  * @param dir パス
  * @param baseDir ベース
- * @returns 
+ * @returns
  */
 export function readdirRecursive(dir: string, baseDir: string = dir): string[] {
 	let files: string[] = [];

--- a/packages/akashic-cli-commons/src/__tests__/FileSystemSpec.ts
+++ b/packages/akashic-cli-commons/src/__tests__/FileSystemSpec.ts
@@ -177,6 +177,6 @@ describe("FileSystemSpec", () => {
 		expect(content).toEqual({ val: 42 });
 
 		await unlink("./foo/test.json");
-		expect(readJSON("./foo/test.json")).rejects.toMatchObject({ code: "ENOENT" });
+		await expect(readJSON("./foo/test.json")).rejects.toMatchObject({ code: "ENOENT" });
 	});
 });

--- a/packages/akashic-cli-export/.eslintrc.cjs
+++ b/packages/akashic-cli-export/.eslintrc.cjs
@@ -2,7 +2,8 @@ module.exports = {
 	root: true,
 	ignorePatterns: [
 		"*.js",
-		"/*.ts"
+		"/*.ts",
+		"**/__tests__/**/*"
 	],
 	overrides: [
 		{

--- a/packages/akashic-cli-export/package.json
+++ b/packages/akashic-cli-export/package.json
@@ -18,7 +18,7 @@
     "build:template:v2": "cd src/template/template-export-html-v2 && npm install --no-package-lock && npm run build && cd ../../",
     "build:template:v3": "cd src/template/template-export-html-v3 && npm install --no-package-lock && npm run build && cd ../../",
     "build:template:ejs": "shx cp src/template/bundle-index.ejs lib/template/ && shx cp src/template/no-bundle-index.ejs lib/template/",
-    "lint": "eslint -c .eslintrc.cjs --fix",
+    "lint": "eslint -c .eslintrc.cjs --fix \"src/**/*.ts\"",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run"
   },

--- a/packages/akashic-cli-export/src/__tests__/licenseUtilSpec.ts
+++ b/packages/akashic-cli-export/src/__tests__/licenseUtilSpec.ts
@@ -22,8 +22,8 @@ describe("licenseUtil", () => {
 	it("writeLicenseTextFile()", async () => {
 		const result = await writeLicenseTextFile(contentPath, destDir,  moduleFilePaths);
 
-		expect(consoleSpy).toBeCalledWith(expect.stringMatching(/^\[WARNING\].+license-warn.+foo.+.$/));		
-		expect(consoleSpy).toBeCalledWith(expect.stringMatching(/^\[WARNING\].+hoge.+LGPL-3.0-or-later.+.$/));
+		expect(consoleSpy).toBeCalledWith(expect.stringMatching(/^\[WARN\].+license-warn.+foo.+.$/));		
+		expect(consoleSpy).toBeCalledWith(expect.stringMatching(/^\[WARN\].+hoge.+LGPL-3.0-or-later.+.$/));
 		expect(result).toBeTruthy();
 
 		const license = fsx.readFileSync(path.join(destDir, "library_license.txt")).toString().split(/\r?\n/g);

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -95,7 +95,7 @@ export async function run(argv: string[]): Promise<void> {
 	const options = commander.opts();
 
 	let configuration;
-	try { 
+	try {
 		configuration = await FileSystem.load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);
@@ -103,9 +103,11 @@ export async function run(argv: string[]): Promise<void> {
 	}
 	if (options.debugOverrideEngineFiles) {
 		if (!/^engineFilesV\d+_\d+_\d+.*\.js$/.test(path.basename(options.debugOverrideEngineFiles))) {
-			console.error(`Invalid ---debug-override-engine-files option argument:${options.debugOverrideEngineFiles},`
-				+ "File name should be in engineFilesVx_x_x format");
-				process.exit(1);
+			console.error(
+				`Invalid ---debug-override-engine-files option argument:${options.debugOverrideEngineFiles}, ` +
+				"File name should be in engineFilesVx_x_x format"
+			);
+			process.exit(1);
 		}
 	}
 	if (options.atsumaru) {

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -6,6 +6,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
+import * as liceneUtil from "../licenseUtil.js";
 import { validateGameJson } from "../utils.js";
 import type {
 	ConvertTemplateParameterObject} from "./convertUtil.js";
@@ -21,7 +22,6 @@ import {
 	validateSandboxConfigJs,
 	readSandboxConfigJs
 } from "./convertUtil.js";
-import * as liceneUtil from "../licenseUtil.js";
 
 interface InnerHTMLAssetData {
 	name: string;
@@ -84,7 +84,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	}
 
 	await liceneUtil.writeLicenseTextFile(options.source, options.output, libPaths, conf._content.environment["sandbox-runtime"]);
-	
+
 	if (errorMessages.length > 0) {
 		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));
 	}
@@ -108,10 +108,10 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 }
 
 async function convertAssetToInnerHTMLObj(
-	assetName: string, 
-	inputPath: string, 
+	assetName: string,
+	inputPath: string,
 	conf: cmn.Configuration,
-	terser: MinifyOptions | undefined, 
+	terser: MinifyOptions | undefined,
 	esDownpile: boolean
 ): Promise<InnerHTMLAssetData> {
 	const assets = conf._content.assets;
@@ -144,10 +144,10 @@ async function convertScriptNameToInnerHTMLObj(
 }
 
 async function writeHtmlFile(
-	innerHTMLAssetArray: InnerHTMLAssetData[], 
+	innerHTMLAssetArray: InnerHTMLAssetData[],
 	outputPath: string,
-	conf: cmn.Configuration, 
-	options: ConvertTemplateParameterObject, 
+	conf: cmn.Configuration,
+	options: ConvertTemplateParameterObject,
 	templatePath: string
 ): Promise<void> {
 	const injects = options.injects ? options.injects : [];

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -6,6 +6,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
+import * as liceneUtil from "../licenseUtil.js";
 import { validateGameJson } from "../utils.js";
 import type {
 	ConvertTemplateParameterObject} from "./convertUtil.js";
@@ -21,7 +22,6 @@ import {
 	resolveEngineFilesPath,
 	validateSandboxConfigJs
 } from "./convertUtil.js";
-import * as liceneUtil from "../licenseUtil.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -5,11 +5,11 @@ import { fileURLToPath } from "url";
 import * as cmn from "@akashic/akashic-cli-commons";
 import type { AssetConfigurationMap, ImageAssetConfigurationBase } from "@akashic/game-configuration";
 import type { SandboxConfiguration } from "@akashic/sandbox-configuration";
+import * as babel from "@babel/core";
+import presetEnv from "@babel/preset-env";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
 import { minify_sync } from "terser";
-import * as babel from "@babel/core";
-import presetEnv from "@babel/preset-env";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -152,5 +152,5 @@ async function createRenamedGame(sourcePath: string, hashLength: number): Promis
 	const gamejson = await cmn.FileSystem.readJSON<cmn.GameConfiguration>(path.join(destDirPath, "game.json"));
 	cmn.Renamer.renameAssetFilenames(gamejson, destDirPath, hashLength);
 	await cmn.FileSystem.writeJSON<cmn.GameConfiguration>(path.resolve(path.join(destDirPath, "game.json")), gamejson);
-	return destDirPath;	
+	return destDirPath;
 }

--- a/packages/akashic-cli-export/src/licenseUtil.ts
+++ b/packages/akashic-cli-export/src/licenseUtil.ts
@@ -1,114 +1,125 @@
-import * as cmn from "@akashic/akashic-cli-commons";
 import * as fs from "fs";
+import { createRequire } from "module";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { createRequire } from "module";
+import * as cmn from "@akashic/akashic-cli-commons";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);
 
-interface LicenseInfo { 
-    name: string;
-    type: string;
-    licenseText: string;
+interface LicenseInfo {
+	name: string;
+	type: string;
+	licenseText: string;
 }
 
 export const LICENSE_TEXT_PREFIX  = "// For the library license, see library_license.txt.\n\n";
 
 /**
  * ライブラリのライセンスファイルをまとめて library_license.txt へ書き出す
- * 
+ *
  * @param source コンテンツの game.json があるディレクトリパス
  * @param dest 出力先
  * @param filePaths ファイルパスの配列
  * @param engineFilesVersion engineFiles のバージョン。akashic 関連のライセンス情報を含める場合に指定する
  */
-export async function writeLicenseTextFile(source: string, dest: string, filePaths: string[], engineFilesVersion?: string): Promise<boolean> {
-    const libPkgJsonPaths = cmn.NodeModules.listPackageJsonsFromScriptsPath(source, filePaths);
-    let licenseInfos = await makeLicenseInfo(source, libPkgJsonPaths);
-    if (!engineFilesVersion && (!libPkgJsonPaths.length || !licenseInfos.length)) return false;
+export async function writeLicenseTextFile(
+	source: string,
+	dest: string,
+	filePaths: string[],
+	engineFilesVersion?: string
+): Promise<boolean> {
+	const libPkgJsonPaths = cmn.NodeModules.listPackageJsonsFromScriptsPath(source, filePaths);
+	let licenseInfos = await makeLicenseInfo(source, libPkgJsonPaths);
+	if (!engineFilesVersion && (!libPkgJsonPaths.length || !licenseInfos.length)) return false;
 
-    if (engineFilesVersion) { 
-        const akashicLicenseInfos = await makeAkashicLibsLicenseInfo(engineFilesVersion);
-        licenseInfos = [...licenseInfos, ...akashicLicenseInfos];
-    }
+	if (engineFilesVersion) {
+		const akashicLicenseInfos = await makeAkashicLibsLicenseInfo(engineFilesVersion);
+		licenseInfos = [...licenseInfos, ...akashicLicenseInfos];
+	}
 
-    let textAry: string[] = [];
-    licenseInfos.forEach(obj => {
-        textAry.push(`# ${obj.name}`);
-        textAry.push("");
-        textAry.push(obj.licenseText);
-    });
-    const body = textAry.join("\n");
+	const textAry: string[] = [];
+	licenseInfos.forEach(obj => {
+		textAry.push(`# ${obj.name}`);
+		textAry.push("");
+		textAry.push(obj.licenseText);
+	});
+	const body = textAry.join("\n");
 
-    cmn.Util.mkdirpSync(dest);
-    fs.writeFileSync(path.resolve(dest, "library_license.txt"), body);
-    return true;
+	cmn.Util.mkdirpSync(dest);
+	fs.writeFileSync(path.resolve(dest, "library_license.txt"), body);
+	return true;
 }
 
 async function makeAkashicLibsLicenseInfo(engineFilesVersion: string): Promise<LicenseInfo[]> {
-    const rootPath = path.resolve(__dirname, "..", "..", "..");
-    const headlessDriverPath = require.resolve("@akashic/headless-driver");
-    const engineFilesPackageDir = path.dirname(require.resolve(`engine-files-v${engineFilesVersion}`, {paths: [headlessDriverPath]}));
-    const engineFilesPackageJson = require(`${engineFilesPackageDir}/package.json`);
-    
-    const libNames = Object.keys(engineFilesPackageJson.dependencies);
-    const libPkgJsonPaths = [];
-    for (const name of libNames) {     
-        try {
-            const libPath = require.resolve(path.join(name, "package.json"));
-            libPkgJsonPaths.push(libPath);
-        } catch(e) { 
-            // do noting
-        }
-    };
-    return await makeLicenseInfo(rootPath, libPkgJsonPaths);
+	const rootPath = path.resolve(__dirname, "..", "..", "..");
+	const headlessDriverPath = require.resolve("@akashic/headless-driver");
+	const engineFilesPackageDir = path.dirname(require.resolve(`engine-files-v${engineFilesVersion}`, {paths: [headlessDriverPath]}));
+	const engineFilesPackageJson = require(`${engineFilesPackageDir}/package.json`);
+
+	const libNames = Object.keys(engineFilesPackageJson.dependencies);
+	const libPkgJsonPaths = [];
+	for (const name of libNames) {
+		try {
+			const libPath = require.resolve(path.join(name, "package.json"));
+			libPkgJsonPaths.push(libPath);
+		} catch (e) {
+			// do noting
+		}
+	};
+	return await makeLicenseInfo(rootPath, libPkgJsonPaths);
 }
 
 async function makeLicenseInfo(source: string, pkgJsonPaths: string[]): Promise<LicenseInfo[]> {
-    const licenseInfos: LicenseInfo[] = [];
-    for (const p of pkgJsonPaths) {
-        const pkgJsonPath = path.resolve(source, p);
-        const pkgJson = await cmn.FileSystem.readJSON<any>(pkgJsonPath);
+	const licenseInfos: LicenseInfo[] = [];
+	for (const p of pkgJsonPaths) {
+		const pkgJsonPath = path.resolve(source, p);
+		const pkgJson = await cmn.FileSystem.readJSON<any>(pkgJsonPath);
 
-        const files = fs.readdirSync(path.dirname(pkgJsonPath));
-        const licenseFile = files.find((file) => {
-            // 仕様上はあらゆる拡張子が許されているが、テキストファイルに取り込むのでここでは .txt と .md のみ考慮する
-            if (/^LICEN[SC]E$/i.test(file) || /^LICEN[SC]E.(txt|md)$/i.test(file)) {
-                return true;    
-            }
-            // LICENSE-LGPL のようなファイルは機械的に扱えないので警告を出力
-            if (/^LICEN[SC]E[^a-z]/i.test(file)) {
-                console.warn(`[WARNING]: Detected a license-like file "${file}" in ${pkgJson.name} but ignored (not included in library_license.txt) because akashic export doesn't know how it should be handled. You may need to follow the license by yourself.`);
-                return false;
-            }
-        });
-        if (!licenseFile) continue;
-        const licensePath = path.join(path.dirname(pkgJsonPath), licenseFile);
+		const files = fs.readdirSync(path.dirname(pkgJsonPath));
+		const licenseFile = files.find((file) => {
+			// 仕様上はあらゆる拡張子が許されているが、テキストファイルに取り込むのでここでは .txt と .md のみ考慮する
+			if (/^LICEN[SC]E$/i.test(file) || /^LICEN[SC]E.(txt|md)$/i.test(file)) {
+				return true;
+			}
+			// LICENSE-LGPL のようなファイルは機械的に扱えないので警告を出力
+			if (/^LICEN[SC]E[^a-z]/i.test(file)) {
+				console.warn(
+					`[WARN]: Detected a license-like file "${file}" in ${pkgJson.name} but ignored (not included in library_license.txt) ` +
+					"because akashic export doesn't know how it should be handled. You may need to follow the license by yourself."
+				);
+				return false;
+			}
+		});
+		if (!licenseFile) continue;
+		const licensePath = path.join(path.dirname(pkgJsonPath), licenseFile);
 
-        if (fs.existsSync(licensePath) && isAutoIncludableLicense(pkgJson.name, pkgJson.license)) {
-            let text = fs.readFileSync(licensePath, "utf-8");
+		if (fs.existsSync(licensePath) && isAutoIncludableLicense(pkgJson.name, pkgJson.license)) {
+			let text = fs.readFileSync(licensePath, "utf-8");
 
-            if(!/[\r\n|\n|\r]$/.test(text)) {
-                text += "\n";
-            };
-            licenseInfos.push({
-                name: pkgJson.name,
-                type:pkgJson.license, 
-                licenseText: text
-            });
-        }
-    };
-    return licenseInfos;
+			if (!/[\r\n|\n|\r]$/.test(text)) {
+				text += "\n";
+			};
+			licenseInfos.push({
+				name: pkgJson.name,
+				type:pkgJson.license,
+				licenseText: text
+			});
+		}
+	};
+	return licenseInfos;
 }
 
 function isAutoIncludableLicense(libName: string, license: string): boolean {
-    // MIT/ISC 以外のライセンスは警告
-    if (/(MIT|ISC)/i.test(license)) {
-        return true;
-    } else { 
-        console.warn(`[WARNING]: The license of ${libName} will not be included in library_license.txt since akashic export doesn't know its license "${license}". You may need to follow the license by yourself.`);
-        return false;
-    }
+	// MIT/ISC 以外のライセンスは警告
+	if (/(MIT|ISC)/i.test(license)) {
+		return true;
+	} else {
+		console.warn(
+			`[WARN]: The license of ${libName} will not be included in library_license.txt ` +
+			`since akashic export doesn't know its license "${license}". You may need to follow the license by yourself.`
+		);
+		return false;
+	}
 }

--- a/packages/akashic-cli-export/src/utils.ts
+++ b/packages/akashic-cli-export/src/utils.ts
@@ -1,5 +1,3 @@
-import { existsSync, readdirSync } from "fs";
-import * as path from "path";
 import type * as cmn from "@akashic/akashic-cli-commons";
 import type { AssetConfiguration } from "@akashic/game-configuration";
 

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -96,7 +96,7 @@ export async function run(argv: string[]): Promise<void> {
 	const options = commander.opts();
 
 	let configuration;
-	try { 
+	try {
 		configuration = await FileSystem.load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -11,12 +11,12 @@ import type { OutputChunk, RollupBuild } from "rollup";
 import { rollup } from "rollup";
 import type { MinifyOptions } from "terser";
 import { minify_sync } from "terser";
+import * as liceneUtil from "../licenseUtil.js";
 import * as utils from "../utils.js";
 import { validateGameJson } from "../utils.js";
 import { getFromHttps } from "./apiUtil.js";
 import { NICOLIVE_SIZE_LIMIT_GAME_JSON, NICOLIVE_SIZE_LIMIT_TOTAL_FILE } from "./constants.js";
 import * as gcu from "./GameConfigurationUtil.js";
-import * as liceneUtil from "../licenseUtil.js";
 import { transformPackSmallImages } from "./transformPackImages.js";
 
 // NOTE: 以下のパッケージは型定義が存在しないか JS と型定義の齟齬があるため `require()` を用いている

--- a/packages/akashic-cli-extra/.eslintrc.cjs
+++ b/packages/akashic-cli-extra/.eslintrc.cjs
@@ -11,6 +11,6 @@ module.exports = {
 	ignorePatterns: [
 		"**/*.js",
 		"*.cjs",
-		"*.ts"
+		"**/__tests__/**/*"
 	]
 }

--- a/packages/akashic-cli-extra/package.json
+++ b/packages/akashic-cli-extra/package.json
@@ -30,7 +30,7 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint -c .eslintrc.cjs --fix"
+    "test:lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\""
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-extra/src/modify/cli.ts
+++ b/packages/akashic-cli-extra/src/modify/cli.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
 import { createRequire } from "module";
+import * as path from "path";
 import type { CliConfigModify } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, FileSystem } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
@@ -27,7 +27,7 @@ function defineCommand(commandName: string): void {
 		.option("-q, --quiet", "Suppress output")
 		.action(async (value: string, opts: CliConfigModify = {}) => {
 			let configuration;
-			try { 
+			try {
 				configuration = await FileSystem.load(path.join(opts.cwd || process.cwd()));
 			} catch (error) {
 				console.error(error);

--- a/packages/akashic-cli-extra/src/stat/cli.ts
+++ b/packages/akashic-cli-extra/src/stat/cli.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
 import { createRequire } from "module";
+import * as path from "path";
 import type { Logger, CliConfigStat, GameConfiguration } from "@akashic/akashic-cli-commons";
 import { ConsoleLogger, FileSystem } from "@akashic/akashic-cli-commons";
 import { Command } from "commander";
@@ -39,12 +39,12 @@ commander
 	.option("-l, --limit <limit>", "Limit size")
 	.option("--raw", "Raw mode. Result will not contain logger prefix.");
 
-function cli(param: CliConfigStat): void {
+async function cli(param: CliConfigStat): Promise<void> {
 	const logger = new ConsoleLogger({ quiet: param.quiet });
 	const target = param.args.length > 0 ? param.args[0] : "(empty)";
 	switch (target) {
 		case "size":
-			statSize(logger, param);
+			await statSize(logger, param);
 			break;
 		default:
 			commander.help();
@@ -63,7 +63,7 @@ export async function run(argv: string[]): Promise<void> {
 		process.exit(1);
 	}
 	const conf = configuration!.commandOptions?.stat ?? {};
-	cli({
+	await cli({
 		args: commander.args ?? conf.args,
 		cwd: options.cwd ?? conf.cwd,
 		quiet: options.quiet ?? conf.quiet,

--- a/packages/akashic-cli-init/.eslintrc.cjs
+++ b/packages/akashic-cli-init/.eslintrc.cjs
@@ -11,7 +11,6 @@ module.exports = {
 	ignorePatterns: [
 		"*.js",
 		"*.cjs",
-		"*.ts",
 		"typings/**/*",
 		"src/__tests__/**/*"
 	]

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf ./lib",
     "start": "npm run build && node bin/run.js",
     "build": "tsc -p ./",
-    "lint": "eslint -c .eslintrc.cjs --fix",
+    "lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\"",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run"
   },

--- a/packages/akashic-cli-init/src/cli.ts
+++ b/packages/akashic-cli-init/src/cli.ts
@@ -1,10 +1,10 @@
 import { createRequire } from "module";
 import type { CliConfigInit } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigInit.js";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger.js";
+import { load } from "@akashic/akashic-cli-commons/lib/FileSystem.js";
 import { Command } from "commander";
 import { promiseInit } from "./init/init.js";
 import { listTemplates } from "./list/listTemplates.js";
-import { load } from "@akashic/akashic-cli-commons/lib/FileSystem.js";
 
 async function cli(param: CliConfigInit): Promise<void> {
 	const logger = new ConsoleLogger({ quiet: param.quiet });
@@ -55,7 +55,7 @@ export async function run(argv: string[]): Promise<void> {
 	const options = commander.opts();
 
 	let configuration;
-	try { 
+	try {
 		configuration = await load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);

--- a/packages/akashic-cli-init/src/init/BasicParameters.ts
+++ b/packages/akashic-cli-init/src/init/BasicParameters.ts
@@ -110,7 +110,7 @@ export async function updateConfigurationFile(confPath: string, logger: Logger, 
 		height: conf.height,
 		fps: conf.fps
 	}, skipAsk);
-		
+
 	setBasicParameters(conf, basicParams);
 	return await writeJSON(confPath, conf);
 }

--- a/packages/akashic-cli-lib-manage/.eslintrc.cjs
+++ b/packages/akashic-cli-lib-manage/.eslintrc.cjs
@@ -11,6 +11,6 @@ module.exports = {
 	ignorePatterns: [
 		"**/*.js",
 		"*.cjs",
-		"*.ts"
+		"**/__tests__/**/*"
 	]
 }

--- a/packages/akashic-cli-lib-manage/package.json
+++ b/packages/akashic-cli-lib-manage/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint -c .eslintrc.cjs --fix"
+    "test:lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\""
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-lib-manage/src/install/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/install/cli.ts
@@ -47,7 +47,7 @@ export async function run(argv: string[]): Promise<void> {
 	commander.parse(argv);
 	const options = commander.opts();
 	let configuration;
-	try { 
+	try {
 		configuration = await FileSystem.load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);

--- a/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/uninstall/cli.ts
@@ -35,7 +35,7 @@ export async function run(argv: string[]): Promise<void> {
 	const options = commander.opts();
 
 	let configuration;
-	try { 
+	try {
 		configuration = await FileSystem.load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);

--- a/packages/akashic-cli-lib-manage/src/update/cli.ts
+++ b/packages/akashic-cli-lib-manage/src/update/cli.ts
@@ -30,7 +30,7 @@ export async function run(argv: string[]): Promise<void> {
 	const options = commander.opts();
 
 	let configuration;
-	try { 
+	try {
 		configuration = await FileSystem.load(options.cwd || process.cwd());
 	} catch (error) {
 		console.error(error);

--- a/packages/akashic-cli-scan/.eslintrc.cjs
+++ b/packages/akashic-cli-scan/.eslintrc.cjs
@@ -11,7 +11,6 @@ module.exports = {
 	ignorePatterns: [
 		"**/*.js",
 		"*.cjs",
-		"*.ts",
 		"src/__tests__/**/*"
 	]
 }

--- a/packages/akashic-cli-scan/package.json
+++ b/packages/akashic-cli-scan/package.json
@@ -8,7 +8,7 @@
     "prepublish": "npm run clean && npm run build",
     "clean": "shx rm -rf lib && shx rm -rf spec/build",
     "build": "tsc -p ./",
-    "lint": "eslint -c .eslintrc.cjs --fix",
+    "lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\"",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run"
   },

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -1,13 +1,14 @@
 import { createRequire } from "module";
 import type { CliConfigScanAsset, CliConfigScanGlobalScripts } from "@akashic/akashic-cli-commons/lib/CliConfig/CliConfigScan.js";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger.js";
+import { load } from "@akashic/akashic-cli-commons/lib/FileSystem.js";
 import { Command } from "commander";
 import type { ScanAssetParameterObject } from "./scanAsset.js";
 import { scanAsset } from "./scanAsset.js";
-import { scanNodeModules, ScanNodeModulesParameterObject } from "./scanNodeModules.js";
+import type { ScanNodeModulesParameterObject } from "./scanNodeModules.js";
+import { scanNodeModules } from "./scanNodeModules.js";
 import type { AssetTargetType } from "./types.js";
 import { watchAsset } from "./watchAsset.js";
-import { load } from "@akashic/akashic-cli-commons/lib/FileSystem.js";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -36,7 +37,7 @@ commander
 	.option("--text-asset-extension <extension...>", "specify TextAsset extension")
 	.action(async (target: AssetTargetType, opts: CliConfigScanAsset = {}) => {
 		let configuration;
-		try { 
+		try {
 			configuration = await load(opts.cwd || process.cwd());
 		} catch (error) {
 			console.error(error);
@@ -101,7 +102,7 @@ commander
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)")
 	.action(async (opts: CliConfigScanGlobalScripts = {}) => {
 		let configuration;
-		try { 
+		try {
 			configuration = await load(opts.cwd || process.cwd());
 		} catch (error) {
 			console.error(error);

--- a/packages/akashic-cli/.eslintrc.cjs
+++ b/packages/akashic-cli/.eslintrc.cjs
@@ -12,6 +12,6 @@ module.exports = {
 	ignorePatterns: [
 		"**/*.js",
 		"*.cjs",
-		"*.ts",
+		"**/__tests__/**/*",
 	]
 }

--- a/packages/akashic-cli/package.json
+++ b/packages/akashic-cli/package.json
@@ -10,7 +10,7 @@
     "prepublish": "npm run clean && npm run build",
     "clean": "rimraf ./lib",
     "build": "tsc -p ./",
-    "lint": "eslint -c .eslintrc.cjs --fix",
+    "lint": "eslint -c .eslintrc.cjs --fix \"./src/**/*.ts\"",
     "test": "npm run lint"
   },
   "author": "DWANGO Co., Ltd.",
@@ -31,9 +31,9 @@
     "commander": "^12.0.0"
   },
   "devDependencies": {
-    "@akashic/eslint-config": "^2.1.0",
+    "@akashic/eslint-config": "2.1.0",
     "@types/node": "^20.16.9",
-    "@typescript-eslint/eslint-plugin": "^8.7.0",
+    "@typescript-eslint/eslint-plugin": "6.21.0",
     "eslint": "^8.57.1",
     "eslint-plugin-import": "^2.30.0",
     "rimraf": "^6.0.1",

--- a/packages/akashic-cli/src/ui.ts
+++ b/packages/akashic-cli/src/ui.ts
@@ -1,5 +1,5 @@
-import { Command } from "commander";
 import { createRequire } from "module";
+import { Command } from "commander";
 
 const require = createRequire(import.meta.url);
 const { version } = require("../package.json");
@@ -22,6 +22,6 @@ commander
 	.command("sandbox", "Start a standalone server for a game")
 	.passThroughOptions();
 
-export function run(argv: string[]) {
+export function run(argv: string[]): void {
 	commander.parse(argv);
 }


### PR DESCRIPTION
掲題どおり。

ESM 移行の過程で eslint の引数が消えており (e.g. [init の例][init-esm])、serve と sandbox 以外は「lint 対象ファイルが 0 個しかない」＝ lint が何もチェックせずに成功する状態になっていました。これを修正します。

- eslint 起動時の引数に `"./src/**/*.ts"` を追加
- .eslintrc.cjs の ignorePatterns から `"*.ts"` を削除 (あるなら)
- .eslintrc.cjs の ignorePatterns に `"**/__tests__/**/*"` を追加 (なければ)
   - 本当はテストコードも lint した方がいいんですが、修正方法が自明でないものが散見されるので一旦見送ります

.ts の変更は (コメントをつけた一部を除き) lint の自動修正によるものです。

[init-esm]: https://github.com/akashic-games/akashic-cli/pull/1430/files#diff-4a5f273387461f9d0e5e02be2a2ca11d62626956cad0db48cdb6c834b090bfecR11
