### PR TITLE
Fix bug export zip

### DIFF
--- a/.changeset/hip-steaks-stare.md
+++ b/.changeset/hip-steaks-stare.md
@@ -2,4 +2,4 @@
 "@akashic/akashic-cli-export": patch
 ---
 
-Fix bug in export-zip
+Fix crash on v1 games and crash for directory output

--- a/.changeset/hip-steaks-stare.md
+++ b/.changeset/hip-steaks-stare.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-export": patch
+---
+
+Fix bug in export-zip

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -330,7 +330,8 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 					(param.minifyJson && gcu.isTextJsonFile(p)) ? JSON.stringify(JSON.parse(encodeToString(buff))) :
 					gcu.isMaybeTextFile(p) ? encodeToString(buff) : buff;
 
-				if (bundleResult === null && gamejson.main.includes(p)) {
+				const entryPoint = gamejson.main || gamejson.assets.mainScene.path;
+				if (bundleResult === null && entryPoint.includes(p)) {
 					value = prefixCode + value;
 				}
 				fs.writeFileSync(path.resolve(param.dest, p), value);

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -127,12 +127,7 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 		})
 		.then(() => {
 			if (!outZip) {
-				try {
-					fs.rmSync(destDir, { recursive: true });
-				} catch (e) {
-					if (e.code !== "ENOENT")
-						throw new Error(e);
-				}
+				fs.rmSync(destDir, { recursive: true, force: true });
 				fs.cpSync(tmpDir, destDir, { recursive: true });
 				return;
 			}

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -127,7 +127,12 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 		})
 		.then(() => {
 			if (!outZip) {
-				fs.rmSync(destDir, { recursive: true });
+				try {
+					fs.rmSync(destDir, { recursive: true });
+				} catch (e) {
+					if (e.code !== "ENOENT")
+						throw new Error(e);
+				}
 				fs.cpSync(tmpDir, destDir, { recursive: true });
 				return;
 			}


### PR DESCRIPTION
## 概要

export zip のバグを修正。
- v1 コンテンツの game.json のエントリーポイントが mainScene のため落ちていた問題
- 出力対象がディレクトリ(-o xxx)で存在しない場合に落ちていた問題

**動作確認**
- v1 コンテンツ(thierfBuster)で export zip で正常に出力されることを確認。
- `-o xxx` でディレクトリを出力対象にして、正常に出力されることを確認。