### PR TITLE
enable webp image file for scan, serve bg

### DIFF
--- a/packages/akashic-cli-scan/src/scanUtils.ts
+++ b/packages/akashic-cli-scan/src/scanUtils.ts
@@ -20,7 +20,7 @@ export function knownExtensionAssetFilter(p: string): boolean {
 }
 
 export function imageAssetFilter(p: string): boolean {
-	return /.*\.(png|gif|jp(?:e)?g)$/i.test(p);
+	return /.*\.(png|gif|jp(?:e)?g|webp)$/i.test(p);
 }
 
 export function vectorImageAssetFilter(p: string): boolean {

--- a/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
+++ b/packages/akashic-cli-serve/src/server/controller/SandboxConfigController.ts
@@ -72,8 +72,9 @@ export const createHandlerToGetSandboxConfigBgImage = (): express.RequestHandler
 					throw new NotFoundError({ errorMessage: `backgroundImage is not found. path:${config.resolvedBackgroundImagePath}` });
 				}
 
-				// SandboxConfigs#normalizeConfig() で PNG/JPEG 以外のファイルはエラーとしている
-				const type = path.extname(imgPath) === ".png" ? "image/png" : "image/jpeg";
+				// SandboxConfigs#normalizeConfig() で PNG/WEBP/JPEG 以外のファイルはエラーとしている
+				const extname = path.extname(imgPath);
+				const type = extname === ".png" ? "image/png" : extname === "webp" ? "image/webp" : "image/jpeg";
 				res.contentType(type);
 				res.sendFile(imgPath);
 			} else {

--- a/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
+++ b/packages/akashic-cli-serve/src/server/domain/SandboxConfigs.ts
@@ -79,8 +79,8 @@ export function normalizeConfig(sandboxConfig: SandboxConfiguration, contentId: 
 	const bgImage = config.displayOptions.backgroundImage;
 	let resolvedBackgroundImagePath = null;
 	if (bgImage) {
-		if (!/\.(jpg|jpeg|png)$/.test(bgImage)) {
-			throw new BadRequestError({ errorMessage: "Invalid backgroundImage, Please specify a png/jpg file." });
+		if (!/\.(jpg|jpeg|png|webp)$/.test(bgImage)) {
+			throw new BadRequestError({ errorMessage: "Invalid backgroundImage, Please specify a png/jpg/webp file." });
 		}
 
 		if (/^\/contents\//.test(bgImage)) {


### PR DESCRIPTION
## このpull requestが解決する内容

- scanコマンドでwebp画像を扱えるようにします
- serveホスト時に背景画像にwebp画像を扱えるようにします

残件として、exportコマンドの画像パック化のwebp対応は着手していません。

## 破壊的な変更を含んでいるか?

- なし

<!-- 
後方互換のない変更を含んでいる場合は詳細を書いてください。
特に含まれていない場合は "なし" で問題ありません。
 -->


