### PR TITLE
Fix shrinkwrap

### DIFF
--- a/.changeset/five-tigers-develop.md
+++ b/.changeset/five-tigers-develop.md
@@ -1,0 +1,12 @@
+---
+"@akashic/akashic-cli-commons": patch
+"@akashic/akashic-cli-export": patch
+"@akashic/akashic-cli-extra": patch
+"@akashic/akashic-cli-init": patch
+"@akashic/akashic-cli-lib-manage": patch
+"@akashic/akashic-cli-sandbox": patch
+"@akashic/akashic-cli-scan": patch
+"@akashic/akashic-cli-serve": patch
+---
+
+Fix generateShrinkwrap.json

--- a/README.md
+++ b/README.md
@@ -80,10 +80,13 @@ publish 時、各パッケージの依存関係のバージョンを固定する
 
 akashic-cli がモノレポであることや、akashic-cli の publish が行われた場合に、akashic-cli-xxxxx が `npm i --before <date>` でエラーとなる事を考慮し、スクリプトは下記の手順で `npm-shrinkwrap.json` を作成します。
 
-1. ルートの `package.json` から workspaces プロパティを削除
-2. 各パッケージの `package.json` の dependencies から `@akashic/xxxxx` を削除し `npm i --before <実行日の七日前>` を実行
-3. 2 で削除した `@akashic/xxxxx` を npm インストール
-4. `npm shrinkwarp` を実行
+1. ルートの `package.json`, `package-lock.json` をリネーム
+2. 依存モジュールが publish 済みかポーリングして確認
+3. ロックファイルを作成。ロックファイルが作成済みの場合はポーリングで待つ
+4. 各パッケージの `package.json` の dependencies/devDependencies から `@akashic/xxxxx` を削除し `npm i --before <実行日の七日前>` を実行
+5. 4 で削除した `@akashic/xxxxx` を npm インストール
+6. `npm shrinkwarp` を実行
+7. 1 でリネームした `package.json`, `package-lock.json` を戻し、ロックファイルを削除
 
 ## ライセンス
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint:md": "remark . --frail --no-stdout --quiet --rc-path ./.remarkrc",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release-packages": "changeset publish",
-    "generateShrinkwrap": "nx run-many -t generateShrinkwrap --parallel=1"
+    "release-packages": "changeset publish"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-commons/package.json
+++ b/packages/akashic-cli-commons/package.json
@@ -26,7 +26,7 @@
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
     "test:lint": "eslint \"./src/**/*.ts\" --fix",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-export/package.json
+++ b/packages/akashic-cli-export/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint \"src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-extra/package.json
+++ b/packages/akashic-cli-extra/package.json
@@ -31,7 +31,7 @@
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
     "test:lint": "eslint \"./src/**/*.ts\" --fix",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-init/package.json
+++ b/packages/akashic-cli-init/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"./src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-lib-manage/package.json
+++ b/packages/akashic-cli-lib-manage/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:vitest && npm run test:lint",
     "test:vitest": "vitest run",
     "test:lint": "eslint \"./src/**/*.ts\" --fix",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-sandbox/package.json
+++ b/packages/akashic-cli-sandbox/package.json
@@ -20,7 +20,7 @@
     "lint:server": "eslint -c \"src/server/eslint.config.cjs\" \"src/server/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-scan/package.json
+++ b/packages/akashic-cli-scan/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"./src/**/*.ts\" --fix",
     "test": "npm run test:vitest && npm run lint",
     "test:vitest": "vitest run",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/packages/akashic-cli-serve/build/copyAgv.js
+++ b/packages/akashic-cli-serve/build/copyAgv.js
@@ -3,6 +3,10 @@ import { createRequire } from "module";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
+if (process.env.SETUP) {
+    process.exit(0);
+}
+
 const require = createRequire(import.meta.url);
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/packages/akashic-cli-serve/build/copyAgv.js
+++ b/packages/akashic-cli-serve/build/copyAgv.js
@@ -3,7 +3,8 @@ import { createRequire } from "module";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
-if (process.env.SETUP) {
+// npm-shrinkwrap.json の生成中の実行を抑止する。generateShrinkwrapJson.js を参照
+if (process.env.SKIP_SETUP) {
     process.exit(0);
 }
 

--- a/packages/akashic-cli-serve/build/copyIcons.js
+++ b/packages/akashic-cli-serve/build/copyIcons.js
@@ -2,6 +2,10 @@ import { execSync } from "child_process";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
+if (process.env.SETUP) {
+    process.exit(0);
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 

--- a/packages/akashic-cli-serve/build/copyIcons.js
+++ b/packages/akashic-cli-serve/build/copyIcons.js
@@ -2,7 +2,8 @@ import { execSync } from "child_process";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
-if (process.env.SETUP) {
+// npm-shrinkwrap.json の生成中の実行を抑止する。generateShrinkwrapJson.js を参照
+if (process.env.SKIP_SETUP) {
     process.exit(0);
 }
 

--- a/packages/akashic-cli-serve/build/updateEngineFiles.js
+++ b/packages/akashic-cli-serve/build/updateEngineFiles.js
@@ -3,6 +3,10 @@ import { createRequire } from "module";
 import path from "path";
 import { fileURLToPath } from "url";
 
+if (process.env.SETUP) {
+    process.exit(0);
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const require = createRequire(import.meta.url);

--- a/packages/akashic-cli-serve/build/updateEngineFiles.js
+++ b/packages/akashic-cli-serve/build/updateEngineFiles.js
@@ -3,7 +3,8 @@ import { createRequire } from "module";
 import path from "path";
 import { fileURLToPath } from "url";
 
-if (process.env.SETUP) {
+// npm-shrinkwrap.json の生成中の実行を抑止する。generateShrinkwrapJson.js を参照
+if (process.env.SKIP_SETUP) {
     process.exit(0);
 }
 

--- a/packages/akashic-cli-serve/package.json
+++ b/packages/akashic-cli-serve/package.json
@@ -20,7 +20,7 @@
     "lint:client": "eslint -c ./src/client/eslint.config.cjs \"src/client/**/*.ts\" \"src/common/**/*.ts\" \"src/client/**/*.tsx\" --fix",
     "lint:server": "eslint -c ./src/server/eslint.conifg.cjs \"src/server/**/*.ts\" --fix",
     "storybook": "sb dev -p 9001",
-    "generateShrinkwrap": "node ../../scripts/generateShrinkwrapJson.js"
+    "prepublishOnly": "node ../../scripts/generateShrinkwrapJson.js"
   },
   "author": "DWANGO Co., Ltd.",
   "license": "MIT",

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -193,7 +193,7 @@ async function generateShrinkwrapJson() {
     execSync(npmShrinkwrapCmd, { stdio: "inherit" });
 
   } catch (err) {
-    console.error("*** err:", err);
+    console.error("--- Error:", err);
     isError = true;
   } finally {
     if (fs.existsSync(rootRenamePackageJsonPath)) fs.renameSync(rootRenamePackageJsonPath, rootPackageJsonPath);

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -1,54 +1,58 @@
 // 各パッケージの依存関係のバージョンを固定するために `npm-shrinkwrap.json` を追加するスクリプト。(packages/*/ でのみ実行する想定)
 // モノレポであることや、直前に akashic-cli の publish が行われた場合、akashic-cli-xxxxx が `npm i --before <date>` でエラーとなるため、下記の手順で `npm-shrinkwrap.json` を作成する。
-// 1. ルートの `package.json` から workspaces プロパティを削除
-// 2. 各パッケージの `package.json` の dependencies から `@akashic/xxxxx` を削除し `npm i --before <実行日の七日前>` を実行
-// 3. 2 で削除した `@akashic/xxxxx` を npm インストール
-// 4. `npm shrinkwarp` を実行
+// 1. ルートの `package.json`, `package-lock.json` をリネーム
+// 2. 依存モジュールが publish 済みかポーリングして確認
+// 3. ロックファイルを作成。ロックファイルが作成済みの場合はポーリングで待つ
+// 4. 各パッケージの `package.json` の dependencies/devDependencies から `@akashic/xxxxx` を削除し `npm i --before <実行日の七日前>` を実行
+// 5. 4 で削除した `@akashic/xxxxx` を npm インストール
+// 6. `npm shrinkwarp` を実行
+// 7. 1 でリネームした `package.json`, `package-lock.json` を戻し、ロックファイルを削除
 
 import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
 
+const POLLING_MAX_RETRY_COUNT = 180; // polling 最大試行回数(要調整)
+const POLLING_WAIT_TIME = 10 * 1000; // ms, retry * time で 30min(要調整)
 const BEFORE_DAYS = 7;
+
 const rootPackageJsonPath = path.resolve(process.cwd(), "..", "..", "package.json");
+const rootRenamePackageJsonPath = path.resolve(process.cwd(), "..", "..", "_package.json");
+const rootPackageLockPath = path.resolve(process.cwd(), "..", "..", "package-lock.json");
+const rootRenamePackageLockPath = path.resolve(process.cwd(), "..", "..", "_package-lock.json");
 const packageJsonPath = path.resolve(process.cwd(), "package.json");
+const lockFilePath = path.resolve(process.cwd(), "..", "..", "publish.lock");
+const cliPackageJsonPath = path.resolve(process.cwd(), "..", "akashic-cli", "package.json");
+
+let fd; // filedescriptor
+let isError = false;
 
 /**
- * ルートの package.json の workspaces プロパティを削除し保存し、元の package.json の内容を返す。
- */
-function removeWorkspacesField() {
-  const orgContent = fs.readFileSync(rootPackageJsonPath, "utf-8");
-  const newContent = { ...JSON.parse(orgContent) };
-  
-  if (newContent.workspaces) {
-    delete newContent.workspaces;
-  } else {
-    return null;
-  }
-
-  fs.writeFileSync(rootPackageJsonPath, JSON.stringify(newContent, null, 2) + "\n");
-  return orgContent;
-}
-
-/**
- * 各パッケージの package.json の dependencies から akashic 系を削除する
+ * 各パッケージの package.json の dependencies/devDependencies から akashic 系を削除する
  */
 function removeAkashicDependencies(pkgJsonPath) {
   const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
-  const akshicDependencies = [];
+  const akashicDependencies = [];
+  const devAkashicDependencies = [];
 
   if (pkgJson.dependencies) {
     for (const module of Object.keys(pkgJson.dependencies)) {
       if (/^@akashic\//.test(module)) {
-        akshicDependencies.push({name: module, ver: pkgJson.dependencies[module]});
+        akashicDependencies.push({ name: module, ver: pkgJson.dependencies[module] });
         delete pkgJson.dependencies[module];
       }
     }
-  } else {
-    return null;
+  }
+  if (pkgJson.devDependencies) {
+    for (const module of Object.keys(pkgJson.devDependencies)) {
+      if (/^@akashic\//.test(module)) {
+        devAkashicDependencies.push({ name: module, ver: pkgJson.devDependencies[module] });
+        delete pkgJson.devDependencies[module];
+      }
+    }
   }
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + "\n");
-  return akshicDependencies;
+  return { dependencies: akashicDependencies, devDependencies: devAkashicDependencies };
 }
 
 /**
@@ -65,58 +69,146 @@ function formatDate(date) {
 }
 
 /**
+ * ロックファイルが作成可能となるまでポーリングする
+ * ロックファイルを flag: "wx" で open() して成功ならポーリング終了、もしくは最大回数試行でエラー
+ */
+async function pollingLockFile() {
+  let count = 0;
+  while (count < POLLING_MAX_RETRY_COUNT) {
+    try {
+      return fs.openSync(lockFilePath, "wx");
+    } catch (_error) {
+      if (count < POLLING_MAX_RETRY_COUNT) {
+        count++;
+        await new Promise(resolve => setTimeout(resolve, POLLING_WAIT_TIME));
+      }
+    }
+  }
+  throw new Error("pollingLockFile(): The maximum number of times has been reached.");
+}
+
+/**
+ * npm view で指定したパッケージのバージョンが取得できるまでポーリングする
+ */
+async function pollingPublish(pkgName, version) {
+  let count = 0;
+  const npmViewCmd = `npm view ${pkgName}@${version}`;
+  console.log(`- exec: "${npmViewCmd}"`);
+
+  while (count < POLLING_MAX_RETRY_COUNT) {
+    try {
+      execSync(npmViewCmd);
+      return true;
+
+    } catch (_error) {
+      if (count < POLLING_MAX_RETRY_COUNT) {
+        count++;
+        await new Promise(resolve => setTimeout(resolve, POLLING_WAIT_TIME));
+      }
+    }
+  }
+  throw new Error("pollingPublish(): The maximum number of times has been reached.");
+}
+
+/**
  * akashic-cli 以外の各 package 配下に shrinkwrap.json を生成する。
  */
 async function generateShrinkwrapJson() {
-  let orgRootPackageJson = null;
   let pkgName = "";
-  let isError = false;
 
   try {
-    orgRootPackageJson = removeWorkspacesField();
-    if (!orgRootPackageJson) {
-        console.log("root package.json is missing workspaces field.");
-        process.exit(1);
-    }
-    const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+    const pkgJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
     pkgName = pkgJson.name;
-    console.log(`--- ${pkgName} generateShrinkwrapJson start ---`);
-  
+    console.log(`--------------- ${pkgName} generateShrinkwrapJson start ---`);
+
+    // バージョン取得用
+    const cliPkgJson = JSON.parse(fs.readFileSync(cliPackageJsonPath, "utf-8"));
+    // 依存モジュールが publish 済みかポーリングして確認
+    if (pkgName !== "@akashic/akashic-cli-commons") {
+      // commons 依存
+      const version = cliPkgJson.dependencies["@akashic/akashic-cli-commons"];
+      await pollingPublish("@akashic/akashic-cli-commons", version);
+    }
+    if (pkgName === "@akashic/akashic-cli-export") {
+      // extra 依存
+      const version = cliPkgJson.dependencies["@akashic/akashic-cli-extra"];
+      await pollingPublish("@akashic/akashic-cli-extra", version);
+    }
+    if (pkgName === "@akashic/akashic-cli-serve") {
+      // scan 依存: [serve]
+      const version = cliPkgJson.dependencies["@akashic/akashic-cli-scan"];
+      await pollingPublish("@akashic/akashic-cli-scan", version);
+    }
+    if (pkgName === "@akashic/akashic-cli-init") {
+      // extra 依存: [init]
+      const version = cliPkgJson.dependencies["@akashic/akashic-cli-extra"];
+      await pollingPublish("@akashic/akashic-cli-extra", version);
+    }
+
+    fd = await pollingLockFile();
+
+    // モノレポの制御を外すため package.json, package-lock.json をリネーム
+    fs.renameSync(rootPackageJsonPath, rootRenamePackageJsonPath);
+    fs.renameSync(rootPackageLockPath, rootRenamePackageLockPath);
+
     const dt = new Date();
     dt.setDate(dt.getDate() - BEFORE_DAYS);
     const formattedDate = formatDate(dt);
     // akashic-cli-xxxxx は publish 日付が直前の可能性があり、--before <date> で引っかかるため package.json から削除し後でインストールする
     const akashicModules = removeAkashicDependencies(packageJsonPath);
 
+    if (pkgName == "@akashic/akashic-cli-serve") {
+      // serve で @akashic 系を削除してインストールした場合、`npm run setup` の処理で落ちる。環境変数の値を設定し処理をスキップさせる。 
+      process.env.SKIP_SERVE_SETUP = true;
+    }
+
     const npmInstallCmd = `npm i --before ${formattedDate}`;
     console.log(`- exec: "${npmInstallCmd}"`);
-    execSync(npmInstallCmd);
+    execSync(npmInstallCmd, { stdio: "inherit" });
 
-    if (akashicModules) { 
+    if (akashicModules.dependencies.length) {
       const installList = [];
-      for (const module of akashicModules) {
+      for (const module of akashicModules.dependencies) {
         const target = `${module.name}@${module.ver}`;
         installList.push(target);
       }
       const akashicInstallCmd = `npm i --save-exact ${installList.join(" ")}`;
+      console.log(`- exec: "${akashicInstallCmd}"`);
+      execSync(akashicInstallCmd, { stdio: "inherit" });
+    }
+
+    if (akashicModules.devDependencies.length) {
+      const installList = [];
+      for (const module of akashicModules.devDependencies) {
+        const target = `${module.name}@${module.ver}`;
+        installList.push(target);
+      }
+      const akashicInstallCmd = `npm i --save-dev --save-exact ${installList.join(" ")}`;
       console.log(`- exec: "${akashicInstallCmd}"`);
       execSync(akashicInstallCmd);
     }
 
     const npmShrinkwrapCmd = "npm shrinkwrap";
     console.log(`- exec: "${npmShrinkwrapCmd}"`);
-    execSync(npmShrinkwrapCmd);
+    execSync(npmShrinkwrapCmd, { stdio: "inherit" });
 
   } catch (err) {
-    console.error("Error:", err);
+    console.error("*** err:", err);
     isError = true;
   } finally {
-    if (orgRootPackageJson) {
-      fs.writeFileSync(rootPackageJsonPath, orgRootPackageJson);
-    }
-    console.log(`--- ${pkgName} generateShrinkwrapJson end ---`);
-    if (isError) process.exit(1);
+    if (fs.existsSync(rootRenamePackageJsonPath)) fs.renameSync(rootRenamePackageJsonPath, rootPackageJsonPath);
+    if (fs.existsSync(rootRenamePackageLockPath)) fs.renameSync(rootRenamePackageLockPath, rootPackageLockPath);
+
+    console.log(`------------ ${pkgName}  end ------------`);
   }
 }
+
+process.on("beforeExit", () => {
+  if (fd != null) {
+    fs.closeSync(fd);
+    fs.rmSync(lockFilePath);
+  }
+  if (isError) process.exit(1);
+});
 
 generateShrinkwrapJson();


### PR DESCRIPTION
## 概要

shrinkwrap.json 対応。

#1612 からの変更点

- ルートの package.json, package-lock.json をリネームして退避し、終了時に戻す
- 各パッケージ の `prepublishOnly` で generateShrinkwrap.js を実行
- 依存パッケージが publish 済みかポーリングして publish を待つ
- ロックファイルを追加し、ロックファイルが存在する場合はポーリングして処理を待つ
- serve の場合、環境変数を用意し build scripts をスキップさせる
