### PR TITLE
feat(export): change runtime-version-table url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20770,7 +20770,7 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.8",
+      "version": "3.0.10",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
@@ -20779,8 +20779,8 @@
         "@akashic/akashic-cli-init": "2.0.0",
         "@akashic/akashic-cli-lib-manage": "2.0.0",
         "@akashic/akashic-cli-sandbox": "2.0.3",
-        "@akashic/akashic-cli-scan": "1.0.1",
-        "@akashic/akashic-cli-serve": "2.0.5",
+        "@akashic/akashic-cli-scan": "1.0.2",
+        "@akashic/akashic-cli-serve": "2.0.7",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -25445,7 +25445,7 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
@@ -26296,11 +26296,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "2.0.5",
+      "version": "2.0.7",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-scan": "1.0.1",
+        "@akashic/akashic-cli-scan": "1.0.2",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.17.5",

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -470,7 +470,7 @@ async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration): Pr
 	}
 
 	const versionInfo = JSON.parse(await getFromHttps(
-		"https://raw.githubusercontent.com/akashic-games/akashic-runtime-version-table/master/versions.json"
+		"https://resource.akashic.coe.nicovideo.jp/coe/contents/runtime_version_table/versions.json"
 	));
 
 	gameJson.environment["akashic-runtime"] = { version: "" };


### PR DESCRIPTION
### やったこと
- akashic-runtime-version-tableの参照先を変更
- キャッシュを無効化する処理はversions.jsonをアップロード時に行うため、ここでは不要