### PR TITLE
Fix to run test after publish in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
           name: shrinkwrap_log
           path: ./logs_shrinkwrap
       - name: Test after publish
+        # package-lock.json を更新するのが publish 直前のため、publish した物と完全に同じ状態でテストできない
+        # ここでエラーになっても既に publish してしまった後だが、問題の検出を早めるため実行している
+        # publish 時に npm-shrinkwrap.json が作成されていなければエラーとなり、このテストは実行されない
         run: | 
           if [[ `find ./packages/**/npm-shrinkwrap.json` ]]; then
             npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,8 @@ jobs:
         with:
           name: shrinkwrap_log
           path: ./logs_shrinkwrap
+      - name: Test after publish
+        run: | 
+          if [[ `find ./packages/**/npm-shrinkwrap.json` ]]; then
+            npm test
+          fi


### PR DESCRIPTION
## 概要

publish 後(npm-shrinkwrap.json生成後)に test を実行するよう修正。
publish 後に shrinkwrap.json が存在する場合のみテストを実行。

**動作確認**　

個人リポジトリで release.yml の version 更新の場合と publish の場合の動作確認。
(ワークフローの `test after shrinkwrap` 内で publish 後の方だけテストが実行される。)

[version 更新の場合](https://github.com/ShinobuTakahashi/test-monorepo/actions/runs/21233681371/job/61097010136) 
[publish の場合](https://github.com/ShinobuTakahashi/test-monorepo/actions/runs/21233709781/job/61097094562)






