### PR TITLE
Fix output for export-zip with --cwd option

### DIFF
--- a/.changeset/small-worms-serve.md
+++ b/.changeset/small-worms-serve.md
@@ -2,4 +2,4 @@
 "@akashic/akashic-cli-export": patch
 ---
 
-Fix output for export-zip with --cwd option
+Fix --output (-o) option: relative path is now interpreted from `--cwd` option's path, if given.

--- a/.changeset/small-worms-serve.md
+++ b/.changeset/small-worms-serve.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-export": patch
+---
+
+Fix output for export-zip with --cwd option

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -51,6 +51,7 @@ function _createExportInfo(param: ExportZipParameterObject): cmn.ExportZipInfo {
 }
 
 export function _completeExportZipParameterObject(param: ExportZipParameterObject): ExportZipParameterObject {
+	const dest = path.resolve((param.source || process.cwd()), (param.dest || "./game.zip"));
 	return {
 		bundle: !!param.bundle,
 		babel: !!param.babel,
@@ -61,7 +62,7 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		packImage: !!param.packImage,
 		strip: !!param.strip,
 		source: param.source || process.cwd(),
-		dest: param.dest || "./game.zip",
+		dest,
 		force: !!param.force,
 		logger: param.logger || new cmn.ConsoleLogger(),
 		hashLength: param.hashLength,
@@ -100,7 +101,7 @@ export function promiseExportZip(param: ExportZipParameterObject): Promise<void>
 	param = _completeExportZipParameterObject(param);
 	const outZip = /\.zip$/.test(param.dest);
 	const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "akashic-export-zip-"));
-	const destDir = path.resolve(param.dest);
+	const destDir = param.dest;
 
 	return _checkDestinationValidity(param.dest, param.force, param.logger)
 		.then(() => {

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -51,7 +51,8 @@ function _createExportInfo(param: ExportZipParameterObject): cmn.ExportZipInfo {
 }
 
 export function _completeExportZipParameterObject(param: ExportZipParameterObject): ExportZipParameterObject {
-	const dest = path.resolve((param.source || process.cwd()), (param.dest || "./game.zip"));
+	const source = param.source || process.cwd();
+	const dest = path.resolve(source, (param.dest || "./game.zip"));
 	return {
 		bundle: !!param.bundle,
 		babel: !!param.babel,
@@ -61,7 +62,7 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		terser: param.terser,
 		packImage: !!param.packImage,
 		strip: !!param.strip,
-		source: param.source || process.cwd(),
+		source,
 		dest,
 		force: !!param.force,
 		logger: param.logger || new cmn.ConsoleLogger(),


### PR DESCRIPTION
## 概要

export-zip で `--cwd` オプション利用時に、zipファイルの出力先を `--cwd` オプションで指定した箇所に出力されるよう修正。
(現状は `--cwd` オプションを指定してもコマンドを実行したディレクトリに出力される。 html は `--cwd` オプションのディレクトリに出力されるので html へ合わせる)

**動作確認**

`--cwd` オプションの有無で zip ファイルが指定したディレクトリに出力されることを確認。
