### PR TITLE
Fix e2e test to run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-2022] # windows-latest 環境では e2e テストが失敗するため、暫定的対応として windows-2022 を指定
         node: [18.x, 20.x]
     steps:
       - name: Checkout code

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -4,7 +4,7 @@
 //  node test/e2e.js          (latestタグでpublishされたものをインストールしてテスト)
 //  node test/e2e.js --local  (このリポジトリの packages/akashic-cli/bin/akashic.js をテスト)
 
-import { tmpdir, platform } from "os";
+import { tmpdir } from "os";
 import { dirname, join, resolve } from "path";
 import { mkdtemp, readdir, readFile, unlink, writeFile } from "fs/promises";
 import { exec as _exec, spawn as _spawn } from "child_process";
@@ -53,11 +53,6 @@ function spawn(command, argv) {
 	// proc.stderr.on("data", data => void console.error(`${data}`));
 	const pid = proc.pid;
 	return async () => {
-		if (platform() === "win32") {
-			// Windows の場合、環境によっては ps-tree モジュール実行時にエラーになるので taskkill に任せる
-			await exec(`taskkill /F /T /PID ${pid}`);
-			return;
-		}
 		const children = await psTree(pid);
 		for (const child of children) {
 			process.kill(child.PID);

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -4,7 +4,7 @@
 //  node test/e2e.js          (latestタグでpublishされたものをインストールしてテスト)
 //  node test/e2e.js --local  (このリポジトリの packages/akashic-cli/bin/akashic.js をテスト)
 
-import { tmpdir } from "os";
+import { tmpdir, platform } from "os";
 import { dirname, join, resolve } from "path";
 import { mkdtemp, readdir, readFile, unlink, writeFile } from "fs/promises";
 import { exec as _exec, spawn as _spawn } from "child_process";
@@ -53,6 +53,11 @@ function spawn(command, argv) {
 	// proc.stderr.on("data", data => void console.error(`${data}`));
 	const pid = proc.pid;
 	return async () => {
+		if (platform() === "win32") {
+			// Windows の場合、環境によっては ps-tree モジュール実行時にエラーになるので taskkill に任せる
+			await exec(`taskkill /F /T /PID ${pid}`);
+			return;
+		}
 		const children = await psTree(pid);
 		for (const child of children) {
 			process.kill(child.PID);


### PR DESCRIPTION
### 概要
- [windows-latestの更新](https://github.blog/changelog/2025-07-31-github-actions-new-apis-and-windows-latest-migration-notice/#windows-latest-image-label-migration)により、windows-latest環境で`wmic.exe`の実行ができなくなり、これを利用するps-treeというモジュールをtest/e2e.jsで利用しているため、windows-latest環境でe2eテストの実行に失敗してしまう。
- 本来であればps-treeを利用せず代替手段を考えるべきだが、根本対応が難しいので暫定対応としてwindows-latestの代わりにwidows-2022環境を利用するに変更した。
