### PR TITLE
feat(scan): support --force option

### DIFF
--- a/.changeset/hungry-dingos-accept.md
+++ b/.changeset/hungry-dingos-accept.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-commons": patch
+"@akashic/akashic-cli-scan": patch
+---
+
+support --force option

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigScan.ts
@@ -2,6 +2,7 @@ export interface CliConfigScanAsset {
 	cwd?: string;
 	quiet?: boolean;
 	watch?: boolean;
+	force?: boolean;
 	usePathAssetId?: boolean;
 	updateAssetId?: boolean;
 	includeExtensionToAssetId?: boolean;
@@ -15,6 +16,7 @@ export interface CliConfigScanAsset {
 export interface CliConfigScanGlobalScripts {
 	cwd?: string;
 	quiet?: boolean;
+	force?: boolean;
 	fromEntryPoint?: boolean;
 	omitPackagejson?: boolean;
 	useMmp?: boolean;

--- a/packages/akashic-cli-scan/src/cli.ts
+++ b/packages/akashic-cli-scan/src/cli.ts
@@ -25,6 +25,7 @@ commander
 	.option("-q, --quiet", "Suppress output")
 	.option("-w, --watch", "Watch Directories of asset (deprecated)")
 	.option("--use-path-asset-id", "Resolve Asset IDs from these path instead of name")
+	.option("--force", "Discard all existing asset settings and scan all assets from scratch")
 	.option("--update-asset-id", "Update previously registered Asset IDs")
 	.option(
 		"--include-ext-to-asset-id",
@@ -59,6 +60,7 @@ commander
 			cwd: opts.cwd ?? conf.cwd,
 			logger,
 			resolveAssetIdsFromPath: opts.usePathAssetId ?? conf.usePathAssetId,
+			forceUpdate: !!opts.force,
 			forceUpdateAssetIds: opts.updateAssetId ?? conf.updateAssetId,
 			includeExtensionToAssetId: opts.usePathAssetId ?? (opts.includeExtensionToAssetId ?? conf.includeExtensionToAssetId),
 			assetScanDirectoryTable,
@@ -97,6 +99,7 @@ commander
 	.option("-C, --cwd <dir>", "The directory includes game.json")
 	.option("-e, --from-entry-point", "Scan from the entry point instead of `npm ls`")
 	.option("-q, --quiet", "Suppress output")
+	.option("--force", "Discard module settings and scan all external modules to update game.json")
 	.option("--no-omit-packagejson", "Add package.json of each module to the globalScripts property (to support older Akashic Engine)")
 	.option("--use-mmp", "Use moduleMainPaths in game.json")
 	.option("--use-mms", "Use moduleMainScripts in game.json (to support older Akashic Engine)")
@@ -114,12 +117,13 @@ commander
 		const parameter: ScanNodeModulesParameterObject = {
 			cwd: opts.cwd ?? conf.cwd,
 			logger,
+			forceUpdate: !!opts.force,
 			fromEntryPoint: opts.fromEntryPoint ?? conf.fromEntryPoint,
 			omitPackagejson: opts.omitPackagejson ?? conf.omitPackagejson,
 			useMmp: opts.useMmp ?? conf.useMmp,
 			useMms: opts.useMms ?? conf.useMms,
 		};
-		scanNodeModules(parameter)
+		return scanNodeModules(parameter)
 			.catch((err: Error) => {
 				logger.error(err.message);
 				process.exit(1);

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -202,6 +202,10 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 
 		// globalScripts のファイルパスはすでに解決済みのため、ここでは akashic-lib.json に関する更新のみを扱う。
 		if (param.forceUpdate) {
+			if (param.fromEntryPoint) {
+				throw new Error("The options '--force' and '--from-entry-point' cannot be used together");
+			}
+
 			content.environment ??= {};
 
 			const beforeExternal = content.environment.external;

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -203,7 +203,7 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 		// globalScripts のファイルパスはすでに解決済みのため、ここでは akashic-lib.json に関する更新のみを扱う。
 		if (param.forceUpdate) {
 			if (param.fromEntryPoint) {
-				throw new Error("The options '--force' and '--from-entry-point' cannot be used together");
+				throw new Error("[Not Implemented] The options '--force' and '--from-entry-point' cannot be used together");
 			}
 
 			content.environment ??= {};

--- a/packages/akashic-cli-scan/src/scanNodeModules.ts
+++ b/packages/akashic-cli-scan/src/scanNodeModules.ts
@@ -204,9 +204,7 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 		if (param.forceUpdate) {
 			content.environment ??= {};
 
-			if (content.environment.external && Object.keys(content.environment.external).length > 0) {
-				logger.warn("'environment.external' in game.json has existing settings, but will be overwritten due to '--force' option");
-			}
+			const beforeExternal = content.environment.external;
 			delete content.environment.external;
 
 			for (const moduleName of entryPaths) {
@@ -232,6 +230,16 @@ export async function scanNodeModules(p: ScanNodeModulesParameterObject): Promis
 							path: assetPath
 						};
 					}
+				}
+			}
+
+			if (beforeExternal && Object.keys(beforeExternal).length > 0) {
+				const deletedKeys = Object.keys(beforeExternal).filter(key => !(key in (content.environment?.external ?? {})));
+				if (deletedKeys.length > 0) {
+					logger.warn(
+						"'environment.external' was overwritten due to '--force' option. " +
+						`The following keys were deleted: ${deletedKeys.map(key => `environment.external["${key}"]`).join(", ")}`
+					);
 				}
 			}
 		}


### PR DESCRIPTION
# このPullRequestが解決する内容
`akashic scan` コマンドに `--force` オプションを追加します。
`akashic scan asset` と `akashic scan globalScripts` でそれぞれ次のような挙動となります。

- `akashic scan asset`
  - 既存のアセット設定をすべて破棄して、すべてをスキャンし直す
- `akashic scan globalScripts`
  - game.json の `extension` や `assetList` などのフィールドをすべて破棄してスキャンし直す
  - **`--from-entry-point` オプションとの併用は未対応になっています**