### PR TITLE
Fix custom font in serve and sandbox

### DIFF
--- a/.changeset/silly-dots-learn.md
+++ b/.changeset/silly-dots-learn.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-sandbox": patch
+"@akashic/akashic-cli-serve": patch
+---
+
+Fix custom font in serve and sandbox

--- a/packages/akashic-cli-sandbox/src/server/app.ts
+++ b/packages/akashic-cli-sandbox/src/server/app.ts
@@ -156,7 +156,7 @@ export default function (options: AppOptions = {}): AkashicSandbox {
 
 				responseBody += [
 					"@font-face {",
-					Object.entries(font.descriptors).map(([key, value]) => `${key}: ${value};`).join("\n"),
+					Object.entries(font.descriptors).map(([key, value]) => `${key}: "${value}";`).join("\n"),
 					`src: url('${path.join("/css/fonts", fontFilename)}') format('${fontFormat}');`,
 					"}\n",
 				].join("\n");

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -360,7 +360,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 
 				responseBody += [
 					"@font-face {",
-					Object.entries(font.descriptors).map(([key, value]) => `${key}: ${value};`).join("\n"),
+					Object.entries(font.descriptors).map(([key, value]) => `${key}: "${value}";`).join("\n"),
 					`src: url('${path.join("/public/external/fonts", fontFilename)}') format('${fontFormat}');`,
 					"}\n",
 				].join("\n");


### PR DESCRIPTION
## 概要

serve, sandbox でカスタムフォントを使用する際、 akashic.config.js の font-family の値に空白入りの文字列が入るとフォントが効かなくなる問題を修正。
(シングルクォートで囲った場合はエラーとなります。)

akahsic.config.js
```
....
descriptors: {
  "font-family": "M PLUS Rounded 1c"
}
```

ホストされる font.css の font-family の値が空白が入っていたので扱えなくなった
```
@font-face {
font-family: M PLUS Rounded 1c;
...
```
