### PR TITLE
Remove untainted in export html

### DIFF
--- a/.changeset/thirty-cobras-confess.md
+++ b/.changeset/thirty-cobras-confess.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-export": patch
+---
+
+Remove imageAsset hint.untainted in export-html

--- a/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
@@ -111,9 +111,10 @@ describe("convertUtil", function () {
 					}
 				}
 			};
-			convert.removeUntaintedToImageAssets(gamejson);
+			convert.removeUntaintedHints(gamejson);
 			const sampleImage1 = gamejson.assets.sample_image1 as ImageAssetConfigurationBase;
-			expect(sampleImage1.hint).toBeUndefined();
+			expect(sampleImage1.hint).toEqual({});
+			expect(sampleImage1.hint.untainted).toBeUndefined();
 		});
 	});
 	describe("validateGameJson", function () {

--- a/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/convertUtilSpec.ts
@@ -92,6 +92,30 @@ describe("convertUtil", function () {
 			expect(gamejson.assets.sample_text1.hasOwnProperty("hint")).toBeFalsy();
 		});
 	});
+	describe("removeUntaintedToImageAssets", function () {
+		it("remove 'hint.untainted' to image asset on specified gamejson", function () {
+			const gamejson: GameConfiguration = {
+				"width": 320,
+				"height": 320,
+				"fps": 30,
+				"main": "./script/main.js",
+				"assets": {
+					"sample_image1": {
+						"type": "image",
+						"width": 150,
+						"height": 149,
+						"path": "image/sample_image1.png",
+						"hint": {
+							"untainted": true
+						}
+					}
+				}
+			};
+			convert.removeUntaintedToImageAssets(gamejson);
+			const sampleImage1 = gamejson.assets.sample_image1 as ImageAssetConfigurationBase;
+			expect(sampleImage1.hint).toBeUndefined();
+		});
+	});
 	describe("validateGameJson", function () {
 		it("throw Error when specified gamejson include @akashic/akashic-engine", function () {
 			const gamejson: any = {

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -20,7 +20,7 @@ import {
 	getInjectedContents,
 	validateSandboxConfigJs,
 	readSandboxConfigJs,
-	removeUntaintedToImageAssets
+	removeUntaintedHints
 } from "./convertUtil.js";
 
 interface InnerHTMLAssetData {
@@ -39,7 +39,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
-	removeUntaintedToImageAssets(content);
+	removeUntaintedHints(content);
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -19,7 +19,8 @@ import {
 	extractAssetDefinitions,
 	getInjectedContents,
 	validateSandboxConfigJs,
-	readSandboxConfigJs
+	readSandboxConfigJs,
+	removeUntaintedToImageAssets
 } from "./convertUtil.js";
 
 interface InnerHTMLAssetData {
@@ -38,6 +39,7 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
+	removeUntaintedToImageAssets(content);
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -19,7 +19,7 @@ import {
 	readSandboxConfigJs,
 	validateEngineFilesName,
 	resolveEngineFilesPath,
-	removeUntaintedToImageAssets,
+	removeUntaintedHints,
 	validateSandboxConfigJs
 } from "./convertUtil.js";
 
@@ -33,7 +33,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
-	removeUntaintedToImageAssets(content);
+	removeUntaintedHints(content);
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -19,6 +19,7 @@ import {
 	readSandboxConfigJs,
 	validateEngineFilesName,
 	resolveEngineFilesPath,
+	removeUntaintedToImageAssets,
 	validateSandboxConfigJs
 } from "./convertUtil.js";
 
@@ -32,6 +33,7 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
+	removeUntaintedToImageAssets(content);
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -235,6 +235,14 @@ export function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void
 	});
 }
 
+export function removeUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void {
+	for (const asset of Object.values(gameJson.assets)) {
+		if (asset.type === "image" && asset.hint) {
+			delete asset.hint;
+		}
+	}
+}
+
 export function validateEngineFilesName(filename: string, expectedMajorVersion: string): void {
 	const matches = filename.match(/(\d+)_\d+_\d+/);
 	const engineFilesVersion = matches ? matches[1] : null;

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -235,10 +235,10 @@ export function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void
 	});
 }
 
-export function removeUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void {
+export function removeUntaintedHints(gameJson: cmn.GameConfiguration): void {
 	for (const asset of Object.values(gameJson.assets)) {
-		if (asset.type === "image" && asset.hint) {
-			delete asset.hint;
+		if (asset.type === "image" && asset.hint?.untainted ) {
+			delete asset.hint.untainted;
 		}
 	}
 }

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -237,7 +237,7 @@ export function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void
 
 export function removeUntaintedHints(gameJson: cmn.GameConfiguration): void {
 	for (const asset of Object.values(gameJson.assets)) {
-		if (asset.type === "image" && asset.hint?.untainted ) {
+		if (asset.type === "image" && asset.hint?.untainted) {
 			delete asset.hint.untainted;
 		}
 	}


### PR DESCRIPTION
## 概要

export-html 実行時に ImageAsset の `hint.untainted` を削除するよう修正。

**動作確認**

game.json の imageAsset に `hint.untainted` があるコンテンツを export-html (bundle/nobundle) で出力し、html ファイルが動作する事を確認。httpサーバに置いての動作も確認。

