### PR TITLE
Add generate shrinkwrapjson script

### DIFF
--- a/.changeset/heavy-rivers-roll.md
+++ b/.changeset/heavy-rivers-roll.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli": patch
+---
+
+Add scripts/generateShrinkwrapJson.js

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,65 @@
+FROM node:22
+
+# Install basic development tools
+RUN apt update && apt install -y less \
+    git \
+    procps \
+    sudo \
+    vim \
+    fzf \
+    zsh \
+    man-db \
+    unzip \
+    gnupg2 \
+    gh \
+    jq \
+    cloc
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+# Ensure default `node` user has access to `sudo`
+ARG USERNAME=node
+RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace && \
+  chown -R node:node /workspace
+
+WORKDIR /workspace
+
+# RUN ARCH=$(dpkg --print-architecture) && \
+#   wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
+#   sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
+#   rm "git-delta_0.18.2_${ARCH}.deb"
+
+# Set up non-root user
+USER node
+
+# Install global packages
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+
+# Default powerline10k theme
+# RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
+#   -p git \
+#   -p fzf \
+#   -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+#   -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+#   -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+#   -x
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+    "name": "akashic-cli sandbox",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "args": {
+            "TZ": "${localEnv:TZ:Asia/Tokyo}"
+        }
+    },
+    "runArgs": [
+        "--memory=8g"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+            ]
+        }
+    },
+    "remoteUser": "node",
+    "forwardPorts": [],
+    "mounts": [
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.npmrc,target=/home/node/.npmrc,type=bind,readonly"
+    ],
+    "remoteEnv": {
+        "NODE_OPTIONS": "--max-old-space-size=4096"
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
+    "workspaceFolder": "/workspace",
+    "postCreateCommand": "sudo chown -R node:node /workspace || true"
+}

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ publish 時、各パッケージの依存関係のバージョンを固定する
 akashic-cli がモノレポであることや、akashic-cli の publish が行われた場合に、akashic-cli-xxxxx が `npm i --before <date>` でエラーとなる事を考慮し、スクリプトは下記の手順で `npm-shrinkwrap.json` を作成します。
 
 1. ルートの `package.json` から workspaces プロパティを削除
-2. 各パッケージの `package.json` の dependencies から `@akashic/xxxxx` を削除し `npm i --before <date>` を実行
+2. 各パッケージの `package.json` の dependencies から `@akashic/xxxxx` を削除し `npm i --before <実行日の七日前>` を実行
 3. 2 で削除した `@akashic/xxxxx` を npm インストール
 4. `npm shrinkwarp` を実行
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ npm run changeset
 対象の PullRequest をマージするとバージョン更新の PullRequest が自動的に作成されます。
 内容を確認後、その PullRequest をマージすることで publish が完了します。
 
+
+### publish 時の npm-shrinkwrap.json の追加
+
+`npm publish` の実行タイミングで `./scripts/generateShrinkwrapJson.js` が実行されます。
+publish 時、各パッケージの依存関係のバージョンを固定するために `npm-shrinkwrap.json` を追加するスクリプトです。
+
+akashic-cli がモノレポであることや、akashic-cli の publish が行われた場合に、akashic-cli-xxxxx が `npm i --before <date>` でエラーとなる事を考慮し、スクリプトは下記の手順で `npm-shrinkwrap.json` を作成します。
+
+1. ルートの `package.json` から workspaces プロパティを削除
+2. 各パッケージの `package.json` の dependencies から `@akashic/xxxxx` を削除し `npm i --before <date>` を実行
+3. 2 で削除した `@akashic/xxxxx` を npm インストール
+4. `npm shrinkwarp` を実行
+
 ## ライセンス
 
 本リポジトリは MIT License の元で公開されています。

--- a/package-lock.json
+++ b/package-lock.json
@@ -20920,17 +20920,17 @@
     },
     "packages/akashic-cli": {
       "name": "@akashic/akashic-cli",
-      "version": "3.0.17-test-dontuse.1",
+      "version": "3.0.17-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-export": "2.0.10-test-dontuse.1",
-        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-init": "2.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-lib-manage": "2.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-sandbox": "2.0.6-test-dontuse.1",
-        "@akashic/akashic-cli-scan": "1.0.5-test-dontuse.1",
-        "@akashic/akashic-cli-serve": "2.0.13-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-export": "2.0.10-test-dontuse.2",
+        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-init": "2.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-lib-manage": "2.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-sandbox": "2.0.6-test-dontuse.2",
+        "@akashic/akashic-cli-scan": "1.0.5-test-dontuse.2",
+        "@akashic/akashic-cli-serve": "2.0.13-test-dontuse.2",
         "commander": "^12.0.0"
       },
       "bin": {
@@ -20945,7 +20945,7 @@
     },
     "packages/akashic-cli-commons": {
       "name": "@akashic/akashic-cli-commons",
-      "version": "1.0.3-test-dontuse.1",
+      "version": "1.0.3-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "2.5.0",
@@ -21827,11 +21827,11 @@
     },
     "packages/akashic-cli-export": {
       "name": "@akashic/akashic-cli-export",
-      "version": "2.0.10-test-dontuse.1",
+      "version": "2.0.10-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.2",
         "@akashic/game-configuration": "2.5.0",
         "@akashic/headless-driver": "2.17.5",
         "@babel/core": "7.25.2",
@@ -22586,10 +22586,10 @@
     },
     "packages/akashic-cli-extra": {
       "name": "@akashic/akashic-cli-extra",
-      "version": "2.0.3-test-dontuse.1",
+      "version": "2.0.3-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
         "commander": "12.1.0",
         "ini": "5.0.0",
         "lodash": "4.17.21"
@@ -23368,11 +23368,11 @@
     },
     "packages/akashic-cli-init": {
       "name": "@akashic/akashic-cli-init",
-      "version": "2.0.3-test-dontuse.1",
+      "version": "2.0.3-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-extra": "2.0.3-test-dontuse.2",
         "@inquirer/checkbox": "^4.2.2",
         "commander": "12.1.0",
         "fs-extra": "11.2.0",
@@ -24203,10 +24203,10 @@
     },
     "packages/akashic-cli-lib-manage": {
       "name": "@akashic/akashic-cli-lib-manage",
-      "version": "2.0.3-test-dontuse.1",
+      "version": "2.0.3-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
         "commander": "12.1.0",
         "minipass": "7.1.2",
         "tar": "7.4.3"
@@ -24903,10 +24903,10 @@
     },
     "packages/akashic-cli-sandbox": {
       "name": "@akashic/akashic-cli-sandbox",
-      "version": "2.0.6-test-dontuse.1",
+      "version": "2.0.6-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
         "@akashic/game-configuration": "^2.0.0",
         "@akashic/headless-driver": "2.17.5",
         "commander": "^11.0.0",
@@ -25596,10 +25596,10 @@
     },
     "packages/akashic-cli-scan": {
       "name": "@akashic/akashic-cli-scan",
-      "version": "1.0.5-test-dontuse.1",
+      "version": "1.0.5-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
         "aac-duration": "0.0.1",
         "chokidar": "^4.0.0",
         "commander": "^12.0.0",
@@ -26447,11 +26447,11 @@
     },
     "packages/akashic-cli-serve": {
       "name": "@akashic/akashic-cli-serve",
-      "version": "2.0.13-test-dontuse.1",
+      "version": "2.0.13-test-dontuse.2",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.1",
-        "@akashic/akashic-cli-scan": "1.0.5-test-dontuse.1",
+        "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
+        "@akashic/akashic-cli-scan": "1.0.5-test-dontuse.2",
         "@akashic/amflow-util": "^1.3.0",
         "@akashic/game-configuration": "^2.1.0",
         "@akashic/headless-driver": "2.17.5",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release-packages": "npm run generateShrinkwrap && changeset publish",
-    "generateShrinkwrap": "node scripts/generateShrinkwrapJson.js"
+    "release-packages": "changeset publish",
+    "prepack": "nx run-many -t generateShrinkwrap"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release-packages": "npm shrinkwrap && changeset publish"
+    "release-packages": "npm run generateShrinkwrap && changeset publish",
+    "generateShrinkwrap": "node scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -31,9 +32,6 @@
       "rollup": "npm:@rollup/wasm-node"
     }
   },
-  "files": [
-    "npm-shrinkwrap.json"
-  ],
   "devDependencies": {
     "@akashic/remark-preset-lint": "^0.1.2",
     "@changesets/changelog-github": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release-packages": "changeset publish",
-    "prepack": "nx run-many -t generateShrinkwrap"
+    "prepublishOnly": "nx run-many -t generateShrinkwrap --parallel=1"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-commons/package.json
+++ b/packages/akashic-cli-commons/package.json
@@ -25,12 +25,14 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint \"./src/**/*.ts\" --fix"
+    "test:lint": "eslint \"./src/**/*.ts\" --fix",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "devDependencies": {
     "@akashic/eslint-config": "^3.0.2",

--- a/packages/akashic-cli-export/package.json
+++ b/packages/akashic-cli-export/package.json
@@ -20,7 +20,8 @@
     "build:template:ejs": "shx cp src/template/bundle-index.ejs lib/template/ && shx cp src/template/no-bundle-index.ejs lib/template/",
     "lint": "eslint \"src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
-    "test:vitest": "vitest run"
+    "test:vitest": "vitest run",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -31,7 +32,8 @@
     "akashic-cli-zip": "./bin/akashic-cli-export-zip.js"
   },
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "devDependencies": {
     "@akashic/akashic-engine": "~2.6.7",

--- a/packages/akashic-cli-extra/package.json
+++ b/packages/akashic-cli-extra/package.json
@@ -30,12 +30,14 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint \"./src/**/*.ts\" --fix"
+    "test:lint": "eslint \"./src/**/*.ts\" --fix",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -10,7 +10,8 @@
     "build": "tsc -p ./",
     "lint": "eslint \"./src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
-    "test:vitest": "vitest run"
+    "test:vitest": "vitest run",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -18,7 +19,8 @@
     "akashic-cli-init": "./bin/run.js"
   },
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "devDependencies": {
     "@akashic/eslint-config": "3.0.2",

--- a/packages/akashic-cli-lib-manage/package.json
+++ b/packages/akashic-cli-lib-manage/package.json
@@ -39,6 +39,7 @@
     "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",
     "commander": "12.1.0",
     "minipass": "7.1.2",
+    "minizlib": "3.0.1",
     "tar": "7.4.3"
   },
   "publishConfig": {

--- a/packages/akashic-cli-lib-manage/package.json
+++ b/packages/akashic-cli-lib-manage/package.json
@@ -9,7 +9,8 @@
     "build": "tsc -p ./",
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
-    "test:lint": "eslint \"./src/**/*.ts\" --fix"
+    "test:lint": "eslint \"./src/**/*.ts\" --fix",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -19,7 +20,8 @@
     "akashic-cli-update": "./bin/akashic-cli-update.js"
   },
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "devDependencies": {
     "@akashic/eslint-config": "3.0.2",

--- a/packages/akashic-cli-sandbox/package.json
+++ b/packages/akashic-cli-sandbox/package.json
@@ -19,7 +19,8 @@
     "lint:client": "eslint -c \"src/client/eslint.config.cjs\" \"src/client/**/*.ts\" --fix",
     "lint:server": "eslint -c \"src/server/eslint.config.cjs\" \"src/server/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
-    "test:vitest": "vitest run"
+    "test:vitest": "vitest run",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -31,7 +32,8 @@
     "js",
     "css",
     "views",
-    "thirdparty"
+    "thirdparty",
+    "npm-shrinkwrap.json"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/akashic-cli-scan/package.json
+++ b/packages/akashic-cli-scan/package.json
@@ -10,7 +10,8 @@
     "build": "tsc -p ./",
     "lint": "eslint \"./src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
-    "test:vitest": "vitest run"
+    "test:vitest": "vitest run",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -19,7 +20,8 @@
   },
   "files": [
     "bin",
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "devDependencies": {
     "@akashic/eslint-config": "3.0.2",

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -19,7 +19,8 @@
     "lint": "npm run lint:client && npm run lint:server",
     "lint:client": "eslint -c ./src/client/eslint.config.cjs \"src/client/**/*.ts\" \"src/common/**/*.ts\" \"src/client/**/*.tsx\" --fix",
     "lint:server": "eslint -c ./src/server/eslint.conifg.cjs \"src/server/**/*.ts\" --fix",
-    "storybook": "sb dev -p 9001"
+    "storybook": "sb dev -p 9001",
+    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",
@@ -95,7 +96,8 @@
     "bin",
     "lib",
     "views",
-    "www/public"
+    "www/public",
+    "npm-shrinkwrap.json"
   ],
   "publishConfig": {
     "access": "public",

--- a/packages/akashic-cli/package.json
+++ b/packages/akashic-cli/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "files": [
     "bin",
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",

--- a/packages/akashic-cli/package.json
+++ b/packages/akashic-cli/package.json
@@ -17,8 +17,7 @@
   "license": "MIT",
   "files": [
     "bin",
-    "lib",
-    "npm-shrinkwrap.json"
+    "lib"
   ],
   "dependencies": {
     "@akashic/akashic-cli-commons": "1.0.3-test-dontuse.2",

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -63,7 +63,6 @@ function formatDate(date) {
  */
 async function generateShrinkwrapJson() {
   let orgRootPackageJson = null;
-  const cwd = process.cwd();
   let pkgName = "";
   let isError = false;
 
@@ -103,7 +102,7 @@ async function generateShrinkwrapJson() {
     execSync(npmShrinkwrapCmd);
 
   } catch (err) {
-    console.error("Failed:", err);
+    console.error("Error:", err);
     isError = true;
   } finally {
     if (orgRootPackageJson) {

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -2,24 +2,47 @@ import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
 
-const BEFORE_DAYS = 3;
+const BEFORE_DAYS = 7;
+const rootPackageJsonPath = path.resolve(process.cwd(), "..", "..", "package.json");
 const packageJsonPath = path.resolve(process.cwd(), "package.json");
 
 /**
- * package.json の workspaces プロパティを削除し保存し、元の packate.json の内容を返す。
+ * ルートの package.json の workspaces プロパティを削除し保存し、元の package.json の内容を返す。
  */
 function removeWorkspacesField() {
-  const orgContent = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const orgContent = JSON.parse(fs.readFileSync(rootPackageJsonPath, "utf8"));
   const newContent = { ...orgContent };
-
+  
   if (newContent.workspaces) {
     delete newContent.workspaces;
   } else {
     return null;
   }
 
-  fs.writeFileSync(packageJsonPath, JSON.stringify(newContent, null, 2) + "\n");
+  fs.writeFileSync(rootPackageJsonPath, JSON.stringify(newContent, null, 2) + "\n");
   return orgContent;
+}
+
+/**
+ * 各パッケージの package.json の dependencies から akashic 系を削除する
+ */
+function removeAkashicDependencies(pkgJsonPath) {
+  const orgContent = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+  const newContent = { ...orgContent };
+  const akshicDependencies = [];
+
+  if (newContent.dependencies) {
+    for (const module of Object.keys(newContent.dependencies)) {
+      if (/^@akashic\//.test(module)) {
+        akshicDependencies.push({name: module, ver: newContent.dependencies[module]});
+        delete newContent.dependencies[module];
+      }
+    }
+  } else {
+    return null;
+  }
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(newContent, null, 2) + "\n");
+  return akshicDependencies;
 }
 
 /**
@@ -36,41 +59,58 @@ function formatDate(date) {
 }
 
 /**
- * packages/akashic-cli 配下に shrinkwrap.json を生成する。
+ * akashic-cli 以外の各 package 配下に shrinkwrap.json を生成する。
  */
 async function generateShrinkwrapJson() {
-  let orgPackageJson = null;
+  let orgRootPackageJson = null;
   const cwd = process.cwd();
+  let pkgName = "";
+  let isError = false;
 
   try {
-    orgPackageJson = removeWorkspacesField();
-    if (!orgPackageJson) {
-        console.log("package.json is missing workspaces field.");
-        return;
+    orgRootPackageJson = removeWorkspacesField();
+    if (!orgRootPackageJson) {
+        console.log("root package.json is missing workspaces field.");
+        process.exit(1);
     }
-
+    const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    pkgName = pkgJson.name;
+    console.log(`--- ${pkgName} generateShrinkwrapJson start ---`);
+  
     const dt = new Date();
     dt.setDate(dt.getDate() - BEFORE_DAYS);
     const formattedDate = formatDate(dt);
+    // akashic-cli-xxxxx は publish 日付が直前の可能性があり、--before <date> で引っかかるため package.json から削除し後でインストールする
+    const akashicModules = removeAkashicDependencies(packageJsonPath);
 
     const npmInstallCmd = `npm i --before ${formattedDate}`;
-    const npmShrinkwrapCmd = "npm shrinkwrap";
-
-    process.chdir("packages/akashic-cli");
     console.log(`- exec: "${npmInstallCmd}"`);
     execSync(npmInstallCmd);
 
+    if (akashicModules) { 
+      const installList = [];
+      for (const module of akashicModules) {
+        const target = `${module.name}@${module.ver}`;
+        installList.push(target);
+      }
+      const akashicInstallCmd = `npm i --save-exact ${installList.join(" ")}`;
+      console.log(`- exec: "${akashicInstallCmd}"`);
+      execSync(akashicInstallCmd);
+    }
+
+    const npmShrinkwrapCmd = "npm shrinkwrap";
     console.log(`- exec: "${npmShrinkwrapCmd}"`);
     execSync(npmShrinkwrapCmd);
 
   } catch (err) {
-    console.error("error:", err);
+    console.error("Failed:", err);
+    isError = true;
   } finally {
-    process.chdir(cwd);
-    if (orgPackageJson) {
-      fs.writeFileSync(packageJsonPath, JSON.stringify(orgPackageJson, null, 2) + "\n");
+    if (orgRootPackageJson) {
+      fs.writeFileSync(rootPackageJsonPath, JSON.stringify(orgRootPackageJson, null, 2) + "\n");
     }
-    console.log("- generateShrinkwrapJson end");
+    console.log(`--- ${pkgName} generateShrinkwrapJson end ---`);
+    if (isError) process.exit(1);
   }
 }
 

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -1,0 +1,77 @@
+import * as fs from "fs";
+import * as path from "path";
+import { execSync } from "child_process";
+
+const BEFORE_DAYS = 3;
+const packageJsonPath = path.resolve(process.cwd(), "package.json");
+
+/**
+ * package.json の workspaces プロパティを削除し保存し、元の packate.json の内容を返す。
+ */
+function removeWorkspacesField() {
+  const orgContent = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  const newContent = { ...orgContent };
+
+  if (newContent.workspaces) {
+    delete newContent.workspaces;
+  } else {
+    return null;
+  }
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(newContent, null, 2) + "\n");
+  return orgContent;
+}
+
+/**
+ * 日付を "yyyy-mm-dd" 形式の文字列へ変換し返す。
+ */
+function formatDate(date) {
+  const options = {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+  };
+  const formatted = new Intl.DateTimeFormat("ja-JP", options).format(date);
+  return formatted.replace(/\//g, "-");
+}
+
+/**
+ * packages/akashic-cli 配下に shrinkwrap.json を生成する。
+ */
+async function generateShrinkwrapJson() {
+  let orgPackageJson = null;
+  const cwd = process.cwd();
+
+  try {
+    orgPackageJson = removeWorkspacesField();
+    if (!orgPackageJson) {
+        console.log("package.json is missing workspaces field.");
+        return;
+    }
+
+    const dt = new Date();
+    dt.setDate(dt.getDate() - BEFORE_DAYS);
+    const formattedDate = formatDate(dt);
+
+    const npmInstallCmd = `npm i --before ${formattedDate}`;
+    const npmShrinkwrapCmd = "npm shrinkwrap";
+
+    process.chdir("packages/akashic-cli");
+    console.log(`- exec: "${npmInstallCmd}"`);
+    execSync(npmInstallCmd);
+
+    console.log(`- exec: "${npmShrinkwrapCmd}"`);
+    execSync(npmShrinkwrapCmd);
+
+  } catch (err) {
+    console.error("error:", err);
+  } finally {
+    process.chdir(cwd);
+    if (orgPackageJson) {
+      fs.writeFileSync(packageJsonPath, JSON.stringify(orgPackageJson, null, 2) + "\n");
+    }
+    console.log("- generateShrinkwrapJson end");
+  }
+}
+
+generateShrinkwrapJson();


### PR DESCRIPTION
## 概要

shrinkwrap.json 対応。

- 各 package.json の script に `generateShrinkwrap` と files に `npm-shrinkwrap.json` を追加。
- generateShrinkwrap.json の追加。(`prepublishOnly` で実行)
  - 1. publish 前に一時的にルートの package.json の workspaces プロパティを削除
  - 2. 各パッケージの package.json から `@akashic/....` を削除し `npm i --before <date>` を実行
  - 3. 2で削除した akashic 系をインストール
  - 4. npm shrinkwarp を実行
- `npm-shrinkwrap.json` の追加に関して README へ追記

**動作確認**

prepack で `generateShrinkwrap` を実行し、pack後の tgz ファイルを解凍して akashic-cli 以外の各パッケージに `npm-shrinkwrap.json` が存在する事、エラー時に pack されない事を確認。 
