### PR TITLE
feat(serve): support 'nicolive:multi' in standalone mode

### DIFF
--- a/.changeset/eleven-owls-roll.md
+++ b/.changeset/eleven-owls-roll.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-serve": patch
+---
+
+support 'nicolive:multi' in standalone mode

--- a/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
+++ b/packages/akashic-cli-serve/src/client/akashic/GameViewManager.ts
@@ -209,9 +209,9 @@ function createPlatformCustomizer(content: ServeGameContent): (platform: Platfor
 						const message = `Surface(): width and height should be integer. (specified ${arguments[0]}x${arguments[1]}) `
 							+ "This is not a bug but warned by akashic serve "
 							+ "to prevent platform-specific rendering trouble.";
-							content.onWarn.fire({ type, message });
+						content.onWarn.fire({ type, message });
 					}
-				} 
+				}
 				const surface: Surface = func.apply(this, [...arguments]);
 				// Safariで範囲外描画時に問題が発生するのはCanvas要素なので、surfaceがCanvasでなければ範囲外描画の警告は行わない
 				if (!(surface._drawable instanceof HTMLCanvasElement)) {

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -132,7 +132,7 @@ export class Operator {
 				playEntity.join(store.player.id, store.player.name);
 			}
 			const { events, autoSendEventName } = playEntity.content.sandboxConfig;
-			if (!events || (autoSendEventName && Array.isArray(events[autoSendEventName]))) {
+			if (!events || (autoSendEventName && !Array.isArray(events[autoSendEventName]))) {
 				// autoSendEvent が存在しない場合のみデフォルトのセッションパラメータを送る
 				playEntity.amflow.enqueueEvent(createSessionParameter(this.store.targetService));
 			}

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -4,6 +4,7 @@ import type { DumpedPlaylog } from "../../../common/types/DumpedPlaylog";
 import type { GameViewManager } from "../../akashic/GameViewManager";
 import { ServeMemoryAmflowClient } from "../../akashic/ServeMemoryAMFlowClient";
 import type { ClientContentLocator } from "../../common/ClientContentLocator";
+import { createSessionParameter } from "../../common/createSessionParameter";
 import type { ScreenSize } from "../../common/types/ScreenSize";
 import type { ExecutionMode } from "../../store/ExecutionMode";
 import { PlayEntity } from "../../store/PlayEntity";
@@ -126,8 +127,15 @@ export class Operator {
 			this.store.profilerStore.pushProfilerValueResult("rendering", value.renderingTime);
 		});
 
-		if (params?.joinsSelf) {
-			playEntity.join(player.id, player.name);
+		if (params?.joinsSelf || this.store.targetService === "nicolive:multi") {
+			if (store.player) {
+				playEntity.join(store.player.id, store.player.name);
+			}
+			const { events, autoSendEventName } = playEntity.content.sandboxConfig;
+			if (!events || (autoSendEventName && Array.isArray(events[autoSendEventName]))) {
+				// autoSendEvent が存在しない場合のみデフォルトのセッションパラメータを送る
+				playEntity.amflow.enqueueEvent(createSessionParameter(this.store.targetService));
+			}
 		}
 
 		this.play.sendAutoStartEvent();

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -127,7 +127,7 @@ export class Operator {
 		});
 
 		if (params?.joinsSelf || this.store.targetService === "nicolive:multi") {
-			playEntity.join(store.player!.id, store.player!.name);
+			playEntity.join(player.id, player.name);
 		}
 
 		this.play.sendAutoStartEvent();

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -126,8 +126,8 @@ export class Operator {
 			this.store.profilerStore.pushProfilerValueResult("rendering", value.renderingTime);
 		});
 
-		if (store.player && (params?.joinsSelf || this.store.targetService === "nicolive:multi")) {
-			playEntity.join(store.player.id, store.player.name);
+		if (params?.joinsSelf || this.store.targetService === "nicolive:multi") {
+			playEntity.join(store.player!.id, store.player!.name);
 		}
 
 		this.play.sendAutoStartEvent();

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -4,7 +4,6 @@ import type { DumpedPlaylog } from "../../../common/types/DumpedPlaylog";
 import type { GameViewManager } from "../../akashic/GameViewManager";
 import { ServeMemoryAmflowClient } from "../../akashic/ServeMemoryAMFlowClient";
 import type { ClientContentLocator } from "../../common/ClientContentLocator";
-import { createSessionParameter } from "../../common/createSessionParameter";
 import type { ScreenSize } from "../../common/types/ScreenSize";
 import type { ExecutionMode } from "../../store/ExecutionMode";
 import { PlayEntity } from "../../store/PlayEntity";
@@ -127,15 +126,8 @@ export class Operator {
 			this.store.profilerStore.pushProfilerValueResult("rendering", value.renderingTime);
 		});
 
-		if (params?.joinsSelf || this.store.targetService === "nicolive:multi") {
-			if (store.player) {
-				playEntity.join(store.player.id, store.player.name);
-			}
-			const { events, autoSendEventName } = playEntity.content.sandboxConfig;
-			if (!events || (autoSendEventName && !Array.isArray(events[autoSendEventName]))) {
-				// autoSendEvent が存在しない場合のみデフォルトのセッションパラメータを送る
-				playEntity.amflow.enqueueEvent(createSessionParameter(this.store.targetService));
-			}
+		if (store.player && (params?.joinsSelf || this.store.targetService === "nicolive:multi")) {
+			playEntity.join(store.player.id, store.player.name);
 		}
 
 		this.play.sendAutoStartEvent();

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/PlayOperator.ts
@@ -1,4 +1,5 @@
 import { toJS as mobxToJS } from "mobx";
+import { createSessionParameter } from "../../common/createSessionParameter";
 import type { Store } from "../Store";
 
 export class PlayOperator {
@@ -22,6 +23,9 @@ export class PlayOperator {
 		const { events, autoSendEventName } = sandboxConfig;
 		if (events && autoSendEventName && events[autoSendEventName] != null) {
 			this.sendRegisteredEvent(autoSendEventName);
+		} else if (this.store.targetService === "nicolive:multi") {
+			// autoSendEvent が存在しない場合のみデフォルトのセッションパラメータを送る
+			this.store.currentPlay!.amflow.enqueueEvent(createSessionParameter(this.store.targetService));
 		}
 	}
 

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -125,7 +125,14 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 		}
 
 		if (cliConfigParam.targetService === "nicolive") {
-			cliConfigParam.targetService = "nicolive:multi"; // "nicolive"  は "nicolive:multi" のエイリアスとする
+			if (cliConfigParam.standalone) {
+				getSystemLogger().error(
+					"Invalid --target-service option argument: 'nicolive' service does not currently support standalone mode"
+				);
+				process.exit(1);
+			} else {
+				cliConfigParam.targetService = "nicolive:multi"; // "nicolive" は "nicolive:multi" のエイリアスとする
+			}
 		}
 		serverGlobalConfig.targetService = cliConfigParam.targetService;
 	}


### PR DESCRIPTION
# このPullRequestが解決する内容
`akashic serve --standalone` で `--target-service nicolive:multi` が指定された場合、以下を実行するように修正します。

- 自動Join
- デフォルトのセッションパラメータを送信