### PR TITLE
fix(cli): fix launch failure of 'akashic serve'

### DIFF
--- a/.changeset/poor-shoes-speak.md
+++ b/.changeset/poor-shoes-speak.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli": patch
+---
+
+fix launch failure of 'akashic serve'

--- a/packages/akashic-cli/bin/akashic-serve.js
+++ b/packages/akashic-cli/bin/akashic-serve.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
-import { createRequire } from "module";
-const require = createRequire(import.meta.url);
-require("@akashic/akashic-cli-serve/lib/server/").run(process.argv);
+(async () => {
+	const { run } = await import("@akashic/akashic-cli-serve/lib/server/index.js");
+	run(process.argv);
+})();


### PR DESCRIPTION
掲題どおり。ESM 移行漏れを修正します。

bin/ 以下のスクリプトのためユニットテストで確認できませんが、 `node bin/akashic-serve.js` で直接実行した時に問題が起きなくなることを確認しています。

対応自明につきセルフマージします。
