### PR TITLE
fix(serve): handle playlog upload correctly

### DIFF
--- a/.changeset/short-cooks-dig.md
+++ b/.changeset/short-cooks-dig.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-serve": patch
+---
+
+handle playlog upload correctly

--- a/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/operator/Operator.ts
@@ -76,6 +76,7 @@ export class Operator {
 
 		if (store.currentPlay) {
 			await store.currentPlay.deleteAllLocalInstances();
+			await store.playStore.deletePlay(playId);
 			store.setCurrentLocalInstance(null);
 		}
 

--- a/packages/akashic-cli-serve/src/client/sandbox/store/PlayStore.ts
+++ b/packages/akashic-cli-serve/src/client/sandbox/store/PlayStore.ts
@@ -55,5 +55,6 @@ export class PlayStore {
 			throw new Error("Play not found: " + playId);
 
 		await play.teardown();
+		delete this.plays[playId];
 	};
 }


### PR DESCRIPTION
# このPullRequestが解決する内容
`PlayState#deletePlay()` で保持している `PlayEntity` を破棄します。
これにより standalone においてプレイログ再生が失敗するバグを修正します。