### PR TITLE
feat(export): add open source options

### DIFF
--- a/.changeset/deep-mangos-relate.md
+++ b/.changeset/deep-mangos-relate.md
@@ -1,0 +1,6 @@
+---
+"@akashic/akashic-cli-commons": patch
+"@akashic/akashic-cli-export": patch
+---
+
+add open source options

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportHtml.ts
@@ -22,4 +22,5 @@ export interface CliConfigExportHtml {
 	omitUnbundledJs?: boolean;
 	esDownpile?: boolean;
 	debugOverrideEngineFiles?: string;
+	useUntaintedImage?: boolean;
 }

--- a/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
+++ b/packages/akashic-cli-commons/src/CliConfig/CliConfigExportZip.ts
@@ -22,6 +22,12 @@ export interface CliConfigExportZip {
 	omitUnbundledJs?: boolean;
 	targetService?: ServiceType;
 	nicolive?: boolean;
-	resolveAkashicRuntime?: boolean;
+	/**
+	 * akashic-runtime フィールドを解決する。
+	 * - `true` の場合: 既定の URL から最新バージョンを取得して設定する。
+	 * - バージョン文字列 (例: `"3.1.2"`) の場合: そのバージョンを `environment["akashic-runtime"].version` に追記する。
+	 * - URL (例: `"https://..."`) の場合: その URL から最新バージョンを取得して設定する。
+	 */
+	resolveAkashicRuntime?: boolean | string;
 	preservePackageJson?: boolean;
 }

--- a/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
+++ b/packages/akashic-cli-export/src/html/__tests__/exportHTMLSpec.ts
@@ -80,6 +80,7 @@ describe("exportHTML", function () {
 			.then((dest) => {
 				expect(dest).toMatch(/^.*akashic-export-html-tmp-.+$/);
 				expect(fs.existsSync(path.join(dest, "library_license.txt"))).toBeTruthy();
+				expect(fs.readFileSync(path.join(dest, "js", "game.json.js"), "utf-8")).not.toContain("untainted");
 				fs.rmSync(dest, { recursive: true });
 			});
 	});
@@ -184,6 +185,47 @@ describe("exportHTML", function () {
 		expect(fs.statSync(path.join(dest, "audio", "dummyse.aac"))).toBeTruthy();
 		expect(fs.statSync(path.join(dest, "audio", "dummyse.m4a"))).toBeTruthy();
 		expect(() => fs.statSync(path.join(dest, "audio", "dummyse.invalidext"))).toThrow();
+		fs.rmSync(dest, { recursive: true });
+	});
+
+	it("promiseExportHTML with useUntaintedImage option (no-bundle)", async () => {
+		const param: exp.ExportHTMLParameterObject = {
+			logger: undefined,
+			cwd: path.join(__dirname, "..", "..", "__tests__", "fixtures", "sample_game"),
+			source: ".",
+			output: undefined,
+			force: true,
+			strip: true,
+			minify: false,
+			terser: {},
+			magnify: false,
+			unbundleText: false,
+			useUntaintedImage: true
+		};
+		const dest = await exp.promiseExportHTML(param);
+		const gameJsonJs = fs.readFileSync(path.join(dest, "js", "game.json.js"), "utf-8");
+		expect(gameJsonJs).toContain("%22untainted%22: true");
+		fs.rmSync(dest, { recursive: true });
+	});
+
+	it("promiseExportHTML with useUntaintedImage option (bundle)", async () => {
+		const param: exp.ExportHTMLParameterObject = {
+			logger: undefined,
+			cwd: path.join(__dirname, "..", "..", "__tests__", "fixtures", "sample_game"),
+			source: ".",
+			output: undefined,
+			force: true,
+			strip: true,
+			minify: false,
+			terser: {},
+			magnify: false,
+			unbundleText: false,
+			bundle: true,
+			useUntaintedImage: true
+		};
+		const dest = await exp.promiseExportHTML(param);
+		const html = fs.readFileSync(path.join(dest, "index.html"), "utf-8");
+		expect(html).toContain("%22untainted%22: true");
 		fs.rmSync(dest, { recursive: true });
 	});
 

--- a/packages/akashic-cli-export/src/html/cli.ts
+++ b/packages/akashic-cli-export/src/html/cli.ts
@@ -33,6 +33,7 @@ function cli(param: CliConfigExportHtml): void {
 		esDownpile: (param.esDownpile != null) ? param.esDownpile : true,
 		compress: param.output ? path.extname(param.output) === ".zip" : false,
 		debugOverrideEngineFiles: param.debugOverrideEngineFiles,
+		useUntaintedImage: param.useUntaintedImage,
 		// index.htmlに書き込むためのexport実行時の情報
 		exportInfo: {
 			version, // export実行時のバージョン
@@ -45,7 +46,8 @@ function cli(param: CliConfigExportHtml): void {
 				minify: param.minify,
 				terser: param.terser,
 				bundle: param.bundle,
-				magnify: param.magnify
+				magnify: param.magnify,
+				useUntaintedImage: param.useUntaintedImage
 			})
 		}
 	};
@@ -86,7 +88,8 @@ commander
 	.option("-a, --atsumaru", "obsolete  option. Use 'akashic export zip --nicolive' instead")
 	.option("--no-omit-unbundled-js", "Unnecessary script files are included even when the `--atsumaru` option is specified.")
 	.option("--no-es-downpile", "No convert JavaScript")
-	.option("--debug-override-engine-files <filePath>", "Use the specified engineFiles");
+	.option("--debug-override-engine-files <filePath>", "Use the specified engineFiles")
+	.option("--use-untainted-image", "Add untainted:true hint to all image assets in game.json");
 
 export async function run(argv: string[]): Promise<void> {
 	// Commander の制約により --strip と --no-strip 引数を両立できないため、暫定対応として Commander 前に argv を処理する
@@ -114,6 +117,12 @@ export async function run(argv: string[]): Promise<void> {
 		console.error("--atsumaru is an obsolete option. Use \"akashic export zip --nicolive\" instead.");
 		process.exit(1);
 	}
+	if (options.useUntaintedImage) {
+		console.warn(
+			"--use-untainted-image: `untainted: true` is set on all image assets. " +
+			"Note that the exported HTML cannot be opened via file:// protocol."
+		);
+	}
 
 	const conf = configuration!.commandOptions?.export?.html ?? {};
 	cli({
@@ -133,8 +142,8 @@ export async function run(argv: string[]): Promise<void> {
 		autoGivenArgsName: options.autoGivenArgsName ?? conf.autoGivenArgsName,
 		omitUnbundledJs: options.omitUnbundledJs ?? conf.omitUnbundledJs,
 		esDownpile: options.esDownpile ?? conf.esDownpile,
-		debugOverrideEngineFiles: options.debugOverrideEngineFiles ?? conf.debugOverrideEngineFiles
-
+		debugOverrideEngineFiles: options.debugOverrideEngineFiles ?? conf.debugOverrideEngineFiles,
+		useUntaintedImage: options.useUntaintedImage ?? conf.useUntaintedImage
 	});
 }
 

--- a/packages/akashic-cli-export/src/html/convertBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertBundle.ts
@@ -20,6 +20,7 @@ import {
 	getInjectedContents,
 	validateSandboxConfigJs,
 	readSandboxConfigJs,
+	addUntaintedToImageAssets,
 	removeUntaintedHints,
 	hasInstanceStorageFeature
 } from "./convertUtil.js";
@@ -40,7 +41,11 @@ export async function promiseConvertBundle(options: ConvertTemplateParameterObje
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
-	removeUntaintedHints(content);
+	if (options.useUntaintedImage) {
+		addUntaintedToImageAssets(content);
+	} else {
+		removeUntaintedHints(content);
+	}
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertNoBundle.ts
+++ b/packages/akashic-cli-export/src/html/convertNoBundle.ts
@@ -19,6 +19,7 @@ import {
 	readSandboxConfigJs,
 	validateEngineFilesName,
 	resolveEngineFilesPath,
+	addUntaintedToImageAssets,
 	removeUntaintedHints,
 	validateSandboxConfigJs,
 	hasInstanceStorageFeature
@@ -34,7 +35,11 @@ export async function promiseConvertNoBundle(options: ConvertTemplateParameterOb
 	content.environment["sandbox-runtime"] = content.environment["sandbox-runtime"] ? content.environment["sandbox-runtime"] : "1";
 
 	validateGameJson(content);
-	removeUntaintedHints(content);
+	if (options.useUntaintedImage) {
+		addUntaintedToImageAssets(content);
+	} else {
+		removeUntaintedHints(content);
+	}
 
 	const conf = new cmn.Configuration({
 		content: content

--- a/packages/akashic-cli-export/src/html/convertUtil.ts
+++ b/packages/akashic-cli-export/src/html/convertUtil.ts
@@ -36,6 +36,7 @@ export interface ConvertTemplateParameterObject {
 	omitUnbundledJs?: boolean;
 	esDownpile?: boolean;
 	debugOverrideEngineFiles?: string;
+	useUntaintedImage?: boolean;
 }
 
 export function extractAssetDefinitions (conf: cmn.Configuration, type: string): string[] {

--- a/packages/akashic-cli-export/src/html/exportHTML.ts
+++ b/packages/akashic-cli-export/src/html/exportHTML.ts
@@ -82,7 +82,8 @@ export function promiseExportHtmlRaw(param: ExportHTMLParameterObject): Promise<
 				exportInfo: param.exportInfo,
 				autoSendEventName: param.autoSendEventName,
 				autoGivenArgsName: param.autoGivenArgsName,
-				debugOverrideEngineFiles: param.debugOverrideEngineFiles
+				debugOverrideEngineFiles: param.debugOverrideEngineFiles,
+				useUntaintedImage: param.useUntaintedImage
 			};
 			if (param.bundle) {
 				return promiseConvertBundle(convertParam);

--- a/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
+++ b/packages/akashic-cli-export/src/zip/__tests__/convertSpec.ts
@@ -8,9 +8,20 @@ import { validateGameJson } from "../../utils.js";
 import type { ConvertGameParameterObject } from "../convert.js";
 import { bundleScripts, convertGame, validateGameJsonForNicolive } from "../convert.js";
 import { LICENSE_TEXT_PREFIX } from "../../licenseUtil.js";
+import * as apiUtil from "../apiUtil.js";
+
+vi.mock("../apiUtil.js", () => ({
+	getFromHttps: vi.fn()
+}));
 
 const require = createRequire(import.meta.url);
 const fixturesDir = path.resolve(__dirname, "..", "..", "__tests__", "fixtures");
+const DEFAULT_VERSIONS_URL = "https://resource.akashic.coe.nicovideo.jp/coe/contents/runtime_version_table/versions.json";
+const MOCK_VERSIONS_JSON = JSON.stringify({ latest: { "1": "1.9.0", "2": "2.8.0", "3": "3.7.0" } });
+
+beforeEach(() => {
+	vi.mocked(apiUtil.getFromHttps).mockResolvedValue(MOCK_VERSIONS_JSON);
+});
 
 function executeCommonJS(code: string): any {
 	const sandbox: any = { module: { exports: {} } };
@@ -81,8 +92,9 @@ describe("convert", () => {
 		const destDir = path.resolve(fixturesDir, "output");
 		const consoleSpy = vi.spyOn(global.console, "warn");
 		afterEach(() => {
-			rmSync(destDir)
+			rmSync(destDir);
 			consoleSpy.mockClear();
+			vi.clearAllMocks();
 		});
 		afterAll(() => {
 			consoleSpy.mockRestore();
@@ -558,6 +570,7 @@ describe("convert", () => {
 			};
 			return convertGame(param)
 				.then(() => {
+					expect(vi.mocked(apiUtil.getFromHttps)).toHaveBeenCalledWith(DEFAULT_VERSIONS_URL);
 					expect(fs.existsSync(path.join(destDir, "script/aez_asset_bundle.js"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "game.json"))).toBe(true);
 					expect(fs.existsSync(path.join(destDir, "package.json"))).toBe(true);
@@ -568,7 +581,7 @@ describe("convert", () => {
 					expect(gameJson.assets.aez_asset_bundle.global).toBe(true);
 					expect(gameJson.environment["sandbox-runtime"]).toBe("3");
 					expect(gameJson.environment.external).toEqual({ send: "0" });
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+(-.*)?$/);
+					expect(gameJson.environment["akashic-runtime"].version).toBe("~3.7.0");
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
 				});
 		});
@@ -583,6 +596,7 @@ describe("convert", () => {
 			};
 			return convertGame(param)
 				.then(() => {
+					expect(vi.mocked(apiUtil.getFromHttps)).not.toHaveBeenCalled();
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.environment.external.send).toBe("0");
 					expect(gameJson.environment["akashic-runtime"].version).toBe("~1.0.9-beta");
@@ -602,9 +616,10 @@ describe("convert", () => {
 			};
 			return convertGame(param)
 				.then(() => {
+					expect(vi.mocked(apiUtil.getFromHttps)).toHaveBeenCalledWith(DEFAULT_VERSIONS_URL);
 					const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json")).toString());
 					expect(gameJson.environment["sandbox-runtime"]).toBe("3");
-					expect(gameJson.environment["akashic-runtime"].version).toMatch(/^~3\.\d+\.\d+(-.*)?$/);
+					expect(gameJson.environment["akashic-runtime"].version).toBe("~3.7.0");
 					expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
 					expect(gameJson.environment.external).toEqual({ send: "0" });
 				});
@@ -906,5 +921,96 @@ describe("validateGameJson", function () {
 	};
 	it("throw Error when specified gamejson include @akashic/akashic-engine", function () {
 		expect(() => validateGameJson(gamejson)).toThrow();
+	});
+});
+
+describe("resolveAkashicRuntime", () => {
+	const destDir = path.resolve(fixturesDir, "output");
+	const getFromHttpsMock = () => vi.mocked(apiUtil.getFromHttps);
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		try { fs.rmSync(destDir, { recursive: true }); } catch { /* ignore */ }
+	});
+
+	it("true: passes the default URL to getFromHttps", async () => {
+		const param: ConvertGameParameterObject = {
+			source: path.resolve(fixturesDir, "sample_game_v3"),
+			dest: destDir,
+			resolveAkashicRuntime: true
+		};
+		await convertGame(param);
+
+		expect(getFromHttpsMock()).toHaveBeenCalledWith(DEFAULT_VERSIONS_URL);
+		const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json"), "utf-8"));
+		expect(gameJson.environment["akashic-runtime"].version).toBe("~3.7.0");
+	});
+
+	it("URL string: passes the given URL to getFromHttps", async () => {
+		const customUrl = "https://example.com/custom/versions.json";
+		const param: ConvertGameParameterObject = {
+			source: path.resolve(fixturesDir, "sample_game_v3"),
+			dest: destDir,
+			resolveAkashicRuntime: customUrl
+		};
+		await convertGame(param);
+
+		expect(getFromHttpsMock()).toHaveBeenCalledWith(customUrl);
+		const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json"), "utf-8"));
+		expect(gameJson.environment["akashic-runtime"].version).toBe("~3.7.0");
+	});
+
+	it("version string: writes akashic-runtime.version directly without HTTP access", async () => {
+		const param: ConvertGameParameterObject = {
+			source: path.resolve(fixturesDir, "sample_game_v3"),
+			dest: destDir,
+			resolveAkashicRuntime: "3.1.2"
+		};
+		await convertGame(param);
+
+		expect(getFromHttpsMock()).not.toHaveBeenCalled();
+		const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json"), "utf-8"));
+		expect(gameJson.environment["akashic-runtime"].version).toBe("~3.1.2");
+		expect(gameJson.environment["akashic-runtime"].flavor).toBe("-canvas");
+		expect(gameJson.environment.external.send).toBe("0");
+	});
+
+	it("version string: no flavor when renderers includes webgl", async () => {
+		const param: ConvertGameParameterObject = {
+			source: path.resolve(fixturesDir, "sample_game_v3"),
+			dest: destDir,
+			resolveAkashicRuntime: "3.1.2"
+		};
+		// game.json の renderers に webgl を追加した一時フィクスチャを用意する
+		const srcGameJson = JSON.parse(fs.readFileSync(path.resolve(fixturesDir, "sample_game_v3", "game.json"), "utf-8"));
+		srcGameJson.renderers = ["canvas", "webgl"];
+		const tmpDir = fs.mkdtempSync(path.join(require("os").tmpdir(), "akashic-test-"));
+		try {
+			fs.cpSync(path.resolve(fixturesDir, "sample_game_v3"), tmpDir, { recursive: true });
+			fs.writeFileSync(path.join(tmpDir, "game.json"), JSON.stringify(srcGameJson));
+			const tmpDest = path.join(tmpDir, "output");
+			await convertGame({ ...param, source: tmpDir, dest: tmpDest });
+
+			expect(getFromHttpsMock()).not.toHaveBeenCalled();
+			const gameJson = JSON.parse(fs.readFileSync(path.join(tmpDest, "game.json"), "utf-8"));
+			expect(gameJson.environment["akashic-runtime"].version).toBe("~3.1.2");
+			expect(gameJson.environment["akashic-runtime"].flavor).toBeUndefined();
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true });
+		}
+	});
+
+	it("version string: skips update when akashic-runtime already exists in game.json", async () => {
+		const param: ConvertGameParameterObject = {
+			source: path.resolve(fixturesDir, "sample_game_with_akashic_runtime"),
+			dest: destDir,
+			resolveAkashicRuntime: "3.1.2"
+		};
+		await convertGame(param);
+
+		expect(getFromHttpsMock()).not.toHaveBeenCalled();
+		const gameJson = JSON.parse(fs.readFileSync(path.join(destDir, "game.json"), "utf-8"));
+		// 既存の値が保持される
+		expect(gameJson.environment["akashic-runtime"].version).toBe("~1.0.9-beta");
 	});
 });

--- a/packages/akashic-cli-export/src/zip/cli.ts
+++ b/packages/akashic-cli-export/src/zip/cli.ts
@@ -36,7 +36,7 @@ export function cli(param: CliConfigExportZip): void {
 			omitUnbundledJs: (param.bundle || param.nicolive) && param.omitUnbundledJs,
 			targetService: param.nicolive ? "nicolive" : param.targetService,
 			nicolive: param.nicolive,
-			resolveAkashicRuntime: param.resolveAkashicRuntime || param.nicolive,
+			resolveAkashicRuntime: param.resolveAkashicRuntime ?? (param.nicolive ? true : undefined),
 			preservePackageJson: param.preservePackageJson,
 			exportInfo: {
 				version,
@@ -86,7 +86,9 @@ commander
 	.option("--pack-image", "Pack small images")
 	.option("--target-service <service>", `(Deprecated) Specify the target service of the exported content:${SERVICE_TYPES}`)
 	.option("--nicolive", "Export zip file for nicolive")
-	.option("--resolve-akashic-runtime", "Fill akashic-runtime field in game.json")
+	.option("--resolve-akashic-runtime [versionOrUrl]",
+		"Fill akashic-runtime field in game.json. " +
+		"Optionally specify a version (e.g. \"3.1.2\") or a URL to use instead of the default remote API")
 	.option("--preserve-package-json", "Preserve package.json even if --strip");
 
 export async function run(argv: string[]): Promise<void> {

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -366,10 +366,10 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			}
 
 			if (param.resolveAkashicRuntime) {
-				const versionsJsonUrl = typeof param.resolveAkashicRuntime === "string"
+				const versionOrTableUrl = typeof param.resolveAkashicRuntime === "string"
 					? param.resolveAkashicRuntime
 					: "https://resource.akashic.coe.nicovideo.jp/coe/contents/runtime_version_table/versions.json";
-				await addGameJsonValuesForNicoLive(gamejson, versionsJsonUrl);
+				await addGameJsonValuesForNicoLive(gamejson, versionOrTableUrl);
 			}
 
 			if (gamejson.environment?.niconico) {
@@ -458,12 +458,12 @@ function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void {
 
 /**
  * nicolive 用に game.json に値を追加する。
- * @param versionsJsonUrl - バージョン文字列 (例: `"3.1.2"`) または バージョン情報 JSON の URL。
+ * @param versionOrTableUrl - バージョン文字列 (例: `"3.1.2"`) または バージョン情報 JSON の URL。
  *   バージョン文字列 (`https?://` で始まらない文字列) の場合は、リモートへのアクセスなしに
  *   そのバージョンを `environment["akashic-runtime"].version` に直接追記する。
  *   URL の場合はその URL からバージョン情報を取得して設定する。
  */
-async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration, versionsJsonUrl: string): Promise<void> {
+async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration, versionOrTableUrl: string): Promise<void> {
 	// game.jsonへの追記
 	if (!gameJson.environment) {
 		gameJson.environment = {};
@@ -477,8 +477,8 @@ async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration, ver
 	}
 
 	// バージョン文字列が直接指定された場合はリモートアクセスなしに追記する
-	if (!/^https?:\/\//.test(versionsJsonUrl)) {
-		gameJson.environment["akashic-runtime"] = { version: "~" + versionsJsonUrl };
+	if (!/^https?:\/\//.test(versionOrTableUrl)) {
+		gameJson.environment["akashic-runtime"] = { version: "~" + versionOrTableUrl };
 		if (!gameJson.renderers || gameJson.renderers.indexOf("webgl") === -1) {
 			const sandboxRuntime = gameJson.environment["sandbox-runtime"];
 			if (sandboxRuntime && sandboxRuntime !== "1") {
@@ -488,7 +488,7 @@ async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration, ver
 		return;
 	}
 
-	const versionInfo = JSON.parse(await getFromHttps(versionsJsonUrl));
+	const versionInfo = JSON.parse(await getFromHttps(versionOrTableUrl));
 
 	gameJson.environment["akashic-runtime"] = { version: "" };
 	if (!gameJson.environment["sandbox-runtime"] || gameJson.environment["sandbox-runtime"] === "1") {

--- a/packages/akashic-cli-export/src/zip/convert.ts
+++ b/packages/akashic-cli-export/src/zip/convert.ts
@@ -44,7 +44,7 @@ export interface ConvertGameParameterObject {
 	omitUnbundledJs?: boolean;
 	targetService?: cmn.ServiceType;
 	nicolive?: boolean;
-	resolveAkashicRuntime?: boolean;
+	resolveAkashicRuntime?: boolean | string;
 	preservePackageJson?: boolean;
 }
 
@@ -63,7 +63,7 @@ export function _completeConvertGameParameterObject(param: ConvertGameParameterO
 	param.omitUnbundledJs = !!param.omitUnbundledJs;
 	param.targetService = param.targetService || "none";
 	param.nicolive = !!param.nicolive;
-	param.resolveAkashicRuntime = !!param.resolveAkashicRuntime;
+	param.resolveAkashicRuntime = param.resolveAkashicRuntime;
 	param.preservePackageJson = !!param.preservePackageJson;
 }
 
@@ -366,7 +366,10 @@ export function convertGame(param: ConvertGameParameterObject): Promise<void> {
 			}
 
 			if (param.resolveAkashicRuntime) {
-				await addGameJsonValuesForNicoLive(gamejson);
+				const versionsJsonUrl = typeof param.resolveAkashicRuntime === "string"
+					? param.resolveAkashicRuntime
+					: "https://resource.akashic.coe.nicovideo.jp/coe/contents/runtime_version_table/versions.json";
+				await addGameJsonValuesForNicoLive(gamejson, versionsJsonUrl);
 			}
 
 			if (gamejson.environment?.niconico) {
@@ -455,8 +458,12 @@ function addUntaintedToImageAssets(gameJson: cmn.GameConfiguration): void {
 
 /**
  * nicolive 用に game.json に値を追加する。
+ * @param versionsJsonUrl - バージョン文字列 (例: `"3.1.2"`) または バージョン情報 JSON の URL。
+ *   バージョン文字列 (`https?://` で始まらない文字列) の場合は、リモートへのアクセスなしに
+ *   そのバージョンを `environment["akashic-runtime"].version` に直接追記する。
+ *   URL の場合はその URL からバージョン情報を取得して設定する。
  */
-async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration): Promise<void> {
+async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration, versionsJsonUrl: string): Promise<void> {
 	// game.jsonへの追記
 	if (!gameJson.environment) {
 		gameJson.environment = {};
@@ -469,9 +476,19 @@ async function addGameJsonValuesForNicoLive(gameJson: cmn.GameConfiguration): Pr
 		return;
 	}
 
-	const versionInfo = JSON.parse(await getFromHttps(
-		"https://resource.akashic.coe.nicovideo.jp/coe/contents/runtime_version_table/versions.json"
-	));
+	// バージョン文字列が直接指定された場合はリモートアクセスなしに追記する
+	if (!/^https?:\/\//.test(versionsJsonUrl)) {
+		gameJson.environment["akashic-runtime"] = { version: "~" + versionsJsonUrl };
+		if (!gameJson.renderers || gameJson.renderers.indexOf("webgl") === -1) {
+			const sandboxRuntime = gameJson.environment["sandbox-runtime"];
+			if (sandboxRuntime && sandboxRuntime !== "1") {
+				gameJson.environment["akashic-runtime"].flavor = "-canvas";
+			}
+		}
+		return;
+	}
+
+	const versionInfo = JSON.parse(await getFromHttps(versionsJsonUrl));
 
 	gameJson.environment["akashic-runtime"] = { version: "" };
 	if (!gameJson.environment["sandbox-runtime"] || gameJson.environment["sandbox-runtime"] === "1") {

--- a/packages/akashic-cli-export/src/zip/exportZip.ts
+++ b/packages/akashic-cli-export/src/zip/exportZip.ts
@@ -29,7 +29,7 @@ export interface ExportZipParameterObject {
 	omitUnbundledJs?: boolean;
 	targetService?: cmn.ServiceType;
 	nicolive?: boolean;
-	resolveAkashicRuntime?: boolean;
+	resolveAkashicRuntime?: boolean | string;
 	preservePackageJson?: boolean;
 }
 
@@ -71,7 +71,7 @@ export function _completeExportZipParameterObject(param: ExportZipParameterObjec
 		omitUnbundledJs: param.omitUnbundledJs,
 		targetService: param.targetService || "none",
 		nicolive: !!param.nicolive,
-		resolveAkashicRuntime: !!param.resolveAkashicRuntime,
+		resolveAkashicRuntime: param.resolveAkashicRuntime,
 		preservePackageJson: !!param.preservePackageJson
 	};
 }


### PR DESCRIPTION
# このPullRequestが解決する内容

Akashic System OSS 向けの対応です。

- `export zip` コマンドの `--resolve-akashic-runtime` オプションに引数を追加
  - 引数を指定しない場合: 既存の動作
  - URL を指定した場合: その URL から game.json の akashic-runtime を解決するように
  - その他文字列を指定した場合: その文字列を game.json の akashic-runtime に

- `export html` コマンドに `--use-untainted-image` オプションを追加
  -  指定された場合画像アセットに `untainted: true` を追加