### PR TITLE
Add sandboxconfig option to serve

### DIFF
--- a/.changeset/silver-snakes-sparkle.md
+++ b/.changeset/silver-snakes-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-commons": patch
+"@akashic/akashic-cli-serve": patch
+---
+
+Add --sandbox-config option to serve

--- a/package-lock.json
+++ b/package-lock.json
@@ -20770,17 +20770,17 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.10",
+      "version": "3.0.14",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-export": "2.0.6",
-        "@akashic/akashic-cli-extra": "2.0.0",
-        "@akashic/akashic-cli-init": "2.0.0",
-        "@akashic/akashic-cli-lib-manage": "2.0.0",
-        "@akashic/akashic-cli-sandbox": "2.0.3",
-        "@akashic/akashic-cli-scan": "1.0.2",
-        "@akashic/akashic-cli-serve": "2.0.7",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-export": "2.0.8",
+        "@akashic/akashic-cli-extra": "2.0.1",
+        "@akashic/akashic-cli-init": "2.0.1",
+        "@akashic/akashic-cli-lib-manage": "2.0.1",
+        "@akashic/akashic-cli-sandbox": "2.0.4",
+        "@akashic/akashic-cli-scan": "1.0.3",
+        "@akashic/akashic-cli-serve": "2.0.10",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -20795,7 +20795,7 @@
     },
     "packages/akashic-cli-commons": {
       "name": "@akashic/akashic-cli-commons",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "2.5.0",
@@ -21677,11 +21677,11 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-extra": "2.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-extra": "2.0.1",
         "@akashic/game-configuration": "2.5.0",
         "@akashic/headless-driver": "2.17.5",
         "@babel/core": "7.25.2",
@@ -22436,10 +22436,10 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "commander": "12.1.0",
         "ini": "5.0.0",
         "lodash": "4.17.21"
@@ -23218,11 +23218,11 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-extra": "2.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-extra": "2.0.1",
         "commander": "12.1.0",
         "fs-extra": "11.2.0",
         "glob": "11.0.0",
@@ -24052,10 +24052,10 @@
     },
     "packages/akashic-cli-lib-manage": {
       "name": "@akashic/akashic-cli-lib-manage",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "commander": "12.1.0",
         "minipass": "7.1.2",
         "tar": "7.4.3"
@@ -24752,10 +24752,10 @@
     },
     "packages/akashic-cli-sandbox": {
       "name": "@akashic/akashic-cli-sandbox",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "@akashic/game-configuration": "^2.0.0",
         "@akashic/headless-driver": "2.17.5",
         "commander": "^11.0.0",
@@ -25445,10 +25445,10 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "aac-duration": "0.0.1",
         "chokidar": "^4.0.0",
         "commander": "^12.0.0",
@@ -26296,11 +26296,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "2.0.7",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-scan": "1.0.2",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-scan": "1.0.3",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.17.5",

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigServe.ts
@@ -24,4 +24,5 @@ export interface CliConfigServe {
 	corsAllowOrigin?: string;
 	fonts?: CliConfigFontDeclaration[];
 	standalone?: boolean;
+	sandboxConfig?: string;
 }

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -52,6 +52,7 @@ akashic-cli-serve [<options>] [<path>]
 |`--ssl-cert <certificatePath>`|N/A|HTTPS で起動するための SSL 証明書のパスを指定します。|N/A|
 |`--ssl-key <privatekeyPath>`|N/A|HTTPS で起動するための 秘密鍵のパスを指定します。|N/A|
 |`--cors-allow-origin <origin>`|N/A|Access-Control-Allow-Origin レスポンスヘッダーの値を指定します。|N/A|
+|`--sandbox-config <path>`|N/A|指定した sandbox.config.js を読み込みます。|N/A|
 |`--help`|`-h`|ヘルプを表示して終了します。|N/A|
 |`--version`|`-V`|バージョンを表示して終了します。|N/A|
 

--- a/packages/akashic-cli-serve/README.md
+++ b/packages/akashic-cli-serve/README.md
@@ -52,7 +52,7 @@ akashic-cli-serve [<options>] [<path>]
 |`--ssl-cert <certificatePath>`|N/A|HTTPS で起動するための SSL 証明書のパスを指定します。|N/A|
 |`--ssl-key <privatekeyPath>`|N/A|HTTPS で起動するための 秘密鍵のパスを指定します。|N/A|
 |`--cors-allow-origin <origin>`|N/A|Access-Control-Allow-Origin レスポンスヘッダーの値を指定します。|N/A|
-|`--sandbox-config <path>`|N/A|指定した sandbox.config.js を読み込みます。|N/A|
+|`--sandbox-config <path>`|N/A|指定した sandbox.config.js を読み込みます。|`./sandbox.config.js`|
 |`--help`|`-h`|ヘルプを表示して終了します。|N/A|
 |`--version`|`-V`|バージョンを表示して終了します。|N/A|
 

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -18,6 +18,7 @@ export interface ServerGlobalConfig {
 	protocol: string;
 	disableFeatCheck: boolean;
 	fontFamilies: string[];
+	sandboxConfig: string | null;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -41,4 +42,5 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	protocol: "http",
 	disableFeatCheck: false,
 	fontFamilies: [],
+	sandboxConfig: null
 };

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -18,7 +18,7 @@ export interface ServerGlobalConfig {
 	protocol: string;
 	disableFeatCheck: boolean;
 	fontFamilies: string[];
-	sandboxConfigDir: string | null;
+	sandboxConfig: string | null;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -42,5 +42,5 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	protocol: "http",
 	disableFeatCheck: false,
 	fontFamilies: [],
-	sandboxConfigDir: null
+	sandboxConfig: null
 };

--- a/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
+++ b/packages/akashic-cli-serve/src/server/common/ServerGlobalConfig.ts
@@ -18,7 +18,7 @@ export interface ServerGlobalConfig {
 	protocol: string;
 	disableFeatCheck: boolean;
 	fontFamilies: string[];
-	sandboxConfig: string | null;
+	sandboxConfigDir: string | null;
 }
 
 export const DEFAULT_HOSTNAME = "localhost";
@@ -42,5 +42,5 @@ export const serverGlobalConfig: ServerGlobalConfig = {
 	protocol: "http",
 	disableFeatCheck: false,
 	fontFamilies: [],
-	sandboxConfig: null
+	sandboxConfigDir: null
 };

--- a/packages/akashic-cli-serve/src/server/controller/ContentController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ContentController.ts
@@ -10,7 +10,10 @@ import * as sandboxConfigs from "../domain/SandboxConfigs.js";
 
 export const createHandlerToGetContents = (targetDirs: string[]): express.RequestHandler => {
 	// サーバ開始後、sandbox.config.js はここで初めて読み込まれる。この処理以前に sandbox.config.js が必要な場合は、その部分で `register()` を行うこと。
-	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfig ?? targetDir));
+	targetDirs.forEach((targetDir, idx) => {
+		const configPath  = serverGlobalConfig.sandboxConfig ?? path.resolve(targetDir, "sandbox.config.js");
+		sandboxConfigs.register(idx.toString(), configPath);
+	});
 
 	return (_req, res, next) => {
 		try {

--- a/packages/akashic-cli-serve/src/server/controller/ContentController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ContentController.ts
@@ -10,7 +10,7 @@ import * as sandboxConfigs from "../domain/SandboxConfigs.js";
 
 export const createHandlerToGetContents = (targetDirs: string[]): express.RequestHandler => {
 	// サーバ開始後、sandbox.config.js はここで初めて読み込まれる。この処理以前に sandbox.config.js が必要な場合は、その部分で `register()` を行うこと。
-	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfig ?? targetDir));
+	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfigDir ?? targetDir));
 
 	return (_req, res, next) => {
 		try {

--- a/packages/akashic-cli-serve/src/server/controller/ContentController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ContentController.ts
@@ -10,7 +10,7 @@ import * as sandboxConfigs from "../domain/SandboxConfigs.js";
 
 export const createHandlerToGetContents = (targetDirs: string[]): express.RequestHandler => {
 	// サーバ開始後、sandbox.config.js はここで初めて読み込まれる。この処理以前に sandbox.config.js が必要な場合は、その部分で `register()` を行うこと。
-	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfigDir ?? targetDir));
+	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfig ?? targetDir));
 
 	return (_req, res, next) => {
 		try {

--- a/packages/akashic-cli-serve/src/server/controller/ContentController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/ContentController.ts
@@ -10,7 +10,7 @@ import * as sandboxConfigs from "../domain/SandboxConfigs.js";
 
 export const createHandlerToGetContents = (targetDirs: string[]): express.RequestHandler => {
 	// サーバ開始後、sandbox.config.js はここで初めて読み込まれる。この処理以前に sandbox.config.js が必要な場合は、その部分で `register()` を行うこと。
-	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), targetDir));
+	targetDirs.forEach((targetDir, idx) => sandboxConfigs.register(idx.toString(), serverGlobalConfig.sandboxConfig ?? targetDir));
 
 	return (_req, res, next) => {
 		try {

--- a/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
@@ -15,8 +15,8 @@ export const createHandlerToGetSandboxConfig = (dirPaths: string[]): express.Req
 			if (!dirPaths[contentId]) {
 				throw new NotFoundError({ errorMessage: `contentId:${contentId} is not found.` });
 			}
-			const confDirPath = serverGlobalConfig.sandboxConfigDir ??  dirPaths[contentId];
-			const configPath = path.resolve(confDirPath, "sandbox.config.js");
+			const confDirPath = dirPaths[contentId];
+			const configPath = serverGlobalConfig.sandboxConfig ?? path.resolve(confDirPath, "sandbox.config.js");
 			// TODO ファイル監視。内容に変化がなければ直前の値を返せばよい
 			const config = dynamicRequire(configPath) ?? {};
 			const normalizedConfig = sandboxConfigs.normalizeConfig(config, req.params.contentId);

--- a/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
@@ -4,6 +4,7 @@ import type * as express from "express";
 import type { SandboxConfigApiResponseData } from "../../common/types/ApiResponse.js";
 import { BadRequestError, NotFoundError } from "../common/ApiError.js";
 import { responseSuccess } from "../common/ApiResponse.js";
+import { serverGlobalConfig } from "../common/ServerGlobalConfig.js";
 import { dynamicRequire } from "../domain/dynamicRequire.js";
 import * as sandboxConfigs from "../domain/SandboxConfigs.js";
 
@@ -14,7 +15,8 @@ export const createHandlerToGetSandboxConfig = (dirPaths: string[]): express.Req
 			if (!dirPaths[contentId]) {
 				throw new NotFoundError({ errorMessage: `contentId:${contentId} is not found.` });
 			}
-			const configPath = path.resolve(dirPaths[contentId], "sandbox.config.js");
+			const confDirPath = serverGlobalConfig.sandboxConfig ??  dirPaths[contentId];
+			const configPath = path.resolve(confDirPath, "sandbox.config.js");
 			// TODO ファイル監視。内容に変化がなければ直前の値を返せばよい
 			const config = dynamicRequire(configPath) ?? {};
 			const normalizedConfig = sandboxConfigs.normalizeConfig(config, req.params.contentId);

--- a/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
@@ -15,7 +15,7 @@ export const createHandlerToGetSandboxConfig = (dirPaths: string[]): express.Req
 			if (!dirPaths[contentId]) {
 				throw new NotFoundError({ errorMessage: `contentId:${contentId} is not found.` });
 			}
-			const confDirPath = serverGlobalConfig.sandboxConfig ??  dirPaths[contentId];
+			const confDirPath = serverGlobalConfig.sandboxConfigDir ??  dirPaths[contentId];
 			const configPath = path.resolve(confDirPath, "sandbox.config.js");
 			// TODO ファイル監視。内容に変化がなければ直前の値を返せばよい
 			const config = dynamicRequire(configPath) ?? {};

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -6,7 +6,6 @@ import * as chokidar from "chokidar";
 import type { SandboxConfigExternalDefinition } from "../../common/types/NamagameCommentConfig.js";
 import { BadRequestError, NotFoundError } from "../common/ApiError.js";
 import { dynamicRequire } from "./dynamicRequire.js";
-import { serverGlobalConfig } from "../common/ServerGlobalConfig.js";
 
 interface ResolvedSandboxConfig extends NormalizedSandboxConfiguration, SandboxConfigExternalDefinition {
 	// backgroundImage がローカルファイルの場合、クライアントからは GET /contents/:contentId/sandboxConfig/backgroundImage で取得される。その場合のローカルファイルのパスをここに保持する。
@@ -19,10 +18,9 @@ const configs: { [key: string]: ResolvedSandboxConfig } = {};
  * コンテンツの sandbox.config.js  ファイルの読み込み/監視を登録。
  *
  * @param contentId コンテンツID
- * @param targetDir sandbox.config.jsが存在するディレクトリパス
+ * @param configPath sandbox.config.js のファイルパス
  */
-export function register(contentId: string, targetDir: string): void {
-	const configPath = serverGlobalConfig.sandboxConfig ?? path.resolve(targetDir, "sandbox.config.js");
+export function register(contentId: string, configPath: string): void {
 	if (configs[contentId]) return;
 	configs[contentId] = watchRequire(configPath, contentId, config => configs[contentId] = config);
 }

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -6,6 +6,7 @@ import * as chokidar from "chokidar";
 import type { SandboxConfigExternalDefinition } from "../../common/types/NamagameCommentConfig.js";
 import { BadRequestError, NotFoundError } from "../common/ApiError.js";
 import { dynamicRequire } from "./dynamicRequire.js";
+import { serverGlobalConfig } from "../common/ServerGlobalConfig.js";
 
 interface ResolvedSandboxConfig extends NormalizedSandboxConfiguration, SandboxConfigExternalDefinition {
 	// backgroundImage がローカルファイルの場合、クライアントからは GET /contents/:contentId/sandboxConfig/backgroundImage で取得される。その場合のローカルファイルのパスをここに保持する。
@@ -21,7 +22,7 @@ const configs: { [key: string]: ResolvedSandboxConfig } = {};
  * @param targetDir sandbox.config.jsが存在するディレクトリパス
  */
 export function register(contentId: string, targetDir: string): void {
-	const configPath = path.resolve(targetDir, "sandbox.config.js");
+	const configPath = serverGlobalConfig.sandboxConfig ?? path.resolve(targetDir, "sandbox.config.js");
 	if (configs[contentId]) return;
 	configs[contentId] = watchRequire(configPath, contentId, config => configs[contentId] = config);
 }

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -149,7 +149,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 		}
 
 		let configPath = path.resolve(cliConfigParam.sandboxConfig);
-		if(!configPath.toLowerCase().endsWith(".js")) {
+		if (!configPath.toLowerCase().endsWith(".js")) {
 			// 値がディレクトリの場合は sandbox.config.js をファイル名のデフォルト値とする
 			configPath = path.join(configPath, "sandbox.config.js");
 		}

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -148,7 +148,7 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 			process.exit(1);
 		}
 		// sandbox.config.js が存在するディレクトリパスを設定。パスの組み立ては利用箇所で行う。
-		serverGlobalConfig.sandboxConfig = path.dirname(cliConfigParam.sandboxConfig);
+		serverGlobalConfig.sandboxConfigDir = path.dirname(cliConfigParam.sandboxConfig);
 	}
 
 	let gameExternalFactory: () => any = () => undefined;

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -142,13 +142,17 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	}
 
 	if (cliConfigParam.sandboxConfig) {
-		const configPath = path.resolve(cliConfigParam.sandboxConfig);
+		let configPath = path.resolve(cliConfigParam.sandboxConfig);
+		if(!configPath.toLowerCase().endsWith(".js")) {
+			// 値がディレクトリの場合は sandbox.config.js をファイル名のデフォルト値とする
+			configPath = path.join(configPath, "sandbox.config.js");
+		}
+
 		if (!fs.existsSync(configPath)) {
 			getSystemLogger().error(`Can not find ${configPath}`);
 			process.exit(1);
 		}
-		// sandbox.config.js が存在するディレクトリパスを設定。パスの組み立ては利用箇所で行う。
-		serverGlobalConfig.sandboxConfigDir = path.dirname(cliConfigParam.sandboxConfig);
+		serverGlobalConfig.sandboxConfig = configPath;
 	}
 
 	let gameExternalFactory: () => any = () => undefined;

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -141,6 +141,16 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 		serverGlobalConfig.allowExternal = cliConfigParam.allowExternal;
 	}
 
+	if (cliConfigParam.sandboxConfig) {
+		const configPath = path.resolve(cliConfigParam.sandboxConfig);
+		if (!fs.existsSync(configPath)) {
+			getSystemLogger().error(`Can not find ${configPath}`);
+			process.exit(1);
+		}
+		// sandbox.config.js が存在するディレクトリパスを設定。パスの組み立ては利用箇所で行う。
+		serverGlobalConfig.sandboxConfig = path.dirname(cliConfigParam.sandboxConfig);
+	}
+
 	let gameExternalFactory: () => any = () => undefined;
 	if (cmdOptions.serverExternalScript) {
 		try {
@@ -515,6 +525,7 @@ export async function run(argv: any): Promise<void> {
 		.option("--ssl-cert <certificatePath>", "Specify path to an SSL/TLS certificate to use HTTPS")
 		.option("--ssl-key <privatekeyPath>", "Specify path to an SSL/TLS privatekey to use HTTPS")
 		.option("--cors-allow-origin <origin>", "Specify origin for Access-Control-Allow-Origin")
+		.option("--sandbox-config <path>", "Specify path of sandbox.config.js")
 		.parse(argv);
 
 	const options = commander.opts();
@@ -550,6 +561,7 @@ export async function run(argv: any): Promise<void> {
 		corsAllowOrigin: options.corsAllowOrigin ?? conf.corsAllowOrigin,
 		standalone: options.standalone ?? conf.standalone,
 		fonts: conf.fonts,
+		sandboxConfig: options.sandboxConfig ?? conf.sandboxConfig
 	};
 	await cli(cliConfigParam, options);
 }

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -142,6 +142,12 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	}
 
 	if (cliConfigParam.sandboxConfig) {
+		// コンテンツが複数指定された場合はエラーとする
+		if (cliConfigParam.targetDirs && cliConfigParam.targetDirs.length > 1) {
+			getSystemLogger().error("--sandbox-config option does not support multiple contents.");
+			process.exit(1);
+		}
+
 		let configPath = path.resolve(cliConfigParam.sandboxConfig);
 		if(!configPath.toLowerCase().endsWith(".js")) {
 			// 値がディレクトリの場合は sandbox.config.js をファイル名のデフォルト値とする


### PR DESCRIPTION
## 概要

serve に sandbox.config.js のパスを指定するオプション `--sandbox-config` を追加します。
複数コンテンツ指定と `--sandbox-config` の組み合わせはエラーとします。

**動作確認**

`--sandbox-config` オプションの有無、akashic.config.js での指定で対象の sandbox.config.js が読み込まれる事を確認。