### PR TITLE
feat(serve): support replaying playlog from JSON in standalone mode

### DIFF
--- a/.changeset/forty-nails-reply.md
+++ b/.changeset/forty-nails-reply.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-serve": patch
+---
+
+support replaying playlog from JSON in standalone mode

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -90,7 +90,7 @@ export class Operator {
 			status: "running",
 			content: this.store.contentStore.defaultContent(),
 			amflow,
-			initialPlaylog: playlog,
+			disableFastForward: !!playlog,
 			durationState: {
 				duration: playDuration,
 				isPaused: executionMode === "replay",

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -1,8 +1,10 @@
+import { calculateFinishedTime } from "@akashic/amflow-util/lib/calculateFinishedTime";
 import { isServiceTypeNicoliveLike } from "../../../common/targetServiceUtil";
 import type { GameViewManager } from "../../akashic/GameViewManager";
 import { ServeMemoryAmflowClient } from "../../akashic/ServeMemoryAMFlowClient";
 import type { ClientContentLocator } from "../../common/ClientContentLocator";
 import type { ScreenSize } from "../../common/types/ScreenSize";
+import type { ExecutionMode } from "../../store/ExecutionMode";
 import { PlayEntity } from "../../store/PlayEntity";
 import type { Store } from "../Store";
 import { DevtoolOperator } from "./DevtoolOperator";
@@ -16,8 +18,9 @@ export interface OperatorParameterObject {
 }
 
 export interface StartContentParameterObject {
-	joinsSelf: boolean;
+	joinsSelf?: boolean;
 	isReplay?: boolean;
+	playlog?: any; // FIXME: 型をつける (DumpedPlaylog は ./src/server 以下にあるため不要な依存を避ける)
 }
 
 export class Operator {
@@ -61,7 +64,24 @@ export class Operator {
 	startContent = async (params?: StartContentParameterObject): Promise<void> => {
 		const store = this.store;
 		const player = store.player ?? { id: "sandbox-player", name: "sandbox-player" };
-		const amflow = new ServeMemoryAmflowClient({ playId: "0", });
+		const executionMode: ExecutionMode = params?.playlog ? "replay" : "active";
+		const playlog = params?.playlog;
+
+		if (store.currentPlay) {
+			await store.currentPlay.deleteAllLocalInstances();
+			store.setCurrentLocalInstance(null);
+		}
+
+		const amflow = new ServeMemoryAmflowClient({
+			playId: "0",
+			tickList: playlog ? playlog.tickList : null,
+			startPoints: playlog ? playlog.startPoints : null
+		});
+
+		let playDuration = 0;
+		if (playlog) {
+			playDuration = calculateFinishedTime(playlog.tickList, playlog.startPoints[0].data.fps);
+		}
 
 		// TODO: 本来は PlayStore で生成すべきだが、現状の PlayStore は SocketIO が必須になるため PlayEntity を直接生成している
 		const playEntity = new PlayEntity({
@@ -70,9 +90,10 @@ export class Operator {
 			status: "running",
 			content: this.store.contentStore.defaultContent(),
 			amflow,
+			initialPlaylog: playlog,
 			durationState: {
-				duration: 0,
-				isPaused: false,
+				duration: playDuration,
+				isPaused: executionMode === "replay",
 			},
 		});
 		amflow.onPutStartPoint.add(startPoint => playEntity.handleStartPointHeader(startPoint));
@@ -87,7 +108,7 @@ export class Operator {
 
 		const instance = await playEntity.createLocalInstance({
 			playId: playEntity.playId,
-			executionMode: "active",
+			executionMode,
 			player,
 			argument,
 			runInIframe: store.appOptions.runInIframe,
@@ -116,6 +137,39 @@ export class Operator {
 
 	setGameViewSize = (size: ScreenSize): void => {
 		this.store.setGameViewSize(size);
+	};
+
+	uploadPlaylog = (): void => {
+		const input = document.createElement("input");
+		input.type = "file";
+		input.accept = "application/json";
+
+		input.addEventListener("change", (event: Event) => {
+			const target = event.target as HTMLInputElement;
+			if (target.files?.length) {
+				const file = target.files[0];
+				const reader = new FileReader();
+
+				reader.onload = async (e: ProgressEvent<FileReader>) => {
+					const result = e.target?.result as string;
+					let playlog: unknown;
+					try {
+						playlog = JSON.parse(result);
+					} catch (error) {
+						console.error(`could not load the file: ${file.name}`, error);
+						return;
+					}
+
+					await this.startContent({
+						playlog,
+					});
+				};
+
+				reader.readAsText(file);
+			}
+		});
+
+		input.click();
 	};
 
 	private _createInstanceArgumentForNicolive(isBroadcaster: boolean): any {

--- a/packages/akashic-cli-serve/src/client/sandbox/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/sandbox/view/container/DevtoolContainer.tsx
@@ -54,7 +54,7 @@ export const DevtoolContainer = observer(class DevtoolContainer extends React.Co
 				isActiveExists: play.status === "running", // NOTE: 現実装に依存した実装。概念的には play.status とは独立な判定が必要
 				isActivePaused: play.isActivePausing,
 				isForceResetOnSeek: devtoolUiStore.isForceResetOnSeek,
-				disableFastForward: !!play.initialPlaylog, // FIXME: 将来的には続きからプレイに対応
+				disableFastForward: !!play.disableFastForward, // FIXME: 将来的には続きからプレイに対応
 				onClickPauseActive: operator.localInstance.togglePause,
 				onClickSavePlaylog: operator.play.downloadPlaylog,
 				onClickUploadPlaylog: operator.uploadPlaylog,

--- a/packages/akashic-cli-serve/src/client/sandbox/view/container/DevtoolContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/sandbox/view/container/DevtoolContainer.tsx
@@ -54,8 +54,10 @@ export const DevtoolContainer = observer(class DevtoolContainer extends React.Co
 				isActiveExists: play.status === "running", // NOTE: 現実装に依存した実装。概念的には play.status とは独立な判定が必要
 				isActivePaused: play.isActivePausing,
 				isForceResetOnSeek: devtoolUiStore.isForceResetOnSeek,
+				disableFastForward: !!play.initialPlaylog, // FIXME: 将来的には続きからプレイに対応
 				onClickPauseActive: operator.localInstance.togglePause,
 				onClickSavePlaylog: operator.play.downloadPlaylog,
+				onClickUploadPlaylog: operator.uploadPlaylog,
 				onClickForceResetOnSeek: operator.devtool.toggleForceResetOnSeek,
 				onProgressChange: operator.localInstance.previewSeekTo,
 				onProgressCommit: operator.localInstance.seekTo,

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -52,6 +52,7 @@ export interface PlayEntityParameterObject {
 	audioState?: PlayAudioState;
 	parent?: PlayEntity;
 	startPointHeaders?: StartPointHeader[];
+	initialPlaylog?: unknown;
 }
 
 export class PlayEntity {
@@ -60,6 +61,7 @@ export class PlayEntity {
 	readonly playId: string;
 	readonly amflow: SocketIOAMFlowClient | ServeMemoryAmflowClient;
 	readonly content: ContentEntity;
+	readonly initialPlaylog?: unknown;
 
 	@observable activePlaybackRate: number;
 	@observable isActivePausing: boolean;
@@ -83,6 +85,7 @@ export class PlayEntity {
 	constructor(param: PlayEntityParameterObject) {
 		this.playId = param.playId;
 		this.amflow = param.amflow;
+		this.initialPlaylog = param.initialPlaylog;
 		this.activePlaybackRate = 1;
 		this.isActivePausing = !!param.durationState && param.durationState.isPaused;
 		this.duration = param.durationState ? param.durationState.duration : 0;

--- a/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
+++ b/packages/akashic-cli-serve/src/client/store/PlayEntity.ts
@@ -52,7 +52,7 @@ export interface PlayEntityParameterObject {
 	audioState?: PlayAudioState;
 	parent?: PlayEntity;
 	startPointHeaders?: StartPointHeader[];
-	initialPlaylog?: unknown;
+	disableFastForward?: boolean; // View レイヤーからの参照のために定義。将来的には名前や役割を修正すべきかもしれない。
 }
 
 export class PlayEntity {
@@ -61,7 +61,7 @@ export class PlayEntity {
 	readonly playId: string;
 	readonly amflow: SocketIOAMFlowClient | ServeMemoryAmflowClient;
 	readonly content: ContentEntity;
-	readonly initialPlaylog?: unknown;
+	readonly disableFastForward?: boolean;
 
 	@observable activePlaybackRate: number;
 	@observable isActivePausing: boolean;
@@ -85,7 +85,7 @@ export class PlayEntity {
 	constructor(param: PlayEntityParameterObject) {
 		this.playId = param.playId;
 		this.amflow = param.amflow;
-		this.initialPlaylog = param.initialPlaylog;
+		this.disableFastForward = param.disableFastForward;
 		this.activePlaybackRate = 1;
 		this.isActivePausing = !!param.durationState && param.durationState.isPaused;
 		this.duration = param.durationState ? param.durationState.duration : 0;

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
@@ -17,6 +17,7 @@ export interface PlaybackOptionBarProps {
 	isActiveExists: boolean;
 	isActivePaused: boolean;
 	isForceResetOnSeek: boolean;
+	disableFastForward?: boolean;
 	startPointHeaders: StartPointHeader[];
 	focusedStartPointHeaderIndex: number;
 	onClickPauseActive: (pause: boolean) => void;
@@ -26,6 +27,7 @@ export interface PlaybackOptionBarProps {
 	onProgressCommit: (val: number) => void;
 	onClickPause: (pause: boolean) => void;
 	onClickFastForward: () => void;
+	onClickUploadPlaylog?: () => void;
 }
 
 export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProps) {
@@ -39,6 +41,7 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 		isActiveExists,
 		isActivePaused,
 		isForceResetOnSeek,
+		disableFastForward,
 		startPointHeaders,
 		focusedStartPointHeaderIndex,
 		onClickPauseActive,
@@ -48,10 +51,11 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 		onProgressCommit,
 		onClickPause,
 		onClickFastForward,
+		onClickUploadPlaylog: onClickUploadPlaylog,
 	} = props;
 
-	const startedAt = startPointHeaders[0]?.timestamp;
-	const startPoint = startPointHeaders[focusedStartPointHeaderIndex];
+	const startedAt = startPointHeaders.length ? startPointHeaders[0].timestamp : null;
+	const startPoint = startPointHeaders.length ? startPointHeaders[focusedStartPointHeaderIndex] : null;
 	const startPointTime = (startedAt != null && startPoint != null) ? startPoint.timestamp - startedAt : undefined;
 
 	return <div className={styles["replay-option-bar"]}>
@@ -78,6 +82,19 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 			>
 				Save playlog
 			</ToolIconButton>
+			{
+				onClickUploadPlaylog ? (
+					<ToolIconButton
+						className="external-ref_button_load-playlog_devtool"
+						icon="file_upload"
+						size={18}
+						title={".json ファイルからリプレイ情報(playlog)をロードします。"}
+						onClick={onClickUploadPlaylog}
+					>
+						Upload playlog
+					</ToolIconButton>
+				) : null
+			}
 			<div className={styles.sep} />
 			<ToolCheckbox
 				checked={isForceResetOnSeek}
@@ -97,7 +114,7 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 				icon="skip_next" onClick={onClickFastForward}
 				size={20}
 				title={"リアルタイム実行に戻る\r\rリプレイ再生をやめ、リアルタイム実行(他インスタンスと同期)します。"}
-				disabled={!isReplay} />
+				disabled={!!disableFastForward || !isReplay} />
 			<div className={styles.progress}>
 				<ToolProgressBar
 					max={duration}

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
@@ -55,7 +55,7 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 	} = props;
 
 	const startedAt = startPointHeaders.length ? startPointHeaders[0].timestamp : null;
-	const startPoint = startPointHeaders.length ? startPointHeaders[focusedStartPointHeaderIndex] : null;
+	const startPoint = focusedStartPointHeaderIndex < startPointHeaders.length ? startPointHeaders[focusedStartPointHeaderIndex] : null;
 	const startPointTime = (startedAt != null && startPoint != null) ? startPoint.timestamp - startedAt : undefined;
 
 	return <div className={styles["replay-option-bar"]}>

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlaybackOptionBar.tsx
@@ -51,7 +51,7 @@ export const PlaybackOptionBar = observer(function (props: PlaybackOptionBarProp
 		onProgressCommit,
 		onClickPause,
 		onClickFastForward,
-		onClickUploadPlaylog: onClickUploadPlaylog,
+		onClickUploadPlaylog,
 	} = props;
 
 	const startedAt = startPointHeaders.length ? startPointHeaders[0].timestamp : null;


### PR DESCRIPTION
# このPullRequestが解決する内容
スタンドアロンモードにおいて playlog ファイルの再生に対応します。

https://github.com/user-attachments/assets/a96c4abc-ef66-4e62-b72c-007495c4c395
