### PR TITLE
Fix generateShrinkwrapJson.js log output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,9 @@ jobs:
           version: npm run version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive artifact
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: shrinkwrap_log
+          path: ./logs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,4 +47,4 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: shrinkwrap_log
-          path: ./logs
+          path: ./logs_shrinkwrap

--- a/scripts/generateShrinkwrapJson.js
+++ b/scripts/generateShrinkwrapJson.js
@@ -23,7 +23,7 @@ const rootRenamePackageLockPath = path.resolve(process.cwd(), "..", "..", "_pack
 const packageJsonPath = path.resolve(process.cwd(), "package.json");
 const lockFilePath = path.resolve(process.cwd(), "..", "..", "publish.lock");
 const cliPackageJsonPath = path.resolve(process.cwd(), "..", "akashic-cli", "package.json");
-const logsDirPath = path.resolve(process.cwd(), "..", "..", "logs");
+const logsDirPath = path.resolve(process.cwd(), "..", "..", "logs_shrinkwrap");
 const logs = [];
 
 let fd; // filedescriptor


### PR DESCRIPTION
## 概要

generateShrinkwrapJson.js のログ出力を修正。
actions でエラーとなった場合に、ログファイルを保存するように修正。


**動作確認**
個人リポジトリで確認。(NPM 認証でエラーとなっているがスクリプトは実行できています)
[正常終了時、ログはなし](https://github.com/ShinobuTakahashi/test-monorepo/actions/runs/21016424107/job/60422359658)
[エラー時、ログをダウンロードできる](https://github.com/ShinobuTakahashi/test-monorepo/actions/runs/21016327308/job/60422070677)
