### PR TITLE
feat(serve): mark experimental devtool

### DIFF
--- a/packages/akashic-cli-serve/src/client/view/atom/DevtoolPageSelector.tsx
+++ b/packages/akashic-cli-serve/src/client/view/atom/DevtoolPageSelector.tsx
@@ -3,7 +3,9 @@ import * as React from "react";
 import styles from "./DevtoolPageSelector.module.css";
 
 export interface DevtoolPageSelectorItem {
-	label: string;
+	label: React.ReactElement | string;
+	key: string;
+	title: string;
 	disabled?: boolean;
 }
 
@@ -19,11 +21,11 @@ export const DevtoolPageSelector = observer(function DevtoolPageSelector(props: 
 			{
 				props.items.map((item, i) => (
 					<li
-						key={item.label}
+						key={item.key}
 						className={
 							item.disabled ? styles.disabled : (i === props.activeIndex ? styles.active : "")
 						}
-						title={item.label}
+						title={item.title}
 						onClick={() => {
 							if (item.disabled) return;
 							props.onChangeActive(i);

--- a/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtool.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtool.tsx
@@ -9,14 +9,26 @@ import { NiconicoDevtoolRankingPage, type NiconicoDevtoolRankingPageProps } from
 
 export type NiconicoDevtoolPageType = "ranking" | "comment";
 
+const rankingPageSelectorItem: DevtoolPageSelectorItem = {
+	label: "Ranking",
+	key: "ranking",
+	title: "Ranking",
+};
+
+const commentPageSelectorItem: DevtoolPageSelectorItem = {
+	label: <><small>&#x1f6a7;</small> Comment</>,
+	key: "comment",
+	title: "Comment (Experimental)",
+};
+
 const pageItems: { key: NiconicoDevtoolPageType; selector: DevtoolPageSelectorItem }[] = [
-	{ key: "ranking", selector: { label: "Ranking" } },
-	{ key: "comment", selector: { label: "Comment" } },
+	{ key: "ranking", selector: rankingPageSelectorItem },
+	{ key: "comment", selector: commentPageSelectorItem },
 ];
 
 const pageItemsNoComment: { key: NiconicoDevtoolPageType; selector: DevtoolPageSelectorItem }[] = [
-	{ key: "ranking", selector: { label: "Ranking" } },
-	{ key: "comment", selector: { label: "Comment", disabled: true } },
+	{ key: "ranking", selector: rankingPageSelectorItem },
+	{ key: "comment", selector: { ...commentPageSelectorItem, disabled: true } },
 ];
 
 export interface NiconicoDevtoolProps {

--- a/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtoolCommentPage.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/NiconicoDevtoolCommentPage.tsx
@@ -168,6 +168,6 @@ function formatCentiseconds(centiseconds: number): string {
 	const hs = hours > 0 ? ("" + hours).padStart(2, "0") + ":" : "";
 	const ms = ("" + mins).padStart(2, "0");
 	const ss = ("" + secs).padStart(2, "0");
-	const cs = csecs.toString().padStart(3, "0");
+	const cs = csecs.toString().padStart(2, "0");
 	return `${hs}${ms}:${ss}.${cs}`;
 }

--- a/packages/akashic-cli-serve/src/client/view/stories/DevtoolPageSelector.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/DevtoolPageSelector.stories.tsx
@@ -17,8 +17,8 @@ export const Basic = {
 		}}>
 			<DevtoolPageSelector
 				items={[
-					{ label: "foo", disabled: true },
-					{ label: "bar" },
+					{ label: "foo", key: "foo", title: "foo", disabled: true },
+					{ label: "bar", key: "bar", title: "bar" },
 				]}
 				activeIndex={1}
 				onChangeActive={action("event:change-active")}
@@ -36,9 +36,9 @@ export const Bleedout = {
 		}}>
 			<DevtoolPageSelector
 				items={[
-					{ label: "an opiton" },
-					{ label: "another option" },
-					{ label: "a ridculously long option that bleeds out the containing box" },
+					{ label: "an opiton", key: "a", title: "an option" },
+					{ label: "another option", key: "b", title: "another option" },
+					{ label: "a ridculously long option that bleeds out the containing box", key: "c", title: "yet another option" },
 				]}
 				activeIndex={1}
 				onChangeActive={action("event:change-active")}
@@ -58,9 +58,9 @@ const TestWithBehavior = observer(() => (
 	}}>
 		<DevtoolPageSelector
 			items={[
-				{ label: "Ranking" },
-				{ label: "Comment" },
-				{ label: "Another Option" },
+				{ label: "Ranking", key: "ranking", title: "Ranking" },
+				{ label: "Comment", key: "comment", title: "Comment (Experimental)" },
+				{ label: "Another Option", key: "another", title: "An option implemented in future" },
 			]}
 			activeIndex={store.activeIndex}
 			onChangeActive={idx => {

--- a/packages/akashic-cli-serve/src/server/domain/nicoliveComment/NamagameCommentPluginHost.ts
+++ b/packages/akashic-cli-serve/src/server/domain/nicoliveComment/NamagameCommentPluginHost.ts
@@ -126,7 +126,7 @@ export class NamagameCommentPluginHost {
 }
 
 function frameToVpos(frame: number, fps: number): number {
-	return (frame * (1000 / fps) * 10); // 10 倍してミリ秒をセンチ秒に
+	return Math.floor(frame * (1000 / fps) * 0.1); // 0.1 倍してミリ秒をセンチ秒に
 }
 
 function objectForEach<T extends object>(obj: T, fun: (val: T[keyof T], key: keyof T) => void): void {


### PR DESCRIPTION
- Devtool の PageSelector にテキスト以外を指定できるようにして、 experimental なツールに 🚧 (`&#x1f6a7;`) を表示するようにします。
- 別件で、単純に誤っていた vpos の計算を修正します。

