### PR TITLE
Update workflows about security

### DIFF
--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -10,6 +10,9 @@ on:
 env:
   PUBLISH_VERSION: patch
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     # PullRequest に release ラベルが付与されている場合のみ実行
@@ -20,6 +23,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # lerna-changelog の実行に tags の情報が必要なため明示的にすべての履歴を取得
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:

--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0 # lerna-changelog の実行に tags の情報が必要なため明示的にすべての履歴を取得
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -1,7 +1,7 @@
 name: Generate changeset for Renovate
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '.github/workflows/changesets-renovate.yml'
       - '**/package-lock.json'
@@ -10,10 +10,13 @@ on:
 env:
   NODE_VERSION: 20
 
+permissions:
+  contents: write
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]' && github.repository == 'akashic-games/akashic-cli' && contains(github.event.pull_request.labels.*.name, 'release')
+    if: github.event.pull_request.user.login == 'renovate[bot]' && github.repository == 'akashic-games/akashic-cli' && contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/changesets-renovate.yml
+++ b/.github/workflows/changesets-renovate.yml
@@ -16,12 +16,12 @@ jobs:
     if: github.actor == 'renovate[bot]' && github.repository == 'akashic-games/akashic-cli' && contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 2
           ref: ${{ github.head_ref }}
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 env:
   NODE_VERSION: 20
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     name: Publish and Release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           # CHANGELOG の差分を適切に生成するため明示的にすべての履歴を取得
           fetch-depth: 0
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -30,7 +30,7 @@ jobs:
           npm ci
           npm test
       - name: Create Release PullRequest or Publish
-        uses: changesets/action@v1
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: npm run release-packages
           version: npm run version-packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           # CHANGELOG の差分を適切に生成するため明示的にすべての履歴を取得
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:

--- a/.github/workflows/serve_dockerfile_build_test.yml
+++ b/.github/workflows/serve_dockerfile_build_test.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Install
         run: npm ci
       - name: Build and export to Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: ${{ env.WORKING_DIR }}
           load: true

--- a/.github/workflows/serve_dockerfile_build_test.yml
+++ b/.github/workflows/serve_dockerfile_build_test.yml
@@ -9,12 +9,17 @@ env:
   WORKING_DIR: packages/akashic-cli-serve
   TEST_TAG: akashic/akashic-cli-serve:test
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ startsWith(github.head_ref, 'renovate/') && 'renovate' || format('{0}-{1}', github.workflow, github.ref) }}
   cancel-in-progress: ${{ !startsWith(github.head_ref, 'renovate/') }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -21,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
         node: [18.x, 20.x]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Setup Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
### やったこと
- GithubActionsワークフローのセキュリティ対応
  - 各モジュール使用時にバージョンやタグではなく、SHA PINを指定
    - SHA PINの指定のために、[pinact](https://github.com/suzuki-shunsuke/pinact/tree/main)を利用
  - permissionsの指定
  - トークンなしでgit push するワークフロー以外のワークフローで checkout アクションに`persist-credentials: false`追加