### PR TITLE
chore: disable vitest's deps.interopDefault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20154,7 +20154,6 @@
         "@akashic/game-configuration": "2.5.0",
         "@types/commander": "2.12.5",
         "@types/form-data": "2.5.0",
-        "@types/fs-extra": "9.0.13",
         "@types/mock-fs": "4.13.4",
         "@types/node": "18.19.44",
         "@types/tar": "6.1.13",

--- a/packages/akashic-cli-extra/vitest.config.ts
+++ b/packages/akashic-cli-extra/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
 		globals: true,
 		include: [
 			"./src/**/__tests__/**/*[sS]pec.ts"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli-init/src/__tests__/BasicParametersSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/BasicParametersSpec.ts
@@ -1,7 +1,7 @@
 import * as os from "os";
 import * as path from "path";
 import {ConsoleLogger} from "@akashic/akashic-cli-commons/lib/ConsoleLogger.js";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import mockfs from "mock-fs";
 import * as bp from "../init/BasicParameters.js";
 import * as mockPrompt from "./support/mockPrompt.js";

--- a/packages/akashic-cli-init/src/__tests__/initSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/initSpec.ts
@@ -1,6 +1,6 @@
 import * as path from "path";
 import { ConsoleLogger } from "@akashic/akashic-cli-commons/lib/ConsoleLogger.js";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import mockfs from "mock-fs";
 import { internals } from "../init/init.js";
 import { completeTemplateConfig } from "../init/TemplateConfig.js";

--- a/packages/akashic-cli-init/vitest.config.ts
+++ b/packages/akashic-cli-init/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
 		],
 		include: [
 			"./src/__tests__/**/*[sS]pec.ts"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli-lib-manage/package.json
+++ b/packages/akashic-cli-lib-manage/package.json
@@ -26,7 +26,6 @@
     "@akashic/game-configuration": "2.5.0",
     "@types/commander": "2.12.5",
     "@types/form-data": "2.5.0",
-    "@types/fs-extra": "9.0.13",
     "@types/mock-fs": "4.13.4",
     "@types/node": "18.19.44",
     "@types/tar": "6.1.13",

--- a/packages/akashic-cli-lib-manage/tsconfig.json
+++ b/packages/akashic-cli-lib-manage/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "Node16",
     "outDir": "./lib",
     "declaration": true,
-    "types" : ["commander", "form-data", "fs-extra", "jest", "mock-fs", "node"],
+    "types" : ["commander", "form-data", "jest", "mock-fs", "node"],
     "useUnknownInCatchVariables": false,
     "strict": true,
     "allowSyntheticDefaultImports": true

--- a/packages/akashic-cli-lib-manage/vitest.config.ts
+++ b/packages/akashic-cli-lib-manage/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
 		],
 		include: [
 			"./src/**/__tests__/**/*[sS]pec.ts"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli-sandbox/vitest.config.ts
+++ b/packages/akashic-cli-sandbox/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
 		globals: true,
 		include: [
 			"./spec/**/*[sS]pec.js"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli-scan/vitest.config.ts
+++ b/packages/akashic-cli-scan/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
 		],
 		include: [
 			"./src/__tests__/**/*[sS]pec.ts"
-		]
+		],
+		deps: {
+			interopDefault: false,
+		},
 	},
 });

--- a/packages/akashic-cli/vitest.config.ts
+++ b/packages/akashic-cli/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
 		globals: true,
 		include: [
 			"./src/**/__tests__/**/*[sS]pec.ts",
-		]
+		],
+		deps: {
+			interopDefault: false,
+		}
 	},
 });


### PR DESCRIPTION
掲題どおり。

#1507 で export, commons に加えた vitest の設定変更 (`deps.interopDefault` の無効化) に各パッケージで追従します。

- init のテストにしか影響がなく、本体のコードは変更していないため changeset は加えていません。
- lib-manage ではそもそも不要だった @types/fs-extra を削除しています。

修正自明のためセルフマージします。
