### PR TITLE
feat(serve): automatically reconnect client on server restart

### DIFF
--- a/.changeset/moody-lands-exist.md
+++ b/.changeset/moody-lands-exist.md
@@ -1,0 +1,5 @@
+---
+"@akashic/akashic-cli-serve": patch
+---
+
+automatically reconnect client on server restart

--- a/packages/akashic-cli-serve/src/client/api/Subscriber.ts
+++ b/packages/akashic-cli-serve/src/client/api/Subscriber.ts
@@ -34,6 +34,7 @@ export const onClientInstanceAppear = new Trigger<ClientInstanceAppearTestbedEve
 export const onClientInstanceDisappear = new Trigger<ClientInstanceDisappearTestbedEvent>();
 export const onBroadcast = new Trigger<any>();
 export const onDisconnect = new Trigger<void>();
+export const onReconnect = new Trigger<void>();
 export const onPutStartPoint = new Trigger<PutStartPointEvent>();
 export const onNamagameCommentPluginStartStop = new Trigger<NamagameCommentPluginStartStopTestbedEvent>();
 
@@ -52,6 +53,7 @@ socket.on("clientInstanceAppear", (arg: ClientInstanceAppearTestbedEvent) => onC
 socket.on("clientInstanceDisappear", (arg: ClientInstanceDisappearTestbedEvent) => onClientInstanceDisappear.fire(arg));
 socket.on("playBroadcast", (arg: PlayBroadcastTestbedEvent) => onBroadcast.fire(arg));
 socket.on("disconnect", () => onDisconnect.fire());
+socket.on("serverReady", () => onReconnect.fire());
 socket.on("putStartPoint", (arg: PutStartPointEvent) => onPutStartPoint.fire(arg));
 socket.on("namagameCommentPluginStartStop", (arg: NamagameCommentPluginStartStopTestbedEvent) => {
 	onNamagameCommentPluginStartStop.fire(arg);

--- a/packages/akashic-cli-serve/src/client/api/createSocketInstance.ts
+++ b/packages/akashic-cli-serve/src/client/api/createSocketInstance.ts
@@ -12,7 +12,6 @@ export function createSocketInstance(uri: string): ioc.Socket {
 	return io(uri, {
 		// サーバが切断された場合に自動再接続を行う。
 		// 再接続成功時 (serverReady イベント) にページリロードを行うため、新しいサーバへ繋いだ場合も正しく初期化される。
-		// TODO: 本当はここを 1 にするよりも、playId を起動ごとにユニークなものにすべきかもしれない。
 		reconnectionAttempts: Infinity,
 		parser
 	});

--- a/packages/akashic-cli-serve/src/client/api/createSocketInstance.ts
+++ b/packages/akashic-cli-serve/src/client/api/createSocketInstance.ts
@@ -10,11 +10,10 @@ export function createSocketInstance(uri: string): ioc.Socket {
 	if (typeof io === "undefined") return null!;
 
 	return io(uri, {
-		// デフォルトはInfinityだが、過去に同じホスト・ポートで起動されたサーバに
-		// 接続していたクライアントが生きている(i.e. ブラウザのタブが開いたまま)時、
-		// つなぎなおして来てしまうのでやむなく1にしている。(0だとInfinity扱いされる)
-		// 本当はここを 1 にするよりも、playId を起動ごとにユニークなものにすべきかもしれない。
-		reconnectionAttempts: 1,
+		// サーバが切断された場合に自動再接続を行う。
+		// 再接続成功時 (serverReady イベント) にページリロードを行うため、新しいサーバへ繋いだ場合も正しく初期化される。
+		// TODO: 本当はここを 1 にするよりも、playId を起動ごとにユニークなものにすべきかもしれない。
+		reconnectionAttempts: Infinity,
 		parser
 	});
 }

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -212,6 +212,8 @@ export class PlayOperator {
 		// サーバが復帰したらページをリロードして再初期化する。
 		// これにより同じサーバへの再接続でも新しいサーバへの接続でも正しく動作する。
 		if (!this.store.isSocketDisconnect) return;
+		if (!this.store.isSocketReconnecting) return;
+
 		window.location.reload();
 	};
 

--- a/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
+++ b/packages/akashic-cli-serve/src/client/operator/PlayOperator.ts
@@ -15,6 +15,7 @@ export class PlayOperator {
 	constructor(store: Store) {
 		this.store = store;
 		Subscriber.onDisconnect.add(this.handleSocketDisconnect);
+		Subscriber.onReconnect.add(this.handleSocketReconnect);
 	}
 
 	togglePauseActive = (pauses: boolean): Promise<PlayPatchApiResponse> => {
@@ -202,6 +203,16 @@ export class PlayOperator {
 
 	private handleSocketDisconnect = (): void => {
 		this.store.setSocketDisconnect(true);
+		this.store.setSocketReconnecting(true);
 		this.closeThisWindowIfNeeded();
 	};
+
+	private handleSocketReconnect = (): void => {
+		// 切断済みの場合のみリロードする (初回接続時の serverReady は無視する)。
+		// サーバが復帰したらページをリロードして再初期化する。
+		// これにより同じサーバへの再接続でも新しいサーバへの接続でも正しく動作する。
+		if (!this.store.isSocketDisconnect) return;
+		window.location.reload();
+	};
+
 }

--- a/packages/akashic-cli-serve/src/client/store/Store.ts
+++ b/packages/akashic-cli-serve/src/client/store/Store.ts
@@ -46,6 +46,7 @@ export class Store {
 	@observable currentLocalInstance: LocalInstanceEntity | null;
 	@observable gameViewSize: ScreenSize;
 	@observable isSocketDisconnect: boolean;
+	@observable isSocketReconnecting: boolean;
 
 	private _gameViewManager: GameViewManager;
 	private _initializationWaiter: Promise<void>;
@@ -74,6 +75,7 @@ export class Store {
 			Subscriber.onMessageEncode.add(this.handleMessageEncode);
 		});
 		this.isSocketDisconnect = false;
+		this.isSocketReconnecting = false;
 
 		autorun(() => {
 			if (!this.toolBarUiStore.fitsToScreen && this.currentLocalInstance?.intrinsicSize) {
@@ -122,6 +124,11 @@ export class Store {
 	@action
 	setSocketDisconnect(isDisconnect: boolean): void {
 		this.isSocketDisconnect = isDisconnect;
+	}
+
+	@action
+	setSocketReconnecting(isReconnecting: boolean): void {
+		this.isSocketReconnecting = isReconnecting;
 	}
 
 	get targetService(): ServiceType {

--- a/packages/akashic-cli-serve/src/server/index.ts
+++ b/packages/akashic-cli-serve/src/server/index.ts
@@ -417,6 +417,8 @@ async function cli(cliConfigParam: CliConfigServe, cmdOptions: OptionValues): Pr
 	app.use("/health-check/", createHealthCheckRouter({ playStore }));
 
 	io.on("connection", (socket: socketio.Socket) => {
+		// 接続直後にクライアントへ通知し、再接続後のリロードを素早く行えるようにする。
+		socket.emit("serverReady");
 		amflowManager.setupSocketIOAMFlow(socket);
 	});
 	// TODO 全体ブロードキャストせず該当するプレイにだけ通知するべき？


### PR DESCRIPTION
# このPullRequestが解決する内容

サーバ切断時、サーバ側が再起動されたらクライアント側で自動的に再接続するように修正します。