### PR TITLE
chore(serve): use local module when using npx

### DIFF
--- a/packages/akashic-cli-serve/build/copyAgv.js
+++ b/packages/akashic-cli-serve/build/copyAgv.js
@@ -9,15 +9,15 @@ const __dirname = dirname(__filename);
 
 try {
 	const agvw = require.resolve("@akashic/agvw/dist/index.js");
-	execSync(`npx shx cp ${agvw} ${join(__dirname, "../www/public/external/akashic-gameview-web.strip.js")}`, { encoding: "utf-8" });
+	execSync(`npx --no shx cp ${agvw} ${join(__dirname, "../www/public/external/akashic-gameview-web.strip.js")}`, { encoding: "utf-8" });
 
 	const plg1 = require.resolve("@akashic/agvw/dist/plugin-instance-storage.js");
-	execSync(`npx shx cp ${plg1} ${join(__dirname, "../www/public/external/plugin-instance-storage.js")}`, { encoding: "utf-8" });
+	execSync(`npx --no shx cp ${plg1} ${join(__dirname, "../www/public/external/plugin-instance-storage.js")}`, { encoding: "utf-8" });
 
 	const plg2 = require.resolve("@akashic/agvw/dist/plugin-instance-storage-limited.js");
-	execSync(`npx shx cp ${plg2} ${join(__dirname, "../www/public/external/plugin-instance-storage-limited.js")}`, { encoding: "utf-8" });
+	execSync(`npx --no shx cp ${plg2} ${join(__dirname, "../www/public/external/plugin-instance-storage-limited.js")}`, { encoding: "utf-8" });
 
-	execSync(`npx shx mkdir -p ${join(__dirname, "../www/internal/untrusted_loader")}`, { encoding: "utf-8" });
+	execSync(`npx --no shx mkdir -p ${join(__dirname, "../www/internal/untrusted_loader")}`, { encoding: "utf-8" });
 } catch (e) {
 	console.error(e);
 	process.exitCode = 1;

--- a/packages/akashic-cli-serve/build/copyIcons.js
+++ b/packages/akashic-cli-serve/build/copyIcons.js
@@ -7,8 +7,8 @@ const __dirname = dirname(__filename);
 
 try {
 	const npmRootPath = execSync("npm root", { encoding: "utf-8" }).trim();
-	execSync("npx shx mkdir -p src/client/static/thirdparty", { encoding: "utf-8" });
-	execSync(`npx shx cp -r ${join(npmRootPath, "/material-icons/iconfont")} ${join(__dirname, "../src/client/static/thirdparty/material-icons")}`, { encoding: "utf-8" });
+	execSync("npx --no shx mkdir -p src/client/static/thirdparty", { encoding: "utf-8" });
+	execSync(`npx --no shx cp -r ${join(npmRootPath, "/material-icons/iconfont")} ${join(__dirname, "../src/client/static/thirdparty/material-icons")}`, { encoding: "utf-8" });
 } catch (e) {
 	console.error(e);
 	process.exitCode = 1;


### PR DESCRIPTION
### やったこと
- セキュリティ対策のためにnpx利用時に`--no`オプションを付与
  - ローカルでインストール済みのものを利用するため