### PR TITLE
feat(serve): add new window button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20770,7 +20770,7 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.8",
+      "version": "3.0.10",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
@@ -20779,8 +20779,8 @@
         "@akashic/akashic-cli-init": "2.0.0",
         "@akashic/akashic-cli-lib-manage": "2.0.0",
         "@akashic/akashic-cli-sandbox": "2.0.3",
-        "@akashic/akashic-cli-scan": "1.0.1",
-        "@akashic/akashic-cli-serve": "2.0.5",
+        "@akashic/akashic-cli-scan": "1.0.2",
+        "@akashic/akashic-cli-serve": "2.0.7",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -25445,7 +25445,7 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
@@ -26296,11 +26296,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "2.0.5",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-scan": "1.0.1",
+        "@akashic/akashic-cli-scan": "1.0.2",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.17.5",

--- a/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
@@ -209,9 +209,9 @@ function createPlatformCustomizer(content: ServeGameContent): (platform: Platfor
 						const message = `Surface(): width and height should be integer. (specified ${arguments[0]}x${arguments[1]}) `
 							+ "This is not a bug but warned by akashic serve "
 							+ "to prevent platform-specific rendering trouble.";
-							content.onWarn.fire({ type, message });
+						content.onWarn.fire({ type, message });
 					}
-				} 
+				}
 				const surface: Surface = func.apply(this, [...arguments]);
 				// Safariで範囲外描画時に問題が発生するのはCanvas要素なので、surfaceがCanvasでなければ範囲外描画の警告は行わない
 				if (!(surface._drawable instanceof HTMLCanvasElement)) {

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -65,14 +65,11 @@ export class PlayOperator {
 	};
 
 	openNewClientInstance = (): void => {
-		const { top, left, width, height } = this.calcWindowLayout();
-		// Mac Chrome で正しく動作しないのと、親ウィンドウかどうかの判別をしたいことがあるので noopener は付けない。
-		// 代わりに ignoreSession を指定して自前でセッションストレージをウィンドウごとに使い分ける (ref. ../store/storage.ts)
-		window.open(
-			`${window.location.pathname}?ignoreSession=1&experimentalIsChildWindow=1`,
-			"_blank",
-			`width=${width},height=${height},top=${top},left=${left}`
-		);
+		this.openClientInstance();
+	};
+
+	openSameClientInstance = (): void => {
+		this.openClientInstance(this.store.player!.id);
 	};
 
 	closeThisWindowIfNeeded = (): void => {
@@ -147,6 +144,17 @@ export class PlayOperator {
 		a.download = fileName;
 		a.click();
 		document.body.removeChild(a);
+	};
+
+	private openClientInstance = (playerId?: string): void => {
+		const { top, left, width, height } = this.calcWindowLayout();
+		// Mac Chrome で正しく動作しないのと、親ウィンドウかどうかの判別をしたいことがあるので noopener は付けない。
+		// 代わりに ignoreSession を指定して自前でセッションストレージをウィンドウごとに使い分ける (ref. ../store/storage.ts)
+		let url = `${window.location.pathname}?ignoreSession=1&experimentalIsChildWindow=1`;
+		if (playerId) {
+			url += `&playerId=${playerId}`;
+		}
+		window.open(url, "_blank", `width=${width},height=${height},top=${top},left=${left}`);
 	};
 
 	private calcWindowLayout(): { top: number; left: number; width: number; height: number } {

--- a/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
+++ b/packages/akashic-cli-serve/src/client/view/container/ToolbarContainer.tsx
@@ -47,6 +47,7 @@ export const ToolBarContainer = observer(class ToolBarContainer extends React.Co
 			onClickReset: operator.restartWithNewPlay,
 			onClickActivePause: operator.play.togglePauseActive,
 			onClickAddInstance: operator.play.openNewClientInstance,
+			onClickAddWindow: operator.play.openSameClientInstance,
 			onClickStep: operator.play.step
 		};
 	};

--- a/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
+++ b/packages/akashic-cli-serve/src/client/view/molecule/PlayControl.tsx
@@ -10,6 +10,7 @@ export interface PlayControlPropsData {
 	onClickReset?: () => void;
 	onClickActivePause?: (toPause: boolean) => void;
 	onClickAddInstance?: () => void;
+	onClickAddWindow?: () => void;
 	onClickStep?: () => void;
 }
 
@@ -46,6 +47,11 @@ export const PlayControl = observer(class PlayControl extends React.Component<Pl
 				icon="group_add"
 				title={"インスタンスを追加\r\r新しいタブ・ウィンドウでこのプレイに接続するインスタンスを追加します。"}
 				onClick={props.onClickAddInstance} />
+			<ToolIconButton
+				className="external-ref_button_add-window"
+				icon="open_in_new"
+				title={"ウィンドウの追加\r\r現在のプレイヤーIDを使用して別ウィンドウを開きます。"}
+				onClick={props.onClickAddWindow} />
 			{/* // 未実装
 			<ToolLabelButton title="Playback Rate (Active)" onClick={props.onClickActivePlaybackRate}>
 				x{"" + props.playbackRate}

--- a/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/PlayControl.stories.tsx
@@ -16,6 +16,7 @@ export const Basic = {
 				onClickReset: action("reset"),
 				onClickActivePause: action("active-pause"),
 				onClickAddInstance: action("add-instance"),
+				onClickAddWindow: action("add-window"),
 				onClickStep: action("step")
 			})}
 		/>
@@ -33,6 +34,7 @@ export const Pausing = {
 				onClickReset: action("reset"),
 				onClickActivePause: action("active-pause"),
 				onClickAddInstance: action("add-instance"),
+				onClickAddWindow: action("add-window"),
 				onClickStep: action("step")
 			})}
 		/>

--- a/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
+++ b/packages/akashic-cli-serve/src/client/view/stories/ToolBar.stories.tsx
@@ -40,6 +40,7 @@ const TestWithBehaviour = observer(() => (
 			onClickReset: action("reset"),
 			onClickActivePause: (v) => (store.isActivePausing = v),
 			onClickAddInstance: action("add-instance"),
+			onClickAddWindow: action("add-window"),
 			onClickStep: action("step")
 		})}
 		makeInstanceControlProps={() => ({
@@ -123,6 +124,7 @@ export const Basic = {
 				onClickReset: action("reset"),
 				onClickActivePause: action("active-pause"),
 				onClickAddInstance: action("add-instance"),
+				onClickAddWindow: action("add-window"),
 				onClickStep: action("step")
 			})}
 			makeInstanceControlProps={() => ({


### PR DESCRIPTION
### やったこと
- プレイヤーID同一の新しいウィンドウを生成するボタンをakashic serveに追加
- UI的には以下のように画面上部のツールバーのインスタンス追加ボタンの右隣に置いた
<img width="1470" height="33" alt="Screenshot 2025-07-30 at 20-25-58 Akashic Serve" src="https://github.com/user-attachments/assets/2966b009-5c9c-41e4-843c-8ec903869173" />
