### PR TITLE
feat(sandbox): support --legacy option

### DIFF
--- a/.changeset/dry-shoes-vanish.md
+++ b/.changeset/dry-shoes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli": patch
+---
+
+support `--legacy` option in akashic-cli-sandbox

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -568,7 +568,7 @@ describe("convert", () => {
 					expect(gameJson.assets.aez_asset_bundle.global).toBe(true);
 					expect(gameJson.environment["sandbox-runtime"]).toBe("3");
 					expect(gameJson.environment.external).toEqual({ send: "0" });
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d\.\d+(-.*)?$/);
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+(-.*)?$/);
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
 				});
 		});
@@ -604,7 +604,7 @@ describe("convert", () => {
 				.then(() => {
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.environment["sandbox-runtime"]).toBe("3");
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d\.\d+(-.*)?$/);
+					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+(-.*)?$/);
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
 					expect(gameJson.environment.external).toEqual({ send: "0" });
 				});

--- a/packages/akashic-cli/bin/akashic-sandbox.js
+++ b/packages/akashic-cli/bin/akashic-sandbox.js
@@ -1,6 +1,37 @@
 #!/usr/bin/env node
 
+import { Command } from "commander";
+
+const program = new Command();
+
+program
+	.allowUnknownOption(true)
+	.option("-p, --port <port>", parseInt)
+	.option("--legacy")
+	.option("--standalone")
+	.parse(process.argv);
+
+const options = program.opts();
+
 (async () => {
-	const { run } = await import("@akashic/akashic-cli-sandbox");
-	run(process.argv);
+	const args = process.argv.filter(arg => arg !== "--legacy" );
+
+	// --legacy オプションが指定された場合は akashic-cli-sandbox (旧バージョン) を使用
+	if (options.legacy) {
+		const { run } = await import("@akashic/akashic-cli-sandbox");
+		run(args);
+		return;
+	}
+
+	if (options.standalone == null) {
+		args.push("--standalone");
+	}
+
+	// port が未指定なら後方互換としてデフォルト値 3000 を設定
+	if (options.port == null) {
+		args.push("--port", "3000");
+	}
+
+	const { run } = await import("@akashic/akashic-cli-serve/lib/server/index.js");
+	run(args);
 })();

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -194,7 +194,7 @@ try {
 		// 通常の動作テスト
 		{
 			const port = await getPort();
-			const finalize = spawn(`${akashicCliPath} sandbox`, ["-p", port]);
+			const finalize = spawn(`${akashicCliPath} sandbox`, ["-p", port, "--legacy"]);
 			try {
 				const baseUrl = `http://localhost:${port}`;
 				await setTimeout(1000); // 起動するまで待機
@@ -230,7 +230,7 @@ try {
 			await writeFile(join(cascadeGameJsonDir, "game.json"), JSON.stringify(cascadeGameJson));
 
 			const port = await getPort();
-			const finalize = spawn(`${akashicCliPath} sandbox`, ["-p", port, "--cascade", cascadeGameJsonDir]);
+			const finalize = spawn(`${akashicCliPath} sandbox`, ["-p", port, "--cascade", cascadeGameJsonDir, "--legacy"]);
 			try {
 				const baseUrl = `http://localhost:${port}`;
 				await setTimeout(1000); // 起動するまで待機


### PR DESCRIPTION
# このPullRequestが解決する内容

- `akashic sandbox` コマンドを `akashic serve --standalone` へとリダイレクトします。
  - `akashic sandbox --legacy` コマンドを既存の `akashic sandbox` へとリダイレクトします。

## コマンドマッピング

| command | alias |
|---|---|
| `akashic sandbox`                       | `akashic serve --standalone --port 3000` |
| `akashic sandbox --port 3001`           | `akashic serve --standalone --port 3001` |
| `akashic sandbox -p 3001`               | `akashic serve --standalone -p 3001` |
| `akashic sandbox --legacy`              | `akashic sandbox` |
| `akashic sandbox --legacy --port 3001`  | `akashic sandbox --port 3001` |
| `akashic sandbox --legacy -p 3001`      | `akashic sandbox -p 3001` |