### PR TITLE
Fix replay in serve

### DIFF
--- a/.changeset/sharp-experts-shake.md
+++ b/.changeset/sharp-experts-shake.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-serve": patch
+---
+
+Fix bug in replay mode with -A option in serve

--- a/packages/akashic-cli-serve/src/client/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/Operator.ts
@@ -31,7 +31,6 @@ export interface OperatorParameterObject {
 export interface StartContentParameterObject {
 	joinsSelf: boolean;
 	instanceArgument: any;
-	isReplay?: boolean;
 }
 
 export class Operator {
@@ -77,7 +76,7 @@ export class Operator {
 				play = await this._createServerLoop(loc, initialJoinPlayer, false, false); // TODO: (起動時の最初のプレイで) audioState を指定する方法
 			}
 		}
-		await this.setCurrentPlay(play, query.mode === "replay");
+		await this.setCurrentPlay(play);
 
 		if (query.mode === "replay") {
 			if (query.replayResetAge != null) {
@@ -104,7 +103,7 @@ export class Operator {
 		}
 	}
 
-	setCurrentPlay = async (play: PlayEntity, isReplay: boolean = false): Promise<void> => {
+	setCurrentPlay = async (play: PlayEntity): Promise<void> => {
 		const store = this.store;
 		if (store.currentPlay === play)
 			return;
@@ -142,8 +141,7 @@ export class Operator {
 		if (store.appOptions.autoStart) {
 			await this.startContent({
 				joinsSelf: false,
-				instanceArgument: argument,
-				isReplay
+				instanceArgument: argument
 			});
 		}
 	};
@@ -156,7 +154,7 @@ export class Operator {
 			playId: play!.playId,
 			playToken: tokenResult.data.playToken,
 			playlogServerUrl: "dummy-playlog-server-url",
-			executionMode: params != null && params.isReplay ? "replay" : "passive",
+			executionMode: query.mode === "replay" ? "replay" : "passive",
 			player: store.player!,
 			argument: params != null ? params.instanceArgument : undefined,
 			proxyAudio: store.appOptions.proxyAudio,


### PR DESCRIPTION
## 概要

serve で -A オプション利用時にリプレイモード(?mode=replay)で正常にリプレイが動作しない問題を修正。
(`akashic serve . --debug-playlog ./playlog.json -A` で引数ウィンドウの Start ボタンを押下した時の動作。)

