### PR TITLE
update workflow for security

### DIFF
--- a/.github/workflows/bump_version_and_publish.yml
+++ b/.github/workflows/bump_version_and_publish.yml
@@ -39,7 +39,7 @@ jobs:
           git config user.name 'github-actions'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc
-          npm run publish:${{ env.PUBLISH_VERSION }}
+          npm run publish:${PUBLISH_VERSION}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/serve_dockerfile_build_test.yml
+++ b/.github/workflows/serve_dockerfile_build_test.yml
@@ -34,4 +34,4 @@ jobs:
           tags: ${{ env.TEST_TAG }}
       - name: Test
         run: |
-          docker run --rm ${{ env.TEST_TAG }} --version
+          docker run --rm "${TEST_TAG}" --version


### PR DESCRIPTION
### やったこと
Github Actionsのワークフローのセキュリティリスクの改善対応
- シェルコマンドで`${{ ~ }}`を使わないようにする
  - `${{ ~ }}` はシェルでそのままコマンドとして実行されてしまうのでシェルインジェクションのリスクがある