### PR TITLE
fix(export): fix --bundle breaks games including audio

### DIFF
--- a/.changeset/beige-scissors-wash.md
+++ b/.changeset/beige-scissors-wash.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-export": patch
+---
+
+Fix export-zip's `--bundle` breaks games including audio

--- a/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
@@ -183,7 +183,7 @@ describe("exportHTML", function () {
 		expect(fsx.statSync(path.join(dest, "audio", "dummyse.ogg"))).toBeTruthy();
 		expect(fsx.statSync(path.join(dest, "audio", "dummyse.aac"))).toBeTruthy();
 		expect(fsx.statSync(path.join(dest, "audio", "dummyse.m4a"))).toBeTruthy();
-		expect(() => void fsx.statSync(path.join(dest, "audio", "dummyse.invalidext"))).toThrow();
+		expect(() => fsx.statSync(path.join(dest, "audio", "dummyse.invalidext"))).toThrow();
 		fsx.removeSync(dest);
 	});
 


### PR DESCRIPTION
掲題どおり。

`--bundle` 時、不要ファイルを削除する際に音声アセットが全て消される問題を解消します。

「不要ファイル」の判定は `preservingFilePathSet` と `asset.path` で行われていますが、音声アセットの場合に限り `asset.path` が拡張子を含まないため、間違って全部不要と判定されていました。( #1486 の最後でつけたコメント https://github.com/akashic-games/akashic-cli/pull/1486#discussion_r1920087860 が誤りでした。)　元々現状では音声アセットが減ることはない＝全て残るだけなので、暫定的に type: "audio" のアセットは常に残すように変更します。

#1465 同様に、ミニマムコンテンツのほか、[ニコニコスネーク](https://github.com/akashic-contents/niconicoSnake/) と [リリアと魔女 [LILIEA - Act1]](https://github.com/akashic-contents/liliea-act1) で動作を確認しています。ユニットテストでは扱えていない範囲で、prerelease 後に reftest で動作確認を行います。
