### PR TITLE
fix(export): fix fs-extra related crash, such as export-html given .zip destination

### DIFF
--- a/.changeset/polite-socks-relate.md
+++ b/.changeset/polite-socks-relate.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-commons": patch
+"@akashic/akashic-cli-export": patch
+---
+
+Fix export-html crash when the output path ends with `.zip`

--- a/packages/akashic-cli-commons/src/Renamer.ts
+++ b/packages/akashic-cli-commons/src/Renamer.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import { sha256 } from "js-sha256";
 import type { GameConfiguration } from "./GameConfiguration.js";
 import { KNOWN_AUDIO_EXTENSIONS } from "./knownAudioExtensions.js";

--- a/packages/akashic-cli-commons/vitest.config.ts
+++ b/packages/akashic-cli-commons/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
 		globals: true,
 		include: [
 			"./src/**/__tests__/**/*[sS]pec.ts",
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli-export/src/__tests__/licenseUtilSpec.ts
+++ b/packages/akashic-cli-export/src/__tests__/licenseUtilSpec.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import { writeLicenseTextFile } from "../licenseUtil.js";
 
 

--- a/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import * as exp from "../exportHTML.js";
 
 describe("exportHTML", function () {

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -6,7 +6,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
-import * as liceneUtil from "../licenseUtil.js";
+import * as licenseUtil from "../licenseUtil.js";
 import { validateGameJson } from "../utils.js";
 import type {
 	ConvertTemplateParameterObject} from "./convertUtil.js";
@@ -83,7 +83,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 		innerHTMLAssetArray = innerHTMLAssetArray.concat(tempScriptData);
 	}
 
-	await liceneUtil.writeLicenseTextFile(options.source, options.output, libPaths, conf._content.environment["sandbox-runtime"]);
+	await licenseUtil.writeLicenseTextFile(options.source, options.output, libPaths, conf._content.environment["sandbox-runtime"]);
 
 	if (errorMessages.length > 0) {
 		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -6,7 +6,7 @@ import * as cmn from "@akashic/akashic-cli-commons";
 import * as ejs from "ejs";
 import fsx from "fs-extra";
 import type { MinifyOptions } from "terser";
-import * as liceneUtil from "../licenseUtil.js";
+import * as licenseUtil from "../licenseUtil.js";
 import { validateGameJson } from "../utils.js";
 import type {
 	ConvertTemplateParameterObject} from "./convertUtil.js";
@@ -76,7 +76,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 		assetPaths = assetPaths.concat(globalScriptPaths);
 	}
 
-	await liceneUtil.writeLicenseTextFile(options.source, options.output, libPaths, content.environment["sandbox-runtime"]);
+	await licenseUtil.writeLicenseTextFile(options.source, options.output, libPaths, content.environment["sandbox-runtime"]);
 
 	if (errorMessages.length > 0) {
 		options.logger.warn("The following ES5 syntax errors exist.\n" + errorMessages.join("\n"));

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -4,7 +4,7 @@ import * as os from "os";
 import * as path from "path";
 import * as cmn from "@akashic/akashic-cli-commons";
 import archiver = require("archiver");
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import { promiseConvertBundle } from "./convertBundle.js";
 import { promiseConvertNoBundle } from "./convertNoBundle.js";
 import type { ConvertTemplateParameterObject } from "./convertUtil.js";

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { createRequire } from "module";
 import * as path from "path";
 import vm from "vm";
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import mockfs from "mock-fs";
 import { vi } from "vitest";
 import { validateGameJson } from "../../utils.js";

--- a/packages/akashic-cli-export/src/zip/__tests__/transformPackImagesSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/transformPackImagesSpec.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { makeUnixPath } from "@akashic/akashic-cli-commons/lib/Util.js";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import { extractPackTargets, transformPackSmallImagesImpl } from "../transformPackImages.js";
 
 describe("transformPackImages", () => {

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -6,7 +6,7 @@ import type { ImageAssetConfigurationBase, NicoliveSupportedModes } from "@akash
 import * as babel from "@babel/core";
 import presetEnv from "@babel/preset-env";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
-import * as fsx from "fs-extra";
+import fsx from "fs-extra";
 import type { OutputChunk, RollupBuild } from "rollup";
 import { rollup } from "rollup";
 import type { MinifyOptions } from "terser";

--- a/packages/akashic-cli-export/vitest.config.ts
+++ b/packages/akashic-cli-export/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
 		globals: true,
 		include: [
 			"./src/**/__tests__/**/*[sS]pec.ts"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });


### PR DESCRIPTION
掲題どおり。次の条件でクラッシュする問題を修正します。

- export html で、 `-o` に `.zip` で終わるパスを渡した場合
- export html で、 `--hash-filename` を指定した場合
- export zip で `--force` かつ `--hash-filename` (や `--nicolive`) を指定した場合

原因は `fs-extra` の使い方で、`import fs from ...` ではなく `import * as fs from ...` とすると一部メソッドが「型検査をパスするが実行時にエラーになる」状態になります。(型定義に問題がありそう……ですが深追いしていません)　悪いことに、Vitest はこの import の不整合の帳尻を合わせるオプション [`deps.interopDefault`][interop-default] がデフォルトで有効になっており、問題のコードはユニットテストでは正しく動作するようです。

`interopDefualt` を外してユニットテストで確認できるようにした他、実コンテンツでも export html, zip 両方の問題が解消することを確認しています。

[interop-default]: https://vitest.dev/config/#deps-interopdefault

#### その他補足

- 本質的にはそもそも fs-extra の利用をやめるべき (今なら fs で事足りるはず) ですが、動作確認の必要な箇所が大きく増えるため見送っています。
- 問題になっていない他のパッケージでも `deps.interopDefault` を有効にすべきですが、changeset がよくわからなくなるので別 PR #1508 で対応します。
- なお zip の方は別の不具合があり、 `--hash-filename` とセットの `--force` は失敗するようです。が、この問題とは別に対応します。