### PR TITLE
Fix add tag after shrinkwrap in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           name: shrinkwrap_log
           path: ./logs_shrinkwrap
-      - name: Push tag after shrinkwrap
+      - name: Push tag after publish
         # checkout の persist-credentials: false で認証情報が消されるので設定し処理後に削除
         run: |
           if [[ `find ./packages/**/npm-shrinkwrap.json` ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,27 @@ jobs:
         with:
           name: shrinkwrap_log
           path: ./logs_shrinkwrap
+      - name: Push tag after shrinkwrap
+        # checkout の persist-credentials: false で認証情報が消されるので設定し処理後に削除
+        run: |
+          if [[ `find ./packages/**/npm-shrinkwrap.json` ]]; then
+            VERSION=`jq -r .version packages/akashic-cli/package.json`
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
+            git config user.name 'github-actions'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+            git checkout -b tag_$VERSION
+            git add .
+            git commit -m "Add tag after published $VERSION"
+            git tag -a v$VERSION -m "tag $VERSION"
+            git push origin v$VERSION
+            
+            git remote rm origin
+            git config unset user.name
+            git config unset user.email
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Test after publish
         # package-lock.json を更新するのが publish 直前のため、publish した物と完全に同じ状態でテストできない
         # ここでエラーになっても既に publish してしまった後だが、問題の検出を早めるため実行している

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,11 @@ jobs:
             git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
             git checkout -b tag_$VERSION
-            git add .
+            git add './packages/**/npm-shrinkwrap.json'
             git commit -m "Add tag after published $VERSION"
             git tag -a v$VERSION -m "tag $VERSION"
             git push origin v$VERSION
-            
+
             git remote rm origin
             git config unset user.name
             git config unset user.email


### PR DESCRIPTION
## 概要

release.yml で publish 後に shrinkwrap.json 生成後のコミットを行い tag を作成/push するよう修正

**動作確認**

個人リポジトリで、 shrinkwrap.json 生成後の状態で tag が push される事を確認

https://github.com/ShinobuTakahashi/test-monorepo/actions/runs/23577864048/job/68654302079#step:7:25
