### PR TITLE
feat(init): support extensions field in template.json

### DIFF
--- a/.changeset/lucky-comics-wave.md
+++ b/.changeset/lucky-comics-wave.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-init": patch
+---
+
+support `extensions` field in template.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -3039,6 +3039,141 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.2.tgz",
+      "integrity": "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "license": "ISC",
@@ -6166,10 +6301,7 @@
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -7551,6 +7683,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -19071,10 +19212,7 @@
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -20720,6 +20858,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zip": {
       "version": "1.2.0",
       "dev": true,
@@ -20770,17 +20920,17 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.10",
+      "version": "3.0.15",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-export": "2.0.6",
-        "@akashic/akashic-cli-extra": "2.0.0",
-        "@akashic/akashic-cli-init": "2.0.0",
-        "@akashic/akashic-cli-lib-manage": "2.0.0",
-        "@akashic/akashic-cli-sandbox": "2.0.3",
-        "@akashic/akashic-cli-scan": "1.0.2",
-        "@akashic/akashic-cli-serve": "2.0.7",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-export": "2.0.8",
+        "@akashic/akashic-cli-extra": "2.0.1",
+        "@akashic/akashic-cli-init": "2.0.1",
+        "@akashic/akashic-cli-lib-manage": "2.0.1",
+        "@akashic/akashic-cli-sandbox": "2.0.4",
+        "@akashic/akashic-cli-scan": "1.0.3",
+        "@akashic/akashic-cli-serve": "2.0.11",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -20795,7 +20945,7 @@
     },
     "packages/akashic-cli-commons": {
       "name": "@akashic/akashic-cli-commons",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "2.5.0",
@@ -21677,11 +21827,11 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "2.0.6",
+      "version": "2.0.8",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-extra": "2.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-extra": "2.0.1",
         "@akashic/game-configuration": "2.5.0",
         "@akashic/headless-driver": "2.17.5",
         "@babel/core": "7.25.2",
@@ -22436,10 +22586,10 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "commander": "12.1.0",
         "ini": "5.0.0",
         "lodash": "4.17.21"
@@ -23218,11 +23368,12 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-extra": "2.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-extra": "2.0.1",
+        "@inquirer/checkbox": "^4.2.2",
         "commander": "12.1.0",
         "fs-extra": "11.2.0",
         "glob": "11.0.0",
@@ -24052,10 +24203,10 @@
     },
     "packages/akashic-cli-lib-manage": {
       "name": "@akashic/akashic-cli-lib-manage",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "commander": "12.1.0",
         "minipass": "7.1.2",
         "tar": "7.4.3"
@@ -24752,10 +24903,10 @@
     },
     "packages/akashic-cli-sandbox": {
       "name": "@akashic/akashic-cli-sandbox",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "@akashic/game-configuration": "^2.0.0",
         "@akashic/headless-driver": "2.17.5",
         "commander": "^11.0.0",
@@ -25445,10 +25596,10 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
+        "@akashic/akashic-cli-commons": "1.0.1",
         "aac-duration": "0.0.1",
         "chokidar": "^4.0.0",
         "commander": "^12.0.0",
@@ -26296,11 +26447,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "2.0.7",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.0",
-        "@akashic/akashic-cli-scan": "1.0.2",
+        "@akashic/akashic-cli-commons": "1.0.1",
+        "@akashic/akashic-cli-scan": "1.0.3",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.17.5",

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@akashic/akashic-cli-commons": "1.0.1",
     "@akashic/akashic-cli-extra": "2.0.1",
+    "@inquirer/checkbox": "^4.2.2",
     "commander": "12.1.0",
     "fs-extra": "11.2.0",
     "glob": "11.0.0",

--- a/packages/akashic-cli-init/src/__tests__/TemplateConfigSpec.ts
+++ b/packages/akashic-cli-init/src/__tests__/TemplateConfigSpec.ts
@@ -41,7 +41,8 @@ describe("completeTemplateConfig", () => {
 				{ src: "path/to/file.txt", dst: "file.txt" }
 			],
 			gameJson: "game.json",
-			guideMessage: null
+			extensions: [],
+			guideMessage: null,
 		});
 		expect(warn.mock.calls.length).toBe(1);
 		expect(
@@ -86,6 +87,7 @@ describe("completeTemplateConfig", () => {
 				{ src: "path/to/file.txt", dst: "" }
 			],
 			gameJson: "game.json",
+			extensions: [],
 			guideMessage: null
 		});
 	});

--- a/packages/akashic-cli-init/src/init/TemplateConfig.ts
+++ b/packages/akashic-cli-init/src/init/TemplateConfig.ts
@@ -13,6 +13,18 @@ export interface TemplateFileEntry {
 	dst?: string;
 }
 
+export interface TemplateExtensionEntry {
+	/**
+	 * モジュールの名前。
+	 */
+	module: string;
+	/**
+	 * モジュールのバージョン。
+	 * 省略された場合、 `latest` 。
+	 */
+	version?: string;
+}
+
 export interface TemplateConfig {
 	/**
 	 * このテンプレートのフォーマット。現在 "0" のみがサポートされている。
@@ -45,6 +57,12 @@ export interface TemplateConfig {
 	 * 省略された場合、 `null` 。
 	 */
 	guideMessage?: string | null;
+
+	/**
+	 * このテンプレートで利用する拡張機能。
+	 * 省略された場合、空配列。
+	 */
+	extensions?: TemplateExtensionEntry[];
 }
 
 // ref. https://off.tokyo/blog/typescript-saiki-utility-types/#DeepRequired
@@ -60,7 +78,7 @@ export async function completeTemplateConfig(
 	baseDir: string,
 	logger?: Logger
 ): Promise<NormalizedTemplateConfig> {
-	const { formatVersion, files, exclude, gameJson, guideMessage } = templateConfig;
+	const { formatVersion, files, exclude, gameJson, guideMessage, extensions } = templateConfig;
 
 	if (formatVersion != null && formatVersion !== "0") {
 		throw new Error(
@@ -95,10 +113,13 @@ export async function completeTemplateConfig(
 			.map(fileName => ({ src: fileName, dst: "" } as Required<TemplateFileEntry>));
 	}
 
+	const normalizedExtensions = (extensions ?? []).map(({ module, version }) => ({ module, version: version ?? "latest" }));
+
 	return {
 		formatVersion: formatVersion ?? "0",
 		files: normalizedFiles,
 		gameJson: gameJson ?? "game.json",
-		guideMessage: guideMessage ?? null
+		guideMessage: guideMessage ?? null,
+		extensions: normalizedExtensions,
 	};
 }


### PR DESCRIPTION
# このPullRequestが解決する内容

refs #1591
akashic-cli-init において template.json の `extensions` フィールドを解釈できるように機能追加します。

<img width="1014" height="226" alt="スクリーンショット 2025-09-18 15 40 33" src="https://github.com/user-attachments/assets/22b886a1-8d05-4479-aecc-c201cfd977d0" />
