### PR TITLE
Fix e2e.js

### DIFF
--- a/test/e2e.js
+++ b/test/e2e.js
@@ -27,7 +27,6 @@ const testsPublished = (process.argv.slice(2)[0] !== "--local");
 
 process.on("exit", () => {
 	console.log("delete test-directory");
-	shell.cd(`${__dirname}`);
 	shell.rm("-rf", `${targetDir}`);
 });
 

--- a/test/e2e.js
+++ b/test/e2e.js
@@ -4,7 +4,6 @@
 //  node test/e2e.js          (latestタグでpublishされたものをインストールしてテスト)
 //  node test/e2e.js --local  (このリポジトリの packages/akashic-cli/bin/akashic.js をテスト)
 
-import { tmpdir } from "os";
 import { dirname, join, resolve } from "path";
 import { mkdtemp, readdir, readFile, unlink, writeFile } from "fs/promises";
 import { exec as _exec, spawn as _spawn } from "child_process";
@@ -22,14 +21,13 @@ const exec = promisify(_exec);
 const shell = require("shelljs");
 const _psTree = require("ps-tree");
 const psTree = promisify(_psTree);
-const tmpDir = tmpdir();
-const targetDir = await mkdtemp(`${join(tmpDir, "test-akashic-cli_")}`);
+const targetDir = await mkdtemp(`${join(__dirname, "..", "test-akashic-cli_")}`);
 
 const testsPublished = (process.argv.slice(2)[0] !== "--local");
 
 process.on("exit", () => {
 	console.log("delete test-directory");
-	shell.cd(`${tmpDir}`);
+	shell.cd(`${__dirname}`);
 	shell.rm("-rf", `${targetDir}`);
 });
 


### PR DESCRIPTION
## 概要

Actions の windows 環境で e2e テストの akashic update が30分位かかってしまう問題の対応。

根本的な原因は不明だが、テストで使用するコンテンツのディレクトリを一時ディレクトリではなく、プロジェクト直下にすることで改善した。


[test のワークフロー](https://github.com/akashic-games/akashic-cli/actions/runs/21206215471/job/61003231482)で確認。